### PR TITLE
Solve "Unreachable Statement" Compilation Error

### DIFF
--- a/sfdx-source/apex-mocks/test/classes/fflib_AnswerTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_AnswerTest.cls
@@ -326,7 +326,6 @@ private class fflib_AnswerTest
 			actualInvocation = invocation;
 
 			throw new fflib_ApexMocks.ApexMocksException('an error occurs on the execution of the answer');
-			return null;
 		}
 	}
 


### PR DESCRIPTION
This is a "clone" of #64, but this PR removes the return statement entirely as the exception is the logical end of execution.

This is needed in order to bump the API version, the issue raised by @daveespo in #97.

I ran all Apex tests pre, and post update, and have attached the test results for review.

[test-result-post.txt](https://github.com/apex-enterprise-patterns/fflib-apex-mocks/files/5794051/test-result-post.txt)
[test-result-pre.txt](https://github.com/apex-enterprise-patterns/fflib-apex-mocks/files/5794052/test-result-pre.txt)

Tagging @ImJohnMDaniel, @daveespo for review.