### PR TITLE
Implement Automatic API Version Management

### DIFF
--- a/.github/workflows/manage.sf.api.versions.yml
+++ b/.github/workflows/manage.sf.api.versions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ClayChipps/manage-sf-api-version@v1.0.0
+      - uses: apex-enterprise-patterns/manage-sf-api-version@v1.0.0
         with:
           api-version: ${{inputs.api-version}}
       - uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/manage.sf.api.versions.yml
+++ b/.github/workflows/manage.sf.api.versions.yml
@@ -1,6 +1,4 @@
-name: Upgrade API Versions
-env:
-  ACTIONS_STEP_DEBUG: true
+name: Manage SF API Versions
 on:
   workflow_dispatch:
     inputs:
@@ -13,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ClayChipps/manage-sf-api-version@v0.1.6
+      - uses: ClayChipps/manage-sf-api-version@v1.0.0
         with:
           api-version: ${{inputs.api-version}}
       - uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -21,7 +21,7 @@ jobs:
             echo "Processing $file"
             sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{inputs.api-version}}.0</apiVersion>|g" $file
           done
-          sed -i "s|\"sourceApiVersion\": \".*\"|\"sourceApiVersion\": \"58.0\"|g" sfdx-project.json
+          sed -i "s|\"sourceApiVersion\": \".*\"|\"sourceApiVersion\": \"${{inputs.api-version}}.0\"|g" sfdx-project.json
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Manage SF API Version
-        uses: ClayChipps/manage-sf-api-version@v0.0.1
+        uses: ClayChipps/manage-sf-api-version@v0.1.1
         with:
           api-version: ${{inputs.api-version}}
       - name: Create Pull Request

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -1,27 +1,20 @@
 name: Upgrade API Versions
-
-on: 
+on:
   workflow_dispatch:
     inputs:
       api-version:
         description: 'api version in the format XX e.g 58'
         required: true
         type: string
-
 jobs:
   update:
     runs-on: ubuntu-latest
-    
     steps:
       - uses: actions/checkout@v3
-      - name: Bump Version
-        run: |
-          file_list=($(find ./sfdx-source -type f -exec grep -lP "<apiVersion>.*</apiVersion>" {} \;))
-          for file in "${file_list[@]}"; do
-            echo "Processing $file"
-            sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{inputs.api-version}}.0</apiVersion>|g" $file
-          done
-          sed -i "s|\"sourceApiVersion\": \".*\"|\"sourceApiVersion\": \"${{inputs.api-version}}.0\"|g" sfdx-project.json
+      - name: Manage SF API Version
+        uses: ctchipps/manage-sf-api-version@v0.0.1
+        with:
+          api-version: ${{inputs.api-version}}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Manage SF API Version
-        uses: ClayChipps/manage-sf-api-version@v0.1.2
+        uses: ClayChipps/manage-sf-api-version@v0.1.3
         with:
           api-version: ${{inputs.api-version}}
       - name: Create Pull Request

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -1,4 +1,6 @@
 name: Upgrade API Versions
+env:
+  ACTIONS_STEP_DEBUG: true
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -1,0 +1,31 @@
+name: Upgrade API Versions
+
+on: 
+  workflow_dispatch:
+    inputs:
+      api-version:
+        description: 'api version in the format XX e.g 58'
+        required: true
+        type: string
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bump Version
+        run: |
+          file_list=($(find ./sfdx-source -type f -exec grep -lP "<apiVersion>.*</apiVersion>" {} \;))
+          for file in "${file_list[@]}"; do
+            echo "Processing $file"
+            sed -i "s|<apiVersion>.*</apiVersion>|<apiVersion>${{inputs.api-version}}.0</apiVersion>|g" $file
+          done
+          sed -i "s|\"sourceApiVersion\": \".*\"|\"sourceApiVersion\": \"58.0\"|g" sfdx-project.json
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: 'Bump API Versions to ${{inputs.api-version}}.0'
+          body: 'Automatically bumped by GitHub Actions '
+          branch: 'devops/bump-api-versions-v${{inputs.api-version}}.0'
+          commit-message: 'chore: bump api to v${{inputs.api-version}}.0'

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ClayChipps/manage-sf-api-version@v0.1.4
+      - uses: ClayChipps/manage-sf-api-version@v0.1.5
         with:
           api-version: ${{inputs.api-version}}
       - uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Manage SF API Version
-        uses: ClayChipps/manage-sf-api-version@v0.1.1
+        uses: ClayChipps/manage-sf-api-version@v0.1.2
         with:
           api-version: ${{inputs.api-version}}
       - name: Create Pull Request

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ClayChipps/manage-sf-api-version@v0.1.3
+      - uses: ClayChipps/manage-sf-api-version@v0.1.4
         with:
           api-version: ${{inputs.api-version}}
       - uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -13,12 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Manage SF API Version
-        uses: ClayChipps/manage-sf-api-version@v0.1.3
+      - uses: ClayChipps/manage-sf-api-version@v0.1.3
         with:
           api-version: ${{inputs.api-version}}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+      - uses: peter-evans/create-pull-request@v5
         with:
           title: 'Bump API Versions to ${{inputs.api-version}}.0'
           body: 'Automatically bumped by GitHub Actions '

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ClayChipps/manage-sf-api-version@v0.1.5
+      - uses: ClayChipps/manage-sf-api-version@v0.1.6
         with:
           api-version: ${{inputs.api-version}}
       - uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/upgrade.api.versions.yml
+++ b/.github/workflows/upgrade.api.versions.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Manage SF API Version
-        uses: ctchipps/manage-sf-api-version@v0.0.1
+        uses: ClayChipps/manage-sf-api-version@v0.0.1
         with:
           api-version: ${{inputs.api-version}}
       - name: Create Pull Request


### PR DESCRIPTION
A continuing headache that we deal with on the AEP projects is managing the upgrade of API versions with each release. In order to eliminate the manual effort associated with this, I have proposed a manual GitHub action which can be ran which will update all API Versions in the project and submit a PR for those changes. As of right now, there is no scheduling or automated runs, but at the minimum this should help reduce the manual effort.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/141)
<!-- Reviewable:end -->
