### PR TITLE
Replace "magic" integer in fflib_IDGenerator, `fakeIdPrefix` string operation

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
@@ -36,7 +36,7 @@ public with sharing class fflib_IDGenerator
 		String keyPrefix = sobjectType.getDescribe().getKeyPrefix();
 		fakeIdCount++;
 
-		String fakeIdPrefix = ID_PATTERN.substring(0, 12 - String.valueOf(fakeIdCount).length());
+		String fakeIdPrefix = ID_PATTERN.substring(0, ID_PATTERN.length() - String.valueOf(fakeIdCount).length());
 
 		return Id.valueOf(keyPrefix + fakeIdPrefix + fakeIdCount);
 	}


### PR DESCRIPTION
Uses the length of the component string instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/117)
<!-- Reviewable:end -->
