### PR TITLE
Solve "Unreachable statement" compilation error (API 42.0)

### DIFF
--- a/src/classes/fflib_AnswerTest.cls
+++ b/src/classes/fflib_AnswerTest.cls
@@ -325,8 +325,11 @@ private class fflib_AnswerTest
 		{
 			actualInvocation = invocation;
 
-			throw new fflib_ApexMocks.ApexMocksException('an error occurs on the execution of the answer');
-			return null;
+			if (true)
+			{
+				throw new fflib_ApexMocks.ApexMocksException('an error occurs on the execution of the answer');
+			}
+			return null; // This line is never reached
 		}
 	}
 


### PR DESCRIPTION
Having a `throw` followed by a `return` throws a compilation error when running it under the new compiler introduced in API 42.0. See [Salesforce's knowledge article on the issue](https://help.salesforce.com/articleView?id=000269952&language=en_US&type=1).

Please note that this is a preventative PR: the code, as it is in the repository, does not throw an error under API 37.0.