### PR TITLE
generate ids for xxxHistory objects

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
@@ -34,6 +34,13 @@ public with sharing class fflib_IDGenerator
 	public static Id generate(Schema.SObjectType sobjectType)
 	{
 		String keyPrefix = sobjectType.getDescribe().getKeyPrefix();
+		//	Deal with null keyprefix
+		//		OpportunityHistory will have keyPrefix 008 from getKeyPrefix
+		//		All other xxxHistory, xxx__History, and OpportunityFieldHistory coerce to 017 (legacy from EntityHistory)
+		if (keyPrefix == null) {	
+			keyPrefix =  sobjectType.getDescribe().getName().endsWith('History') ? '017' : null;
+		}
+		if (keyPrefix == null) {throw new System.IllegalArgumentException(sobjectType + ' has no known keyPrefix');}
 		fakeIdCount++;
 
 		String fakeIdPrefix = ID_PATTERN.substring(0, 12 - String.valueOf(fakeIdCount).length());

--- a/sfdx-source/apex-mocks/test/classes/fflib_IDGeneratorTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_IDGeneratorTest.cls
@@ -52,5 +52,10 @@ private class fflib_IDGeneratorTest
 		System.assertEquals('001000000000009AAA', id9);
 		System.assertEquals('001000000000010AAA', id10);
 		System.assertEquals('001000000000011AAA', id11);
+
+		//	Given History SObjectTypes
+		System.assertEquals('017000000000012AAA',(String)fflib_IDGenerator.generate(AccountHistory.SObjectType),'history sobjectTypes are always 017...');
+		System.assertEquals('008000000000013AAA',(String)fflib_IDGenerator.generate(OpportunityHistory.SObjectType),'special case OpportunityHistory sobjectType is always 008...');
+		System.assertEquals('017000000000014AAA',(String)fflib_IDGenerator.generate(OpportunityFieldHistory.SObjectType),'special case OpportunityFieldHistory sobjectType is always 017...');
 	}
 }


### PR DESCRIPTION
**use case:** 

Mocking `xxxHistorySelector` result records (e.g. `AccountHistory`, `CaseHistory`, `customObj__History`)

    fflib_IdGenerator.generate(AccountHistory.SObjectType);

current behavior: null pointer exception
PR: returns `017xxxxxxxxxxxxxxx` 

**Notes:**

    OpportunityHistory returns `008xxxxxxxxxxxxxxx` (as this object has a keyPrefix available from Describe)
    OpportunityFieldHistory returns `017xxxxxxxxxxxxx`
    All other xxxHistory returns `017xxxxxxxxxxxxx`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/95)
<!-- Reviewable:end -->
