### PR TITLE
Bug fix fflib_IDGenerator.generate called > 999 times.

### DIFF
--- a/src/classes/fflib_IDGenerator.cls
+++ b/src/classes/fflib_IDGenerator.cls
@@ -36,7 +36,7 @@ public with sharing class fflib_IDGenerator
 		String keyPrefix = sobjectType.getDescribe().getKeyPrefix();
 		fakeIdCount++;
 
-		String fakeIdPrefix = ID_PATTERN.substring(0, 12 - fakeIdCount.format().length());
+		String fakeIdPrefix = ID_PATTERN.substring(0, 12 - String.valueOf(fakeIdCount).length());
 
 		return Id.valueOf(keyPrefix + fakeIdPrefix + fakeIdCount);
 	}


### PR DESCRIPTION
I mentioned this in an [issue](https://github.com/financialforcedev/fflib-apex-mocks/issues/72) because I wanted to make sure I wasn't missing something. Here is the simple fix though.

Thanks