### PR TITLE
Feature/better verification messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ mockList.add('bob');
 ((fflib_MyList.IList) mocks.verify(mockList)).add('bob');
 ((fflib_MyList.IList) mocks.verify(mockList, fflib_ApexMocks.NEVER)).clear();
 ```
+
+If the method wasn't called the expected number of times, or with the expected arguments, verify will throw an exception.
+The exception message contains details of the expected and actual invocations:
+
+```
+EXPECTED COUNT: 1
+ACTUAL COUNT: 0
+METHOD: EmailService__sfdc_ApexStub.sendTo(String)
+---
+ACTUAL ARGS: ("user-two@example.com")
+---
+EXPECTED ARGS: [[contains "user-one"]]
+
+```
+
 ### when() dependency stubbing
 ```Java
 fflib_ApexMocks mocks = new fflib_ApexMocks();

--- a/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
@@ -17,10 +17,13 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 	 */
 	protected override void verify(
 		fflib_QualifiedMethod qm,
-		fflib_MethodArgValues methodArg,
+		fflib_MethodArgValues expectedArguments,
 		fflib_VerificationMode verificationMode)
 	{
-		Integer methodCount = getMethodCount(qm, methodArg);
+		List<fflib_IMatcher> expectedMatchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
+		List<fflib_MethodArgValues> actualArguments = fflib_MethodCountRecorder.getMethodArgumentsByTypeName().get(qm);
+
+		Integer methodCount = getMethodCount(expectedArguments, expectedMatchers, actualArguments);
 
 		String qualifier = '';
 		Integer expectedCount = null;
@@ -42,17 +45,13 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 
 		if (expectedCount != null)
 		{
-			throwException(qm, '', expectedCount, qualifier, methodCount, verificationMode.CustomAssertMessage);
+			throwException(qm, '', expectedCount, qualifier, methodCount, verificationMode.CustomAssertMessage, expectedArguments, expectedMatchers, actualArguments);
 		}
 	}
 
-	private Integer getMethodCount(fflib_QualifiedMethod qm, fflib_MethodArgValues methodArg)
+	private Integer getMethodCount(fflib_MethodArgValues methodArg, List<fflib_IMatcher> matchers, List<fflib_MethodArgValues> methodArgs)
 	{
-		List<fflib_IMatcher> matchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(methodArg.argValues.size()) : null;
 		Integer retval = 0;
-
-		List<fflib_MethodArgValues> methodArgs =
-			fflib_MethodCountRecorder.getMethodArgumentsByTypeName().get(qm);
 
 		if (methodArgs != null)
 		{
@@ -63,7 +62,6 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 					if (fflib_Match.matchesAllArgs(args, matchers))
 					{
 						capture(matchers);
-
 						retval ++;
 					}
 				}

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
@@ -418,4 +418,15 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	{
 		this.methodVerifier = verifyOrderingMode;
 	}
+	
+	/**
+	 * A simple override to suppress the default toString logic, which is noisy and rarely useful.
+	 * In some cases, the Salesforce default implementation of toString here can cause internal Salesforce errors
+	 * if it has circular references.
+	 * @return "fflib_ApexMocks" String literal
+	 */
+	public override String toString()
+	{
+		return 'fflib_ApexMocks';
+	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
@@ -111,30 +111,36 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	 * The in-order verifier remembers the last method invocation it successfully verified,
 	 * and only considers subsequent method invocations for subsequent verifications.
 	 * @param qualifiedMethod The method to be verified.
-	 * @param methodArg The arguments of the method that needs to be verified.
+	 * @param expectedArguments The arguments of the method that needs to be verified.
 	 * @param verificationMode The verification mode that holds the setting about how the verification should be performed.
 	 */
 	protected override void verify(
 		fflib_QualifiedMethod qm,
-		fflib_MethodArgValues methodArg,
+		fflib_MethodArgValues expectedArguments,
 		fflib_VerificationMode verificationMode)
 	{
-		String inOrder = 'In Order: ';
-		List<fflib_IMatcher> matchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(methodArg.argValues.size()) : null;
+		String inOrder = ' in order';
+		List<fflib_IMatcher> matchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
+		List<fflib_InvocationOnMock> actualInvocations = fflib_MethodCountRecorder.getOrderedMethodCalls();
+		List<fflib_MethodArgValues> actualArguments = new List<fflib_MethodArgValues>();
+		for (fflib_InvocationOnMock invocation : actualInvocations)
+		{
+			actualArguments.add(invocation.getMethodArgValues());
+		}
 
 		if( verificationMode.VerifyMin == 0 && verificationMode.VerifyMax == 0)
 		{
-			Integer methodCounts = countInteractions(matchers, qm, methodArg);
+			Integer methodCounts = countInteractions(matchers, qm, expectedArguments);
 			if(methodCounts != 0 )
-				throwException(qm, inOrder, fflib_ApexMocks.NEVER, '', methodCounts, verificationMode.CustomAssertMessage);
+				throwException(qm, inOrder, fflib_ApexMocks.NEVER, '', methodCounts, verificationMode.CustomAssertMessage, expectedArguments, matchers, actualArguments);
 		}
 
 		Integer i=0;
-		for ( ; i<verificationMode.VerifyMin; i++)
+		for ( ; i<verificationMode.VerifyMin; i++ )
 		{
-			if(!verifyMethodCalled(matchers, qm, methodArg))
+			if(!verifyMethodCalled(matchers, qm, expectedArguments))
 			{
-				throwException(qm, inOrder, verificationMode.VerifyMin, '', i, verificationMode.CustomAssertMessage);
+				throwException(qm, inOrder, verificationMode.VerifyMin, '', i, verificationMode.CustomAssertMessage, expectedArguments, matchers, actualArguments);
 			}
 		}
 
@@ -145,10 +151,10 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 				fflib_InvocationOnMock nextMethod = getNextMethodCall(false);
 
 				if(nextMethod.getMethod() == qm &&
-					argumentsMatch(nextMethod.getMethodArgValues(), matchers, methodArg))
+					argumentsMatch(nextMethod.getMethodArgValues(), matchers, expectedArguments))
 				{
-					Integer methodCounts = i + countInteractions(matchers, qm, methodArg);
-					throwException(qm, inOrder, verificationMode.VerifyMin, '', methodCounts, verificationMode.CustomAssertMessage);
+					Integer methodCounts = i + countInteractions(matchers, qm, expectedArguments);
+					throwException(qm, inOrder, verificationMode.VerifyMin, '', methodCounts, verificationMode.CustomAssertMessage, expectedArguments, matchers, actualArguments);
 				}
 			}
 
@@ -159,7 +165,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		if(verificationMode.Method == fflib_VerificationMode.ModeName.atLeast
 			|| verificationMode.Method == fflib_VerificationMode.ModeName.atLeastOnce)
 		{
-			consumeInteractions(matchers, qm, methodArg);
+			consumeInteractions(matchers, qm, expectedArguments);
 		}
 	}
 
@@ -268,7 +274,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 
 	private fflib_InvocationOnMock getNextMethodCall()
 	{
-			return getNextMethodCall(true);
+		return getNextMethodCall(true);
 	}
 
 	private fflib_InvocationOnMock getNextMethodCall(Boolean updateIdxMethodCall)

--- a/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
@@ -116,6 +116,32 @@ public with sharing class fflib_MatcherDefinitions
 			
 			return innerMatchers;
 		}
+
+		public override String toString()
+		{
+			List<String> internalDescriptions = new List<String>();
+			for (fflib_IMatcher internalMatcher : internalMatchers)
+			{
+				internalDescriptions.add('' + internalMatcher);
+			}
+			String internalDescription = String.join(internalDescriptions, ', ');
+
+			switch on connectiveExpression
+			{
+				when AT_LEAST_ONE
+				{
+					return '[any of: ' + internalDescription + ']';
+				}
+				when ALL
+				{
+					return '[all of: ' + internalDescription + ']';
+				}
+				when else
+				{
+					return '[none of: ' + internalDescription + ']';
+				}
+			}
+		}
 	}
 	
 	/*
@@ -143,6 +169,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return toMatch == arg;
 		}
+
+		public override String toString()
+		{
+			return '[equals ' + stringify(toMatch) + ']';
+		}
 	}
 	
 	/**
@@ -166,6 +197,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return toMatch === arg;
 		}
+
+		public override String toString()
+		{
+			return '[reference equals ' + stringify(toMatch) + ']';
+		}
 	}
 	
 	/*
@@ -181,6 +217,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof Boolean;
 		}
+
+		public override String toString()
+		{
+			return '[any Boolean]';
+		}
 	}
 
 	/**
@@ -191,6 +232,11 @@ public with sharing class fflib_MatcherDefinitions
 		public Boolean matches(Object arg)
 		{
 			return arg != null && arg instanceof Date;
+		}
+
+		public override String toString()
+		{
+			return '[any Date]';
 		}
 	}
 
@@ -203,6 +249,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof Datetime;
 		}
+
+		public override String toString()
+		{
+			return '[any DateTime]';
+		}
 	}
 
 	/**
@@ -213,6 +264,11 @@ public with sharing class fflib_MatcherDefinitions
 		public Boolean matches(Object arg)
 		{
 			return arg != null && arg instanceof Decimal;
+		}
+
+		public override String toString()
+		{
+			return '[any Decimal]';
 		}
 	}
 
@@ -225,6 +281,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof Double;
 		}
+
+		public override String toString()
+		{
+			return '[any Double]';
+		}
 	}
 
 	/**
@@ -235,6 +296,11 @@ public with sharing class fflib_MatcherDefinitions
 		public Boolean matches(Object arg)
 		{
 			return arg != null && arg instanceof Schema.FieldSet;
+		}
+
+		public override String toString()
+		{
+			return '[any FieldSet]';
 		}
 	}
 
@@ -247,6 +313,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof Id;
 		}
+
+		public override String toString()
+		{
+			return '[any Id]';
+		}
 	}
 	
 	/**
@@ -257,6 +328,11 @@ public with sharing class fflib_MatcherDefinitions
 		public Boolean matches(Object arg)
 		{
 			return arg != null && arg instanceof Integer;
+		}
+
+		public override String toString()
+		{
+			return '[any Integer]';
 		}
 	}
 
@@ -269,6 +345,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof List<Object>;
 		}
+
+		public override String toString()
+		{
+			return '[any list]';
+		}
 	}
 
 	/**
@@ -279,6 +360,11 @@ public with sharing class fflib_MatcherDefinitions
 		public Boolean matches(Object arg)
 		{
 			return arg != null && arg instanceof Long;
+		}
+
+		public override String toString()
+		{
+			return '[any Long]';
 		}
 	}
 
@@ -291,6 +377,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null;
 		}
+
+		public override String toString()
+		{
+			return '[any Object]';
+		}
 	}
 	
 	/**
@@ -301,6 +392,11 @@ public with sharing class fflib_MatcherDefinitions
 		public Boolean matches(Object arg)
 		{
 			return arg != null && arg instanceof String;
+		}
+
+		public override String toString()
+		{
+			return '[any String]';
 		}
 	}
 
@@ -313,6 +409,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof SObject;
 		}
+
+		public override String toString()
+		{
+			return '[any SObject]';
+		}
 	}
 
 	/**
@@ -324,6 +425,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof SObjectField;
 		}
+
+		public override String toString()
+		{
+			return '[any SObjectField]';
+		}
 	}
 
 	/**
@@ -334,6 +440,11 @@ public with sharing class fflib_MatcherDefinitions
 		public Boolean matches(Object arg)
 		{
 			return arg != null && arg instanceof SObjectType;
+		}
+
+		public override String toString()
+		{
+			return '[any SObjectType]';
 		}
 	}
 	
@@ -371,6 +482,18 @@ public with sharing class fflib_MatcherDefinitions
 
 			return false;
 		}
+
+		public override String toString()
+		{
+			if (inclusive)
+			{
+				return '[on or after ' + JSON.serialize(fromDateTime) + ']';
+			}
+			else
+			{
+				return '[after ' + JSON.serialize(fromDateTime) + ']';
+			}
+		}
 	}
 	
 	/**
@@ -402,6 +525,18 @@ public with sharing class fflib_MatcherDefinitions
 			}
 
 			return false;
+		}
+
+		public override String toString()
+		{
+			if (inclusive)
+			{
+				return '[on or before ' + JSON.serialize(toDateTime) + ']';
+			}
+			else
+			{
+				return '[before ' + JSON.serialize(toDateTime) + ']';
+			}
 		}
 	}
 
@@ -444,6 +579,16 @@ public with sharing class fflib_MatcherDefinitions
 			}
 
 			return false;
+		}
+
+		public override String toString()
+		{
+			return String.format('[{0} {1} and {2} {3}]', new List<String>{
+				inclusiveFrom ? 'on or after' : 'after',
+				JSON.serialize(fromDateTime),
+				inclusiveTo ? 'on or before' : 'before',
+				JSON.serialize(toDateTime)
+			});
 		}
 	}
 
@@ -492,6 +637,16 @@ public with sharing class fflib_MatcherDefinitions
 
 			return false;
 		}
+
+		public override String toString()
+		{
+			return String.format('{0} {1} and {2} {3}', new List<String>{
+				inclusiveLower ? 'greater than or equal to' : 'greater than',
+				'' + lower,
+				inclusiveUpper ? 'less than or equal to' : 'less than',
+				'' + upper
+			});
+		}
 	}
 
 	/**
@@ -523,6 +678,18 @@ public with sharing class fflib_MatcherDefinitions
 			}
 
 			return false;
+		}
+
+		public override String toString()
+		{
+			if (inclusive)
+			{
+				return '[less than or equal to ' + toMatch + ']';
+			}
+			else
+			{
+				return '[less than ' + toMatch + ']';
+			}
 		}
 	}
 
@@ -556,6 +723,18 @@ public with sharing class fflib_MatcherDefinitions
 
 			return false;
 		}
+
+		public override String toString()
+		{
+			if (inclusive)
+			{
+				return '[greater than or equal to ' + toMatch + ']';
+			}
+			else
+			{
+				return '[greater than ' + toMatch + ']';
+			}
+		}
 	}
 
 	/** 
@@ -588,6 +767,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return (toMatch != null && arg != null && arg instanceof Schema.FieldSet) ? toMatch == new Set<Schema.FieldSetMember>(((FieldSet)arg).getFields()) : false;
 		}
+
+		public override String toString()
+		{
+			return '[FieldSet with fields ' + fflib_MatcherDefinitions.stringify(toMatch) + ']';
+		}
 	}
 
 	/*
@@ -603,6 +787,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null;
 		}
+
+		public override String toString()
+		{
+			return '[is not null]';
+		}
 	}
 	
 	/**
@@ -613,6 +802,11 @@ public with sharing class fflib_MatcherDefinitions
 		public Boolean matches(Object arg)
 		{
 			return arg == null;
+		}
+
+		public override String toString()
+		{
+			return '[is null]';
 		}
 	}
 
@@ -652,6 +846,11 @@ public with sharing class fflib_MatcherDefinitions
 
 			return false;
 		}
+
+		public override String toString()
+		{
+			return '[list containing ' + fflib_MatcherDefinitions.stringify(toMatch) + ']';
+		}
 	}
 
 	/**
@@ -664,6 +863,11 @@ public with sharing class fflib_MatcherDefinitions
 			return arg != null
 				&& arg instanceof List<Object>
 				&& ((List<Object>)arg).isEmpty();
+		}
+
+		public override String toString()
+		{
+			return '[empty list]';
 		}
 	}
 
@@ -697,6 +901,11 @@ public with sharing class fflib_MatcherDefinitions
 			}
 
 			return false;
+		}
+
+		public override String toString()
+		{
+			return '[SObject of type ' + objectType + ']';
 		}
 	}
 
@@ -744,6 +953,11 @@ public with sharing class fflib_MatcherDefinitions
 			}
 
 			return arg;
+		}
+
+		public override String toString()
+		{
+			return '[SObject with fields ' + fflib_MatcherDefinitions.stringify(toMatch) + ']';
 		}
 	}
 
@@ -878,6 +1092,18 @@ public with sharing class fflib_MatcherDefinitions
 
 			return arg;
 		}
+
+		public override String toString()
+		{
+			if (matchInOrder)
+			{
+				return '[matches ' + stringify(toMatch) + ' in order]';
+			}
+			else
+			{
+				return '[matches ' + stringify(toMatch) + ' in any order]';
+			}
+		}
         
 
 	}    
@@ -938,6 +1164,11 @@ public with sharing class fflib_MatcherDefinitions
 
 			return false;
 		}
+
+		public override String toString()
+		{
+			return '[SObject with Id "' + toMatch + '"]';
+		}
 	}
 
 	/**
@@ -974,6 +1205,11 @@ public with sharing class fflib_MatcherDefinitions
 
 			return false;
 		}
+
+		public override String toString()
+		{
+			return '[SObject with Name "' + toMatch + '"]';
+		}
 	}
 
 	/*
@@ -1001,6 +1237,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof String ? ((String)arg).contains(toMatch) : false;
 		}
+
+		public override String toString()
+		{
+			return '[contains "' + toMatch + '"]';
+		}
 	}
 
 	/**
@@ -1024,6 +1265,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof String ? ((String)arg).endsWith(toMatch) : false;
 		}
+
+		public override String toString()
+		{
+			return '[ends with "' + toMatch + '"]';
+		}
 	}
 
 	/**
@@ -1034,6 +1280,11 @@ public with sharing class fflib_MatcherDefinitions
 		public Boolean matches(Object arg)
 		{
 			return arg == null || (arg instanceof String ? String.isBlank((String)arg) : false);
+		}
+
+		public override String toString()
+		{
+			return '[blank String]';
 		}
 	}
 
@@ -1046,6 +1297,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return (arg != NULL && arg instanceof String) ? String.isNotBlank((String)arg) : false;
 		}
+
+		public override String toString()
+		{
+			return '[non-blank String]';
+		}
 	}
 
 	/**
@@ -1054,6 +1310,7 @@ public with sharing class fflib_MatcherDefinitions
 	public class StringMatches implements fflib_IMatcher
 	{
 		private Pattern pat;
+		private final String regEx;
 		
 		/**
 		 * StringMatches constructor
@@ -1062,12 +1319,18 @@ public with sharing class fflib_MatcherDefinitions
 		 */
 		public StringMatches(String regEx)
 		{
+			this.regEx = regEx;
 			this.pat = Pattern.compile((String)validateNotNull(regEx));
 		}	
 		
 		public Boolean matches(Object arg)
 		{
 			return arg != null && arg instanceof String ? pat.matcher((String)arg).matches() : false;
+		}
+
+		public override String toString()
+		{
+			return '[matches regex "' + regEx + '"]';
 		}
 	}
 
@@ -1092,6 +1355,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			return arg != null && arg instanceof String ? ((String)arg).startsWith(toMatch) : false;
 		}
+
+		public override String toString()
+		{
+			return '[starts with "' + toMatch + '"]';
+		}
 	}
 
 	/*
@@ -1106,5 +1374,17 @@ public with sharing class fflib_MatcherDefinitions
 		}
 		
 		return arg;
+	}
+
+	public static String stringify(Object value)
+	{
+		try
+		{
+			return JSON.serialize(value, false);
+		}
+		catch (Exception error)
+		{
+			return '' + value;
+		}
 	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
@@ -1097,11 +1097,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			if (matchInOrder)
 			{
-				return '[matches ' + stringify(toMatch) + ' in order]';
+				return '[ordered SObjects with ' + stringify(toMatch) + ']';
 			}
 			else
 			{
-				return '[matches ' + stringify(toMatch) + ' in any order]';
+				return '[unordered SObjects with ' + stringify(toMatch) + ']';
 			}
 		}
         

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodVerifier.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodVerifier.cls
@@ -62,22 +62,93 @@ public abstract class fflib_MethodVerifier
 		Integer expectedCount,
 		String qualifier,
 		Integer methodCount,
-		String customAssertMessage)
+		String customAssertMessage,
+		fflib_MethodArgValues expectedArguments,
+		List<fflib_IMatcher> expectedMatchers,
+		List<fflib_MethodArgValues> actualArguments)
 	{
-		String assertMessage = 'Wanted but not invoked: ' + qm + '.';
+		String template = 'EXPECTED COUNT: {0}{1}{2}' // qualified expected count (e.g. "3 or fewer times in order")
+			+ '\nACTUAL COUNT: {3}' // actual count
+			+ '\nMETHOD: {4}' // method signature
+			+ '{5}'; // custom assert message
 
-		if(customAssertMessage != null)
+		String expectedDescription = '';
+		String actualDescription = '';
+
+		if (qm.hasArguments())
 		{
-			assertMessage = assertMessage + ' ' + customAssertMessage + '.';
+			template += '\n---' // separator
+				+ '\nACTUAL ARGS: {6}' // actual args
+				+ '\n---' // separator
+				+ '\nEXPECTED ARGS: {7}'; // matcher descriptions 
+
+			if (expectedMatchers == null)
+			{
+				expectedDescription = describe(expectedArguments);
+			}
+			else
+			{
+				expectedDescription = describe(expectedMatchers);
+			}
+			actualDescription = describe(actualArguments);
 		}
 
-		String message = '{0}Expected : {1}{2}, Actual: {3} -- {4}';
+		String message = String.format(template, new List<String>{
+			'' + expectedCount,
+			String.isBlank(qualifier) ? '' : ('' + qualifier),
+			inOrder,
+			'' + methodCount,
+			'' + qm,
+			String.isBlank(customAssertMessage) ? '' : ('\n' + customAssertMessage),
+			actualDescription,
+			expectedDescription
+		});
 
-		List<String> errorParameters = new List<String>
+		throw new fflib_ApexMocks.ApexMocksException(message);
+	}
+
+	private static String describe(List<fflib_IMatcher> matchers)
+	{
+		List<String> descriptions = new List<String>();
+		for (fflib_IMatcher matcher : matchers)
 		{
-			inOrder, expectedCount + '', qualifier, methodCount + '', assertMessage
-		};
+			descriptions.add('' + matcher);
+		}
 
-		throw new fflib_ApexMocks.ApexMocksException(String.format(message, errorParameters));
+		return String.join(descriptions, ', ');
+	}
+
+	private static String describe(List<fflib_MethodArgValues> valuesFromAllInvocations)
+	{
+		List<String> descriptions = new List<String>();
+		if (valuesFromAllInvocations != null)
+		{
+			for (fflib_MethodArgValues valuesFromOneInvocation : valuesFromAllInvocations)
+			{
+				descriptions.add(describe(valuesFromOneInvocation));
+			}
+		}
+
+		return '(' + String.join(descriptions, '), (') + ')';
+	}
+
+	private static String describe(fflib_MethodArgValues values)
+	{
+		List<String> descriptions = new List<String>();
+		for (Object value : values.argValues)
+		{
+			try
+			{
+				// Attempt to JSON serialize - that way it doesn't truncate SObject fields etc.
+				// Bear in mind that something are not JSON serializable, e.g. things with circular references.
+				descriptions.add(JSON.serialize(value));
+			}
+			catch (Exception error)
+			{
+				descriptions.add('' + value);
+			}
+		}
+
+		return String.join(descriptions, ', ');
 	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
@@ -70,4 +70,13 @@ public with sharing class fflib_QualifiedMethod
 	{
 		return typeName + '.' + methodName + methodArgTypes;
 	}
+
+	/**
+	 * Predicate describing whether the qualified method accepts arguments or not.
+	 * @return True if the method accepts arguments.
+	 */
+	public Boolean hasArguments()
+	{
+		return this.methodArgTypes != null && !this.methodArgTypes.isEmpty();
+	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
@@ -3,10 +3,10 @@
  */
 public with sharing class fflib_QualifiedMethod
 {
-	private Object mockInstance;
-	private String typeName;
-	private String methodName;
-	private List<Type> methodArgTypes;
+	public final Object mockInstance;
+	public final String typeName;
+	public final String methodName;
+	public final List<Type> methodArgTypes;
 	
 	public fflib_QualifiedMethod(String typeName, String methodName, List<Type> methodArgTypes)
 	{

--- a/sfdx-source/apex-mocks/test/classes/fflib_AnyOrderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_AnyOrderTest.cls
@@ -8,8 +8,6 @@
 @isTest
 private class fflib_AnyOrderTest
 {
-	private static final String BASIC_VERIFY_ASSERTION_MESSAGE = 'Expected : {0}, Actual: {1} -- Wanted but not invoked: ';
-
 	/*
 	 *	replicating the apex mocks tests with the new syntax
 	 */
@@ -328,15 +326,16 @@ private class fflib_AnyOrderTest
 		}
 		catch(Exception exc)
 		{
-			String exceptionMessage = exc.getMessage();
-
-			String expectedMessage =
-				String.format(BASIC_VERIFY_ASSERTION_MESSAGE,
-					new List<String>{'2', '3'}) + fflib_MyList.getStubClassName() + '.add(String). ' + customAssertMessage + '.';
-
-			System.assertEquals(expectedMessage, exceptionMessage,
-				'The exception was caught, but the message was not as expected. ' +
-				'Expected: [' + expectedMessage + '],  Actual: [' + exceptionMessage + '].');
+			System.assertEquals('EXPECTED COUNT: 2'
+				+ '\nACTUAL COUNT: 3'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\nCustom message to explain the reason of the verification'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("bob"), ("bob")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: [any String]',
+				exc.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -401,10 +400,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 3 or more times, Actual: 2 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 3 or more times'
+				+ '\nACTUAL COUNT: 2'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("bob")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "bob"',
+				ex.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -460,10 +464,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 3 or more times, Actual: 2 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 3 or more times'
+				+ '\nACTUAL COUNT: 2'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: [any String]',
+				ex.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -532,10 +541,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 3 or fewer times, Actual: 4 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 3 or fewer times'
+				+ '\nACTUAL COUNT: 4'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("fred"), ("bob"), ("bob"), ("bob"), ("fred")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "bob"',
+				ex.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -593,10 +607,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 3 or fewer times, Actual: 4 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 3 or fewer times'
+				+ '\nACTUAL COUNT: 4'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("fred"), ("fred")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: [any String]'
+				, ex.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -657,10 +676,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 1 or more times, Actual: 0 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 or more times'
+				+ '\nACTUAL COUNT: 0'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("rob"), ("fred")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "bob"',
+				ex.getmessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -719,10 +743,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 1 or more times, Actual: 0 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 or more times'
+				+ '\nACTUAL COUNT: 0'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ()'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: [any String]',
+				ex.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -772,10 +801,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 3 or more times, Actual: 2 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 3 or more times'
+				+ '\nACTUAL COUNT: 2'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("bob")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "bob"',
+				ex.getMessage()
+			);
 		}
 	}
 
@@ -816,10 +850,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 3 or more times, Actual: 2 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 3 or more times'
+				+ '\nACTUAL COUNT: 2'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: [any String]',
+				ex.getMessage()
+			);
 		}
 	}
 
@@ -850,10 +889,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 5 or fewer times, Actual: 6 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 5 or fewer times'
+				+ '\nACTUAL COUNT: 6'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("fred"), ("bob"), ("bob"), ("bob"), ("bob"), ("bob"), ("fred")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "bob"',
+				ex.getMessage()
+			);
 		}
 	}
 
@@ -881,11 +925,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-
-			String expectedMessage = 'Expected : 5 or fewer times, Actual: 6 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 5 or fewer times'
+				+ '\nACTUAL COUNT: 6'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("bob"), ("fred"), ("fred"), ("fred")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: [any String]',
+				ex.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1037,10 +1085,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 1 or more times, Actual: 0 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 or more times'
+				+ '\nACTUAL COUNT: 0'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("bob")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "rob"',
+				ex.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1096,10 +1149,15 @@ private class fflib_AnyOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException ex)
 		{
-			String expectedMessage = 'Expected : 1 or more times, Actual: 0 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			String actualMessage = ex.getMessage();
-			System.assertEquals(expectedMessage, actualMessage,
-				'the exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 or more times'
+				+ '\nACTUAL COUNT: 0'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("bob"), ("fred")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: [starts with "rob"]',
+				ex.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1109,12 +1167,10 @@ private class fflib_AnyOrderTest
 
 	private static void assertFailMessage(String exceptionMessage, Integer expectedInvocations, Integer actualsInvocations)
 	{
-		String expectedMessage =
-			String.format(BASIC_VERIFY_ASSERTION_MESSAGE,
-				new List<String>{String.valueOf(expectedInvocations), String.valueOf(actualsInvocations)});
-		System.assert(exceptionMessage.contains(expectedMessage),
-			'The exception was caught, but the message was not as expected. ' +
-			'Expected: [' + expectedMessage + '],  Actual: [' + exceptionMessage + '].');
+		System.assert(
+			exceptionMessage.startsWith('EXPECTED COUNT: ' + expectedInvocations + '\nACTUAL COUNT: ' + actualsInvocations),
+			'Unexpected verify fail message: ' + exceptionMessage
+		);
 	}
 
 	/*

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksTest.cls
@@ -1598,6 +1598,12 @@ private class fflib_ApexMocksTest
 	{
 		System.assertEquals(expectedValue, MY_MOCK_LIST.get2(2, 'Hello.'), 'the method did not returned the expected value');
 	}
+	
+	@isTest
+	static void thatToStringReturnsSimpleStringValue()
+	{
+		System.assertEquals('fflib_ApexMocks', '' + new fflib_ApexMocks());
+	}
 
 	private class MyException extends Exception
 	{

--- a/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
@@ -26,8 +26,23 @@ private class fflib_InOrderTest
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-3');
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
 
-		assertVerifyInOrderExceptionForAddMethod('1-2', inOrder1, firstMock,
-			'It should fail because 1-2 is in the wrong order', 1, 0 );
+		try
+		{
+			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
+			System.assert(false, 'It should fail because 1-2 is in the wrong order');
+		}
+		catch (fflib_ApexMocks.ApexMocksException error)
+		{
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+'\nACTUAL COUNT: 0'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("1-2"), ("1-3"), ("1-4")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "1-2"',
+				error.getMessage(),
+				'Unexpected verify fail message');
+		}
 	}
 
 	@isTest
@@ -70,8 +85,23 @@ private class fflib_InOrderTest
 		// Then
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
 
-		assertVerifyInOrderExceptionForAddMethod('1-1', inOrder1, firstMock,
-			'It should fail because 1-1 is called before the addMore(1-1)', 1, 0 );
+		try
+		{
+			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+			System.assert(false, 'It should fail because 1-1 is called before the addMore(1-1)');
+		}
+		catch (fflib_ApexMocks.ApexMocksException error)
+		{
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+'\nACTUAL COUNT: 0'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("1-1"), ("1-2"), ("1-2")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "1-1"',
+				error.getMessage(),
+				'Unexpected verify fail message');
+		}
 	}
 
 	@isTest
@@ -90,8 +120,23 @@ private class fflib_InOrderTest
 		// Then
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
 
-		assertVerifyInOrderExceptionForAddMoreMethod('1-1', inOrder1, firstMock,
-			'It should fail because addMore(1-1) is called only Once', 1, 0 );
+		try
+		{
+			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
+			System.assert(false, 'It should fail because addMore(1-1) is called only Once');
+		}
+		catch (fflib_ApexMocks.ApexMocksException error)
+		{
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+ '\nACTUAL COUNT: 0'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.addMore(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("1-1"), ("1-2"), ("1-2")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "1-1"',
+				error.getMessage(),
+				'Unexpected verify fail message');
+		}
 	}
 
 	@isTest
@@ -131,8 +176,23 @@ private class fflib_InOrderTest
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(2))).add(fflib_Match.stringStartsWith('1-1'));
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
 
-		assertVerifyInOrderExceptionForAddMethod('1-11', inOrder1, firstMock,
-			'It should fail because addMore(1-11) has been already verified using the matchers', 1, 0 );
+		try
+		{
+			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-11');
+			System.assert(false, 'It should fail because addMore(1-11) has been already verified using the matchers');
+		}
+		catch (fflib_ApexMocks.ApexMocksException error)
+		{
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+'\nACTUAL COUNT: 0'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-0"), ("1-11"), ("1-12"), ("1-3"), ("1-4")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "1-11"',
+				error.getMessage(),
+				'Unexpected verify fail message');
+		}
 	}
 
 	@isTest
@@ -202,8 +262,23 @@ private class fflib_InOrderTest
 		// Then
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add(fflib_Match.stringStartsWith('1-'));
 
-		assertVerifyInOrderExceptionForAddMethod('1-11', inOrder1, firstMock,
-			'It should fail because only one call for the 2- is available to verify', 4, 0 );
+		try
+		{
+			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add('1-11');
+			System.assert(false, 'It should fail because only one call for the 2- is available to verify');
+		}
+		catch (fflib_ApexMocks.ApexMocksException error)
+		{
+			System.assertEquals('EXPECTED COUNT: 4 in order'
+				+'\nACTUAL COUNT: 0'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-2"), ("2-2"), ("1-3"), ("2-3"), ("1-4"), ("2-4")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "1-11"',
+				error.getMessage(),
+				'Unexpected verify fail message');
+		}
 	}
 
 	@isTest
@@ -223,8 +298,23 @@ private class fflib_InOrderTest
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
 
-		assertVerifyInOrderExceptionForAddMethod('1-2', inOrder1, firstMock,
-			'It should fail because is out of order', 1, 0 );
+		try
+		{
+			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
+			System.assert(false, 'It should fail because is out of order');
+		}
+		catch (fflib_ApexMocks.ApexMocksException error)
+		{
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+'\nACTUAL COUNT: 0'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("1-2"), ("1-3"), ("1-4")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "1-2"',
+				error.getMessage(),
+				'Unexpected verify fail message');
+		}
 	}
 
 	@isTest
@@ -283,9 +373,23 @@ private class fflib_InOrderTest
 		firstMock.add('1-4');
 
 		// Then
-
-		assertVerifyInOrderExceptionForAddMethod('1-2', inOrder1, firstMock,
-			'It should fail because is actually called only 3 times', 4, 3 );
+		try
+		{
+			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add('1-2');
+			System.assert(false, 'It should fail because is actually called only 3 times');
+		}
+		catch (fflib_ApexMocks.ApexMocksException e)
+		{
+			System.assertEquals('EXPECTED COUNT: 4 in order'
+				+'\nACTUAL COUNT: 3'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("1-2"), ("1-2"), ("1-2"), ("1-3"), ("1-4")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "1-2"',
+				e.getMessage(),
+				'Unexpected verify fail message');
+		}
 	}
 
 	@isTest
@@ -385,9 +489,15 @@ private class fflib_InOrderTest
 		}
 		catch(fflib_ApexMocks.ApexMocksException mockexcep)
 		{
-			String expectedMessage = 'In Order: Expected : 1, Actual: 0 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-			System.assertEquals(expectedMessage, mockexcep.getMessage(),
-				'an exception has been caught as expected, however the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+ '\nACTUAL COUNT: 0'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("2-1")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "2-1"',
+				mockexcep.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -414,11 +524,16 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
-			String expectedMessage = 'In Order: Expected : 1, Actual: 0 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String). Some custom error message.';
-			System.assertEquals(
-				expectedMessage,
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+ '\nACTUAL COUNT: 0'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\nSome custom error message'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("1-2")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "1-1"',
 				e.getMessage(),
-				'the verify throw an Exception, but the message is not as expected');
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -558,10 +673,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
-			String expectedMessage = 'In Order: Expected : 0, Actual: 4 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-
-			System.assertEquals(expectedMessage, e.getMessage(),
-				'the verify throw an Exception, but the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 0 in order'
+				+ '\nACTUAL COUNT: 4'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "1-1"',
+				e.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -592,10 +712,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
-			String expectedMessage = 'In Order: Expected : 0, Actual: 4 -- Wanted but not invoked: ' + fflib_MyList.getStubClassName() + '.add(String).';
-
-			System.assertEquals(expectedMessage, e.getMessage(),
-				'the verify throw an Exception, but the message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 0 in order'
+				+ '\nACTUAL COUNT: 4'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: [starts with "1-"]',
+				e.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -763,7 +888,6 @@ private class fflib_InOrderTest
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
 
-
 		// When
 		secondMock.add('1-2');
 		//Then
@@ -882,8 +1006,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 4, Actual: 3 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 4 in order'
+				+'\nACTUAL COUNT: 3'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "1-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -918,8 +1049,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 1, Actual: 0 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+'\nACTUAL COUNT: 0'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("1-1")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "2-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -997,8 +1135,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 1, Actual: 0 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+'\nACTUAL COUNT: 0'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "1-3"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1027,8 +1172,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 1, Actual: 0 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+'\nACTUAL COUNT: 0'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("2-1"), ("1-1"), ("1-1")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "2-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1080,8 +1232,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 2, Actual: 3 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 2 in order'
+				+ '\nACTUAL COUNT: 3'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "1-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1111,8 +1270,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 4, Actual: 3 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 4 in order'
+				+ '\nACTUAL COUNT: 3'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "1-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1258,8 +1424,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 5, Actual: 4 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 5 in order'
+				+ '\nACTUAL COUNT: 4'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("2-1")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "1-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1317,8 +1490,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 1, Actual: 4 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+'\nACTUAL COUNT: 4'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("2-1")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "1-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1370,8 +1550,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 2, Actual: 3 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 2 in order'
+				+ '\nACTUAL COUNT: 3'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "1-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1401,8 +1588,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 4, Actual: 3 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 4 in order'
+				+ '\nACTUAL COUNT: 3'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "1-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1458,8 +1652,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 5, Actual: 4 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 5 in order'
+				+ '\nACTUAL COUNT: 4'
+				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+ '\n---'
+				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("2-1")'
+				+ '\n---'
+				+ '\nEXPECTED ARGS: "1-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1543,8 +1744,15 @@ private class fflib_InOrderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			String expectedMessage = 'In Order: Expected : 1, Actual: 0 -- Wanted but not invoked: fflib_MyList__sfdc_ApexStub.add(String).';
-			System.assertEquals(expectedMessage, mockExcept.getMessage(), ' the error message is not as expected');
+			System.assertEquals('EXPECTED COUNT: 1 in order'
+				+'\nACTUAL COUNT: 0'
+				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+				+'\n---'
+				+'\nACTUAL ARGS: ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("2-1"), ("2-1"), ("2-1"), ("2-1"), ("1-1")'
+				+'\n---'
+				+'\nEXPECTED ARGS: "2-1"',
+				mockExcept.getMessage(),
+				'Unexpected verify fail message');
 		}
 	}
 
@@ -1619,65 +1827,5 @@ private class fflib_InOrderTest
 		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(2))).get2(fflib_Match.eqInteger(1), (String) argument.capture());
 
 		System.assertEquals('2-1', (string) argument.getValue(), 'the last value captured is not as expected');
-	}
-
-	private static void assertVerifyInOrderExceptionForAddMoreMethod(
-		String argument,
-		fflib_InOrder inOrderInstance,
-		fflib_MyList.IList mockToVerify,
-		String expectedFailingReasson,
-		Integer expectedCount,
-		Integer actualCounts
-		)
-	{
-		try
-		{
-			((fflib_MyList.IList)inOrderInstance.verify(mockToVerify, MY_MOCKS.calls(1))).addMore(argument);
-			System.assert(false, 'expected some exception ' + expectedFailingReasson);
-		}
-		catch (fflib_ApexMocks.ApexMocksException e)
-		{
-			String message = 'In Order: Expected : {0}, Actual: {1} -- Wanted but not invoked: {2}.addMore(String).';
-
-			String expectedMessage = String.format(message, new List<String>{
-					'' + expectedCount,
-					'' + actualCounts,
-					fflib_MyList.getStubClassName()
-				});
-
-			System.assertEquals(expectedMessage, e.getMessage(),
-				'the verify throw an Exception, but the message is not as expected');
-		}
-	}
-
-
-	private static void assertVerifyInOrderExceptionForAddMethod(
-		String argument,
-		fflib_InOrder inOrderInstance,
-		fflib_MyList.IList mockToVerify,
-		String expectedFailingReasson,
-		Integer expectedCount,
-		Integer actualCounts
-		)
-	{
-		try
-		{
-			((fflib_MyList.IList)inOrderInstance.verify(mockToVerify, MY_MOCKS.calls(expectedCount))).add(argument);
-			System.assert(false, 'expected some exception ' + expectedFailingReasson);
-		}
-		catch (fflib_ApexMocks.ApexMocksException e)
-		{
-
-			String message = 'In Order: Expected : {0}, Actual: {1} -- Wanted but not invoked: {2}.add(String).';
-
-			String expectedMessage = String.format(message, new List<String>{
-					'' + expectedCount,
-					'' + actualCounts,
-					fflib_MyList.getStubClassName()
-				});
-
-			System.assertEquals(expectedMessage, e.getMessage(),
-				'the verify throw an Exception, but the message is not as expected');
-		}
 	}
 }

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
@@ -138,6 +138,29 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenCombinedMatcherToStringReturnsExpectedString()
+	{
+		List<fflib_IMatcher> innerMatchers = new List<fflib_IMatcher>{
+			new StringMatcher('one'),
+			new StringMatcher('two'),
+			new StringMatcher('three')
+		};
+
+		System.assertEquals(
+			'[any of: "one", "two", "three"]',
+			'' + new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.AT_LEAST_ONE, innerMatchers)
+		);
+		System.assertEquals(
+			'[all of: "one", "two", "three"]',
+			'' + new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.ALL, innerMatchers)
+		);
+		System.assertEquals(
+			'[none of: "one", "two", "three"]',
+			'' + new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.NONE, innerMatchers)
+		);
+	}
+
+	@isTest
 	private static void constructEq_WithNullArg_ThrowsException()
 	{
 		try
@@ -161,6 +184,12 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!matcher.matches(new List<String> {'bob'}));
 		System.assert(matcher.matches(s2));
 		System.assert(matcher.matches(s1));		
+	}
+
+	@isTest
+	private static void whenEqToStringShouldReturnExpectedString()
+	{
+		System.assertEquals('[equals 1]', '' + new fflib_MatcherDefinitions.Eq(1));
 	}
 
 	@isTest
@@ -199,6 +228,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenAnyBooleanToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any Boolean]', '' + new fflib_MatcherDefinitions.AnyBoolean());
+	}
+
+	@isTest
 	private static void whenAnyDateMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyDate();
@@ -208,12 +243,24 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenAnyDateToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any Date]', '' + new fflib_MatcherDefinitions.AnyDate());
+	}
+
+	@isTest
 	private static void whenAnyDatetimeMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyDatetime();
 		System.assert(!matcher.matches(null));
 		System.assert(matcher.matches(NOW));
 		System.assert(matcher.matches(TODAY));
+	}
+
+	@isTest
+	private static void whenAnyDatetimeToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any DateTime]', '' + new fflib_MatcherDefinitions.AnyDatetime());
 	}
 
 	@isTest
@@ -228,6 +275,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenAnyDecimalToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any Decimal]', '' + new fflib_MatcherDefinitions.AnyDecimal());
+	}
+
+	@isTest
 	private static void whenAnyDoubleMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyDouble();
@@ -236,6 +289,12 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(matcher.matches(9));
 		System.assert(matcher.matches(9L));
 		System.assert(matcher.matches(9.99));
+	}
+
+	@isTest
+	private static void whenAnyDoubleToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any Double]', '' + new fflib_MatcherDefinitions.AnyDouble());
 	}
 
 	@isTest
@@ -253,6 +312,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenAnyFieldSetToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any FieldSet]', '' + new fflib_MatcherDefinitions.AnyFieldSet());
+	}
+
+	@isTest
 	private static void whenAnyIdMatchesShouldReturnCorrectResults()
 	{
 		String idString = fflib_IDGenerator.generate(Account.SObjectType);
@@ -262,6 +327,12 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!matcher.matches('bob'));
 		System.assert(matcher.matches(idString));
 		System.assert(matcher.matches(accountId));
+	}
+
+	@isTest
+	private static void whenAnyIdToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any Id]', '' + new fflib_MatcherDefinitions.AnyId());
 	}
 
 	@isTest
@@ -276,6 +347,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenAnyIntegerToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any Integer]', '' + new fflib_MatcherDefinitions.AnyInteger());
+	}
+
+	@isTest
 	private static void whenAnyListMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyList();
@@ -284,6 +361,12 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(matcher.matches(new List<String>()));
 		System.assert(matcher.matches(new List<Integer>()));
 		System.assert(matcher.matches(new List<Object>()));
+	}
+
+	@isTest
+	private static void whenAnyListToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any list]', '' + new fflib_MatcherDefinitions.AnyList());
 	}
 
 	@isTest
@@ -298,6 +381,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenAnyLongToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any Long]', '' + new fflib_MatcherDefinitions.AnyLong());
+	}
+
+	@isTest
 	private static void whenAnyObjectMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyObject();
@@ -305,6 +394,12 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(matcher.matches('bob'));
 		System.assert(matcher.matches(9));
 		System.assert(matcher.matches(new List<String>()));
+	}
+
+	@isTest
+	private static void whenAnyObjectToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any Object]', '' + new fflib_MatcherDefinitions.AnyObject());
 	}
 
 	@isTest
@@ -317,12 +412,24 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenAnyStringToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any String]', '' + new fflib_MatcherDefinitions.AnyString());
+	}
+
+	@isTest
 	private static void whenAnySObjectMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnySObject();
 		System.assert(!matcher.matches(null));
 		System.assert(!matcher.matches('bob'));
 		System.assert(matcher.matches(new Account()));
+	}
+
+	@isTest
+	private static void whenAnySObjectToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any SObject]', '' + new fflib_MatcherDefinitions.AnySObject());
 	}
 
 	@isTest
@@ -335,12 +442,24 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenAnySObjectFieldToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any SObjectField]', '' + new fflib_MatcherDefinitions.AnySObjectField());
+	}
+
+	@isTest
 	private static void whenAnySObjectTypeMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnySObjectType();
 		System.assert(!matcher.matches(null));
 		System.assert(!matcher.matches(new Account()));
 		System.assert(matcher.matches(Account.SObjectType));
+	}
+
+	@isTest
+	private static void whenAnySObjectTypeToStringReturnsExpectedString()
+	{
+		System.assertEquals('[any SObjectType]', '' + new fflib_MatcherDefinitions.AnySObjectType());
 	}
 
 	@isTest
@@ -394,6 +513,34 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenDatetimeAfterWithInclusiveToStringReturnsExpectedString()
+	{
+		// Given
+		DateTime fromDate = DateTime.newInstanceGmt(2019, 1, 1, 12, 0, 0);
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeAfter(fromDate, true);
+
+		// When
+		String actual = '' + matcher;
+
+		// Then
+		System.assertEquals('[on or after "2019-01-01T12:00:00.000Z"]', actual);
+	}
+
+	@isTest
+	private static void whenDatetimeAfterWithNotInclusiveToStringReturnsExpectedString()
+	{
+		// Given
+		DateTime fromDate = DateTime.newInstanceGmt(2019, 1, 1, 12, 0, 0);
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeAfter(fromDate, false);
+
+		// When
+		String actual = '' + matcher;
+
+		// Then
+		System.assertEquals('[after "2019-01-01T12:00:00.000Z"]', actual);
+	}
+
+	@isTest
 	private static void constructDatetimeBefore_WithNullToDatetime_ThrowsException()
 	{
 		try
@@ -441,6 +588,34 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!matcher.matches(NOW.addSeconds(1)));
 		System.assert(matcher.matches(NOW));
 		System.assert(matcher.matches(NOW.addSeconds(-1)));
+	}
+
+	@isTest
+	private static void whenDatetimeBeforeWithInclusiveToStringReturnsExpectedString()
+	{
+		// Given
+		DateTime toDate = DateTime.newInstanceGmt(2019, 1, 1, 12, 0, 0);
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeBefore(toDate, true);
+
+		// When
+		String actual = '' + matcher;
+
+		// Then
+		System.assertEquals('[on or before "2019-01-01T12:00:00.000Z"]', actual);
+	}
+
+	@isTest
+	private static void whenDatetimeBeforeWithNotInclusiveToStringReturnsExpectedString()
+	{
+		// Given
+		DateTime toDate = DateTime.newInstanceGmt(2019, 1, 1, 12, 0, 0);
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeBefore(toDate, false);
+
+		// When
+		String actual = '' + matcher;
+
+		// Then
+		System.assertEquals('[before "2019-01-01T12:00:00.000Z"]', actual);
 	}
 
 	@isTest
@@ -521,6 +696,36 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!matcher.matches(NOW.addSeconds(-1)));
 		System.assert(matcher.matches(NOW));
 		System.assert(matcher.matches(NOW.addSeconds(1)));
+	}
+
+	@isTest
+	private static void whenDatetimeBetweenWithInclusiveToStringReturnsExpectedString()
+	{
+		// Given
+		DateTime fromDate = DateTime.newInstanceGmt(2019, 1, 1, 12, 0, 0);
+		DateTime toDate = DateTime.newInstanceGmt(2019, 1, 3, 12, 0, 0);
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeBetween(fromDate, true, toDate, true);
+
+		// When
+		String actual = '' + matcher;
+
+		// Then
+		System.assertEquals('[on or after "2019-01-01T12:00:00.000Z" and on or before "2019-01-03T12:00:00.000Z"]', actual);
+	}
+
+	@isTest
+	private static void whenDatetimeBetweenWithNotInclusiveToStringReturnsExpectedString()
+	{
+		// Given
+		DateTime fromDate = DateTime.newInstanceGmt(2019, 1, 1, 12, 0, 0);
+		DateTime toDate = DateTime.newInstanceGmt(2019, 1, 3, 12, 0, 0);
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeBetween(fromDate, false, toDate, false);
+
+		// When
+		String actual = '' + matcher;
+
+		// Then
+		System.assertEquals('[after "2019-01-01T12:00:00.000Z" and before "2019-01-03T12:00:00.000Z"]', actual);
 	}
 
 	@isTest
@@ -779,11 +984,23 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenIsNullToStringReturnsExpectedString()
+	{
+		System.assertEquals('[is null]', '' + new fflib_MatcherDefinitions.IsNull());
+	}
+
+	@isTest
 	private static void whenIsNotNullMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.IsNotNull();
 		System.assert(!matcher.matches(null));
 		System.assert(matcher.matches('bob'));
+	}
+
+	@isTest
+	private static void whenIsNotNullToStringReturnsExpectedString()
+	{
+		System.assertEquals('[is not null]', '' + new fflib_MatcherDefinitions.IsNotNull());
 	}
 
 	@isTest
@@ -800,6 +1017,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenListContainsToStringReturnsExpectedString()
+	{
+		System.assertEquals('[list containing "hello"]', '' + new fflib_MatcherDefinitions.ListContains('hello'));
+	}
+
+	@isTest
 	private static void whenListIsEmptyMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.ListIsEmpty();
@@ -811,6 +1034,12 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!matcher.matches(names));
 		System.assert(matcher.matches(empty));
 		System.assert(!matcher.matches('NotAList'));
+	}
+
+	@isTest
+	private static void whenListIsEmptyToStringReturnsExpectedString()
+	{
+		System.assertEquals('[empty list]', '' + new fflib_MatcherDefinitions.ListIsEmpty());
 	}
 
 	@isTest
@@ -838,6 +1067,12 @@ public class fflib_MatcherDefinitionsTest
 
 		System.assert(matcher.matches(ACCOUNT_OBJECT_TYPE.newSObject()));
 		System.assert(matcher.matches(ACCOUNT_RECORD));
+	}
+
+	@isTest
+	private static void whenSObjectOfTypeToStringReturnsExpectedString()
+	{
+		System.assertEquals('[SObject of type Account]', '' + new fflib_MatcherDefinitions.SObjectOfType(ACCOUNT_OBJECT_TYPE));
 	}
 
 	@isTest
@@ -897,6 +1132,15 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(matcher.matches(ACCOUNT_RECORD));
 
 		System.assert(!new fflib_MatcherDefinitions.SObjectWith(notQueriedFieldValues).matches(ACCOUNT_RECORD));
+	}
+
+	@isTest
+	private static void whenSObjectWithToStringReturnsExpectedString()
+	{
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectWith(new Map<Schema.SObjectField, Object>{
+			Account.Name => 'Test'
+		});
+		System.assertEquals('[SObject with fields {"Name":"Test"}]', '' + matcher);
 	}
 
 	@isTest
@@ -1060,6 +1304,13 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenSObjectWithIdToStringReturnsExpectedString()
+	{
+		Id recordId = '001000000000001AAA';
+		System.assertEquals('[SObject with Id "001000000000001AAA"]', '' + new fflib_MatcherDefinitions.SObjectWithId(recordId));
+	}
+
+	@isTest
 	private static void constructSObjectWithName_WithNullArg_ThrowsException()
 	{
 		try
@@ -1084,6 +1335,12 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!matcher.matches('NotASObject'));
 
 		System.assert(matcher.matches(ACCOUNT_RECORD));
+	}
+
+	@isTest
+	private static void whenSObjectWithNameToStringReturnsExpectedString()
+	{
+		System.assertEquals('[SObject with Name "Test"]', '' + new fflib_MatcherDefinitions.SObjectWithName('Test'));
 	}
 
 	@isTest
@@ -1113,6 +1370,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenStringContainsToStringReturnsExpectedStrings()
+	{
+		System.assertEquals('[contains "hello"]', '' + new fflib_MatcherDefinitions.StringContains('hello'));
+	}
+
+	@isTest
 	private static void whenStringEndsWithMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.StringEndsWith('bob');
@@ -1139,6 +1402,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenStringEndsWithToStringReturnsExpectedStrings()
+	{
+		System.assertEquals('[ends with "hello"]', '' + new fflib_MatcherDefinitions.StringEndsWith('hello'));
+	}
+
+	@isTest
 	private static void whenIsBlankWithMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.StringIsBlank();
@@ -1149,6 +1418,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenStringIsBlankToStringReturnsExpectedStrings()
+	{
+		System.assertEquals('[blank String]', '' + new fflib_MatcherDefinitions.StringIsBlank());
+	}
+
+	@isTest
 	private static void whenIsNotBlankWithMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.StringIsNotBlank();
@@ -1156,6 +1431,12 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!matcher.matches(null));
 		System.assert(!matcher.matches(''));
 		System.assert(matcher.matches('bob'));
+	}
+
+	@isTest
+	private static void whenStringIsNotBlankToStringReturnsExpectedStrings()
+	{
+		System.assertEquals('[non-blank String]', '' + new fflib_MatcherDefinitions.StringIsNotBlank());
 	}
 
 	@isTest
@@ -1170,6 +1451,12 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!matcher.matches('bob1'));
 		System.assert(matcher.matches('bobby'));
 		System.assert(matcher.matches('mo'));
+	}
+
+	@isTest
+	private static void whenStringMatchesToStringReturnsExpectedStrings()
+	{
+		System.assertEquals('[matches regex "hello"]', '' + new fflib_MatcherDefinitions.StringMatches('hello'));
 	}
 
 	@isTest
@@ -1199,6 +1486,12 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenStringStartsWithToStringReturnsExpectedStrings()
+	{
+		System.assertEquals('[starts with "hello"]', '' + new fflib_MatcherDefinitions.StringStartsWith('hello'));
+	}
+
+	@isTest
 	private static void constructStringStartsWith_WithNullArg_ThrowsException()
 	{
 		try
@@ -1209,6 +1502,26 @@ public class fflib_MatcherDefinitionsTest
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
 			System.assertEquals('Arg cannot be null: null', e.getMessage());
+		}
+	}
+
+	private class StringMatcher implements fflib_IMatcher
+	{
+		private final String value;
+
+		public StringMatcher(String value)
+		{
+			this.value = value;
+		}
+
+		public Boolean matches(Object arg)
+		{
+			return true;
+		}
+
+		public override String toString()
+		{
+			return '"' + value + '"';
 		}
 	}
 }

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
@@ -1277,6 +1277,19 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenSObjectsWithToStringReturnsExpectedString()
+	{
+		List<Map<Schema.SObjectField, Object>> toMatch = new List<Map<Schema.SObjectField, Object>>{
+			new Map<Schema.SObjectField, Object> {
+				Account.Name => 'Test'
+			}
+		};
+
+		System.assertEquals('[ordered SObjects with [{"Name":"Test"}]]', '' + new fflib_MatcherDefinitions.SObjectsWith(toMatch, true));
+		System.assertEquals('[unordered SObjects with [{"Name":"Test"}]]', '' + new fflib_MatcherDefinitions.SObjectsWith(toMatch, false));
+	}
+
+	@isTest
 	private static void constructSObjectWithId_WithNullArg_ThrowsException()
 	{
 		try


### PR DESCRIPTION
Adds better logging around expected and actual values to help diagnose match failures, and better descriptions of matchers.
Addresses #58 and others.

Ported from FF internal repo.
Tests all passing in my org.