### PR TITLE
Implement Automatic API Version Management

### DIFF
--- a/.github/workflows/UpgradeApiVersions.yml
+++ b/.github/workflows/UpgradeApiVersions.yml
@@ -1,0 +1,52 @@
+# This is a basic workflow to help you get started with Actions
+
+name: UpgradeApiVersions
+
+# Controls when the workflow will run
+on: 
+  workflow_dispatch:
+    inputs:
+      api-version:
+        description: 'api version in the format XX.X e.g 58.0'
+        required: true
+        type: string
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Bump Version
+        run: |
+          find ./ -type f -exec sed -i -e 's/apple/orange/g' {} \;
+          
+  commit:
+    needs: update
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: EndBug/add-and-commit@v9
+        with:
+          message: 'chore: bump api to v${{inputs.api-version}}'
+          new_branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
+          
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          title: 'Bump API Versions to ${{api-version}}'
+          title: 'Bump API Versions to ${{inputs.api-version}}'
           body: Automatically performed by GitHub actions
           branch: 'devops/bump-api-versions-v${{inputs.api-version}}'

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -1,8 +1,5 @@
-# This is a basic workflow to help you get started with Actions
-
 name: UpgradeApiVersions
 
-# Controls when the workflow will run
 on: 
   workflow_dispatch:
     inputs:
@@ -11,7 +8,6 @@ on:
         required: true
         type: string
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -21,7 +21,7 @@ jobs:
             echo "Processing $file"
             sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{inputs.api-version}}.0</apiVersion>|g" $file
           done
-          sed -i "s|"sourceApiVersion": "*"|"sourceApiVersion": "${{inputs.api-version}}.0"|g" sfdx-project.json
+          sed -i "s|\"sourceApiVersion\": \".*\"|\"sourceApiVersion\": \"58.0\"|g" sfdx-project.json
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - uses: actions/checkout@v3
       - name: Bump Version
         run: |
           file_list=($(find ./sfdx-source -type f -exec grep -lP "<apiVersion>.*</apiVersion>" {} \;))

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           message: 'chore: bump api to v${{inputs.api-version}}'
           new_branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
+      - uses: actions/checkout@v3
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           title: 'Bump API Versions to ${{inputs.api-version}}'
           body: Automatically performed by GitHub actions
           branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
-          base: master

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -25,15 +25,10 @@ jobs:
             echo "Processing $file"
             sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{inputs.api-version}}</apiVersion>|g" $file
           done
-      - name: Create Branch
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: 'chore: bump api to v${{inputs.api-version}}'
-          new_branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
-      - uses: actions/checkout@v3
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           title: 'Bump API Versions to ${{inputs.api-version}}'
           body: Automatically performed by GitHub actions
           branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
+          commit-message: 'chore: bump api to v${{inputs.api-version}}'

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -22,7 +22,7 @@ jobs:
           file_list=($(find ./sfdx-source -type f -exec grep -lP "<apiVersion>.*</apiVersion>" {} \;))
           for file in "${file_list[@]}"; do
             echo "Processing $file"
-            sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{api-version}}</apiVersion>|g" $file
+            sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{inputs.api-version}}</apiVersion>|g" $file
           done
       - name: Create Branch
         uses: EndBug/add-and-commit@v9

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -29,6 +29,6 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           title: 'Bump API Versions to ${{inputs.api-version}}'
-          body: Automatically performed by GitHub actions
+          body: 'Automatically bumped by GitHub Actions '
           branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
           commit-message: 'chore: bump api to v${{inputs.api-version}}'

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -35,3 +35,5 @@ jobs:
         with:
           title: 'Bump API Versions to ${{inputs.api-version}}'
           body: Automatically performed by GitHub actions
+          branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
+          base: master

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -19,7 +19,11 @@ jobs:
     steps:
       - name: Bump Version
         run: |
-          find ./ -type f -exec sed -i -e 's/apple/orange/g' {} \;
+          file_list=($(find ./sfdx-source -type f -exec grep -lP "<apiVersion>.*</apiVersion>" {} \;))
+          for file in "${file_list[@]}"; do
+            echo "Processing $file"
+            sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{api-version}}</apiVersion>|g" $file
+          done
           
   commit:
     needs: update
@@ -30,23 +34,3 @@ jobs:
         with:
           message: 'chore: bump api to v${{inputs.api-version}}'
           new_branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
-          
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          title: 'Bump API Versions to ${{inputs.api-version}}'
+          title: 'Bump API Versions to ${{inputs.api-version}}.0'
           body: 'Automatically bumped by GitHub Actions '
           branch: 'devops/bump-api-versions-v${{inputs.api-version}}.0'
           commit-message: 'chore: bump api to v${{inputs.api-version}}.0'

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -35,4 +35,3 @@ jobs:
         with:
           title: 'Bump API Versions to ${{inputs.api-version}}'
           body: Automatically performed by GitHub actions
-          branch: 'devops/bump-api-versions-v${{inputs.api-version}}'

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -21,6 +21,7 @@ jobs:
             echo "Processing $file"
             sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{inputs.api-version}}.0</apiVersion>|g" $file
           done
+          sed -i "s|"sourceApiVersion": "*"|"sourceApiVersion": "${{inputs.api-version}}.0"|g" sfdx-project.json
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -24,13 +24,14 @@ jobs:
             echo "Processing $file"
             sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{api-version}}</apiVersion>|g" $file
           done
-          
-  commit:
-    needs: update
-    runs-on: ubuntu-latest
-    
-    steps:
-      - uses: EndBug/add-and-commit@v9
+      - name: Create Branch
+        uses: EndBug/add-and-commit@v9
         with:
           message: 'chore: bump api to v${{inputs.api-version}}'
           new_branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: 'Bump API Versions to ${{api-version}}'
+          body: Automatically performed by GitHub actions
+          branch: 'devops/bump-api-versions-v${{inputs.api-version}}'

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       api-version:
-        description: 'api version in the format XX.X e.g 58.0'
+        description: 'api version in the format XX e.g 58'
         required: true
         type: string
 
@@ -19,12 +19,12 @@ jobs:
           file_list=($(find ./sfdx-source -type f -exec grep -lP "<apiVersion>.*</apiVersion>" {} \;))
           for file in "${file_list[@]}"; do
             echo "Processing $file"
-            sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{inputs.api-version}}</apiVersion>|g" $file
+            sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{inputs.api-version}}.0</apiVersion>|g" $file
           done
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           title: 'Bump API Versions to ${{inputs.api-version}}'
           body: 'Automatically bumped by GitHub Actions '
-          branch: 'devops/bump-api-versions-v${{inputs.api-version}}'
-          commit-message: 'chore: bump api to v${{inputs.api-version}}'
+          branch: 'devops/bump-api-versions-v${{inputs.api-version}}.0'
+          commit-message: 'chore: bump api to v${{inputs.api-version}}.0'

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -1,4 +1,4 @@
-name: UpgradeApiVersions
+name: Upgrade API Versions
 
 on: 
   workflow_dispatch:


### PR DESCRIPTION
A continuing headache that we deal with on the AEP projects is managing the upgrade of API versions with each release. In order to eliminate the manual effort associated with this, I have proposed a manual GitHub action which can be ran which will update all API Versions in the project and submit a PR for those changes. As of right now, there is no scheduling or automated runs, but at the minimum this should help reduce the manual effort.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/140)
<!-- Reviewable:end -->
