### PR TITLE
Bugfix for matcherDefinitions

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
@@ -830,8 +830,8 @@ public with sharing class fflib_MatcherDefinitions
 						{
 							return false;
 						}
-						return true;
 					}
+					return true;
 				}
 				else
 				{	

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
@@ -924,6 +924,20 @@ public class fflib_MatcherDefinitionsTest
             }               
 		};
 
+		list<Map<Schema.SObjectField, Object>> failingFieldValues = new list<Map<Schema.SObjectField, Object>>
+		{
+				new map<Schema.SObjectField,Object>
+				{
+						idField => GROUP_RECORDS[0].Id,
+						nameField => GROUP_RECORDS[0].get('Name')
+				},
+				new map<Schema.SObjectField,Object>
+				{
+						idField => GROUP_RECORDS[1].Id,
+						nameField => GROUP_RECORDS[1].get('Name') + 'test'
+				}
+		};
+
 		list<Map<Schema.SObjectField, Object>> notQueriedFieldValues = new list<Map<Schema.SObjectField, Object>>
 		{
 			new map<Schema.SObjectField,Object> 
@@ -959,6 +973,7 @@ public class fflib_MatcherDefinitionsTest
                       
 
 		System.assert(!new fflib_MatcherDefinitions.SObjectsWith(notQueriedFieldValues).matches(GROUP_RECORDS));
+		System.assert(!new fflib_MatcherDefinitions.SObjectsWith(failingFieldValues).matches(GROUP_RECORDS));
 	}
 
     @isTest

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
@@ -926,16 +926,16 @@ public class fflib_MatcherDefinitionsTest
 
 		list<Map<Schema.SObjectField, Object>> failingFieldValues = new list<Map<Schema.SObjectField, Object>>
 		{
-				new map<Schema.SObjectField,Object>
-				{
-						idField => GROUP_RECORDS[0].Id,
-						nameField => GROUP_RECORDS[0].get('Name')
-				},
-				new map<Schema.SObjectField,Object>
-				{
-						idField => GROUP_RECORDS[1].Id,
-						nameField => GROUP_RECORDS[1].get('Name') + 'test'
-				}
+			new map<Schema.SObjectField,Object>
+			{
+				idField => GROUP_RECORDS[0].Id,
+				nameField => GROUP_RECORDS[0].get('Name')
+			},
+			new map<Schema.SObjectField,Object>
+			{
+				idField => GROUP_RECORDS[1].Id,
+				nameField => GROUP_RECORDS[1].get('Name') + 'test'
+			}
 		};
 
 		list<Map<Schema.SObjectField, Object>> notQueriedFieldValues = new list<Map<Schema.SObjectField, Object>>


### PR DESCRIPTION
Previously the fflib_MatcherDefinitions.SObjectsWith.matches method, only validated the first record in the given list of records.
When this first record was matching it return true, without even checking the other records in the list.

Notice the `return true;` which is inside the `for` loop iterating over the records.

Without the change to fflib_MatcherDefinitions.SObjectsWith.matches the unit test with the failingFieldValues was just passing when you modify the fields on the second record.
Now I have added an assertion to assert a failing scenario