### PR TITLE
feat: support setReadOnlyFields by FieldName

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
@@ -97,15 +97,27 @@ public class fflib_ApexMocksUtils
 	 */
 	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<SObjectField, Object> properties) {
 
-		Map<String, Object> mergedMap = new Map<String, Object>(objInstance.getPopulatedFieldsAsMap());
+		Map<String, Object> fieldNameMap = new Map<String, Object>();
 		for (SObjectField field : properties.keySet()) {
-			// Merge the values from the properties map into the fields already set on the object
-			mergedMap.put(field.getDescribe().getName(), properties.get(field));
+			// Resolve the fieldNames from the FieldTokens
+			fieldNameMap.put(field.getDescribe().getName(), properties.get(field));
 		}
+		return (SObject) setReadOnlyFields(objInstance, deserializeType, fieldNameMap);
+	}
+
+	/**
+	 * Generic overload to setReadOnlyFields. Enables setting test
+	 * values on read-only fields by their name
+	 */
+	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<String, Object> properties) {
+
+		Map<String, Object> mergedMap = new Map<String, Object>(objInstance.getPopulatedFieldsAsMap());
+		// Merge the values from the properties map into the fields already set on the object
+		mergedMap.putAll(properties);
 		// Serialize the merged map, and then deserialize it as the desired object type.
 		String jsonString = JSON.serializePretty(mergedMap);
 		return (SObject) JSON.deserialize(jsonString, deserializeType);
-	} 
+	}
 
 	/**
 	 * Helper Methods

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
@@ -258,4 +258,21 @@ public class fflib_ApexMocksUtilsTest
 
 		System.assertEquals(isDeleted, acc.IsDeleted);
 	}
+
+	@isTest
+	static void setReadOnlyFields_PolymorphicRelationJoin_FieldSetSuccessfully() {
+
+		Account acc = new Account(Name='TestAccount');
+		Task t = new Task();
+
+		Test.startTest();
+		t = (Task)fflib_ApexMocksUtils.setReadOnlyFields(
+			t,
+			Task.class,
+			new Map<String, Object> {'What' => acc}
+		);
+		Test.stopTest();
+
+		System.assertEquals(acc.Name, t.What.Name);
+	}
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
When trying to mock a SObject with parent record fields from a polymorphic relationship, i can't set these using `fflib_ApexMocksUtils.setReadOnlyFields()`

Example query i want to mock:
```
SELECT Id, Subject, TYPEOF What WHEN Account THEN Id, Name END FROM Task
```

Trying this:
```
Account acc = new Account(Name='TestAccount');
Task t = new Task(
  What = acc
);
```
results in: `Field is not writeable: Task.What`

`fflib_ApexMocksUtils.setReadOnlyFields()` only allows to set readonly fields using a `Map<SObjectField, Object>`, which does not help in this case.


So this PR adds a new overload `setReadOnlyFields(SObject objInstance, Type deserializeType, Map<String, Object> properties)`, which allows me to do this, using strings instead of SObjectField:
```
Task t = (Task)fflib_ApexMocksUtils.setReadOnlyFields(
  new Task(Subject='TestTask'),
  Task.class,
  new Map<String, Object> {'What' => acc}
);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/129)
<!-- Reviewable:end -->
