### PR TITLE
Tests for fflib matcher definitions

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
@@ -200,7 +200,7 @@ public with sharing class fflib_MatcherDefinitions
 
 		public override String toString()
 		{
-			return '[reference equals ' + stringify(toMatch) + ']';
+			return '[reference equals ' + fflib_MatcherDefinitions.stringify(toMatch) + ']';
 		}
 	}
 	
@@ -1097,11 +1097,11 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			if (matchInOrder)
 			{
-				return '[ordered SObjects with ' + stringify(toMatch) + ']';
+				return '[ordered SObjects with ' + fflib_MatcherDefinitions.stringify(toMatch) + ']';
 			}
 			else
 			{
-				return '[unordered SObjects with ' + stringify(toMatch) + ']';
+				return '[unordered SObjects with ' + fflib_MatcherDefinitions.stringify(toMatch) + ']';
 			}
 		}
         

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
@@ -1351,6 +1351,31 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenSObjectsWithDifferentArityMatchesShouldReturnFalse()
+	{
+		List<Map<Schema.SObjectField, Object>> toMatch = new List<Map<Schema.SObjectField, Object>>{
+			new Map<Schema.SObjectField, Object> {
+				Account.Name => 'Test'
+			}
+		};
+		Boolean matchResult = new fflib_MatcherDefinitions.SObjectsWith(toMatch).matches(new List<SObject>{});
+		System.assertEquals(matchResult, false);	
+	}
+
+	@isTest
+	private static void constructSObjectsWith_WithNullArg_ThrowsException()
+	{
+		try {
+			new fflib_MatcherDefinitions.SObjectsWith(null);
+			System.assert(false, 'Expected exception');
+		}
+		catch (fflib_ApexMocks.ApexMocksException e)
+		{
+			System.assertEquals('Arg cannot be null/empty/other than list of map<Schema.SobjectField,Object>: null', e.getMessage());
+		}
+	}
+
+	@isTest
 	private static void constructSObjectWithId_WithNullArg_ThrowsException()
 	{
 		try
@@ -1577,6 +1602,14 @@ public class fflib_MatcherDefinitionsTest
 		{
 			System.assertEquals('Arg cannot be null: null', e.getMessage());
 		}
+	}
+
+	@isTest
+	private static void whenJSONExceptionOccursStringifyShouldReturnsObjectToString()
+	{
+		// SObjectField object definitely can't be serialized by JSON.serialize() method
+		Schema.SObjectField sObjField = Account.Description;
+		System.assertEquals('' + sObjField, fflib_MatcherDefinitions.stringify(sObjField));
 	}
 
 	private class StringMatcher implements fflib_IMatcher

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
@@ -218,6 +218,13 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenRefEqToStringReturnsExpectedString()
+	{
+        List<String> s1 = new List<String> {'bob', 'tom'};
+		System.assertEquals('[reference equals ' + JSON.serialize(s1, false) + ']', '' + new fflib_MatcherDefinitions.RefEq(s1));
+	}
+
+	@isTest
 	private static void whenAnyBooleanMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyBoolean();
@@ -837,6 +844,24 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenDecimalBetweenToStringReturnsExpectedString()
+	{
+		Integer lower = 5;
+		Integer upper = 10;
+
+		List<Integer> formatList = new List<Integer>{lower, upper};
+
+		System.assertEquals(String.format('greater than {0} and less than {1}', formatList), 
+			'' + new fflib_MatcherDefinitions.DecimalBetween(lower, false, upper, false));
+		System.assertEquals(String.format('greater than {0} and less than or equal to {1}', formatList),
+			'' + new fflib_MatcherDefinitions.DecimalBetween(lower, false, upper, true));
+		System.assertEquals(String.format('greater than or equal to {0} and less than {1}', formatList),
+			'' + new fflib_MatcherDefinitions.DecimalBetween(lower, true, upper, false));
+		System.assertEquals(String.format('greater than or equal to {0} and less than or equal to {1}', formatList),
+			'' + new fflib_MatcherDefinitions.DecimalBetween(lower, true, upper, true));
+	}
+
+	@isTest
 	private static void constructDecimalLessThan_WithNullToMatch_ThrowsException()
 	{
 		try
@@ -885,6 +910,17 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!inclusive.matches(toMatch + 1));
 		System.assert(!inclusive.matches(null));
 		System.assert(!inclusive.matches('NotADecimal'));
+	}
+
+	@isTest
+	private static void whenDecimalLessThanToStringReturnsExpectedString()
+	{
+		Integer toMatch = 5;
+
+		System.assertEquals('[less than or equal to ' + toMatch + ']',
+			'' + new fflib_MatcherDefinitions.DecimalLessThan(toMatch, true));
+		System.assertEquals('[less than ' + toMatch + ']', 
+			'' + new fflib_MatcherDefinitions.DecimalLessThan(toMatch, false));
 	}
 
 	@isTest
@@ -939,6 +975,17 @@ public class fflib_MatcherDefinitionsTest
 	}
 
 	@isTest
+	private static void whenDecimalMoreThanToStringReturnsExpectedString()
+	{
+		Integer toMatch = 5;
+
+		System.assertEquals('[greater than or equal to ' + toMatch + ']',
+			'' + new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, true));
+		System.assertEquals('[greater than ' + toMatch + ']', 
+			'' + new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, false));
+	}
+
+	@isTest
 	private static void constructFieldSetEquivalentTo_WithNullFieldSet_ThrowsException()
 	{
 		try
@@ -973,6 +1020,20 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(!matcher.matches(null));
 		System.assert(!matcher.matches('hello'));
 		System.assert(matcher.matches(anyFieldSet));
+	}
+
+	@isTest
+	private static void whenFieldSetEquivalentToToStringReturnsExpectedString()
+	{
+		Schema.FieldSet anyFieldSet = fflib_ApexMocksUtilsTest.findAnyFieldSet();
+		if (anyFieldSet == null)
+		{
+			return;
+		}
+		Set<Schema.FieldSetMember> fieldSetMembers = new Set<Schema.FieldSetMember>((anyFieldSet).getFields());
+
+		System.assertEquals('[FieldSet with fields ' + JSON.serialize(fieldSetMembers, false) + ']', 
+			'' + new fflib_MatcherDefinitions.FieldSetEquivalentTo(anyFieldSet));
 	}
 
 	@isTest


### PR DESCRIPTION
This PR increases test coverage of class `fflib_MatcherDefinitions` up to 100% 

This PR contains:
- test methods for `RefEq/DecimalBetween/DecimalLessThan/DecimaMoreThan/FieldSetEquivalentTo `
overridden `toString()` methods;
- test methods for missed test scenarios like `SObjectsWith` with `args = null` passed; `SObjectsWith` matches objects with different arity; `JSONException` occurrence inside `fflib_MatcherDefinitions.stringify()` method;
- minor edits for the same `fflib_MatcherDefinitions.stringify()` method usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/111)
<!-- Reviewable:end -->
