### PR TITLE
setReadOnlyFields() child record support (see issue #163)

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
@@ -110,13 +110,12 @@ public class fflib_ApexMocksUtils
 	 * values on read-only fields by their name
 	 */
 	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<String, Object> properties) {
+		JSONParser parser = JSON.createParser((JSON.serialize(objInstance)));
+		JSONGenerator combinedOutput = JSON.createGenerator(false);
 
-		Map<String, Object> mergedMap = new Map<String, Object>(objInstance.getPopulatedFieldsAsMap());
-		// Merge the values from the properties map into the fields already set on the object
-		mergedMap.putAll(properties);
-		// Serialize the merged map, and then deserialize it as the desired object type.
-		String jsonString = JSON.serializePretty(mergedMap);
-		return (SObject) JSON.deserialize(jsonString, deserializeType);
+		// parse the source object and inject new fields into the resulting JSON
+		streamTokens(parser, combinedOutput, new InjectFieldsEventHandler(properties) );
+		return JSON.deserialize(combinedOutput.getAsString(), deserializeType);
 	}
 
 	/**
@@ -179,6 +178,29 @@ public class fflib_ApexMocksUtils
 				streamTokens(childrenParser, toStream, null);
 				toStream.writeEndObject();
 				childListIdx++;
+			}
+		}
+	}
+
+	/**
+	 * Monitors stream events for end of object for the current SObject
+	 *   then injects new fields into the stream
+	 */
+	private class InjectFieldsEventHandler implements JSONParserEvents
+	{
+		Map<String, Object> properties;
+
+		public InjectFieldsEventHandler(Map<String, Object> properties) {
+			this.properties = properties;
+		}
+
+		public void nextToken(JSONParser fromStream, Integer depth, JSONGenerator toStream) {
+			// Inject children?
+			JSONToken currentToken = fromStream.getCurrentToken();
+			if(depth == 1 && currentToken == JSONToken.END_OBJECT ) {
+				for(String field : properties.keySet()) {
+					toStream.writeObjectField(field, properties.get(field));
+				}
 			}
 		}
 	}

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
@@ -337,4 +337,47 @@ public class fflib_ApexMocksUtilsTest
 
 		System.Assert.areEqual(acc.Name, t.What.Name);
 	}
+
+	@isTest
+	static void setReadOnlyFields_WithChildren_FieldSetSuccessfully() {
+		// Given
+		Contact cont = new Contact(
+			Id = fflib_IDGenerator.generate(Contact.SObjectType),
+			LastName = 'ContactName'
+		);
+
+		Opportunity opp = new Opportunity(
+			Id = fflib_IDGenerator.generate(Opportunity.SObjectType),
+			Name = 'OpportunityName'
+		);
+
+		Account acc = new Account();
+
+		Id userId = fflib_IDGenerator.generate((new User()).getSObjectType());
+
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
+			List<Account>.class,
+			new List<Account>{ acc },
+			Contact.AccountId,
+			new List<List<Contact>>{ new List<Contact>{cont} }
+		))[0];
+
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
+			List<Account>.class,
+			new List<Account>{ acc },
+			Opportunity.AccountId,
+			new List<List<Opportunity>>{ new List<Opportunity>{opp} }
+		))[0];
+
+		// When
+		Test.startTest();
+		acc = (Account)fflib_ApexMocksUtils.setReadOnlyFields(
+				acc,
+				Account.class,
+				new Map<SObjectField, Object>{Account.CreatedById => userId}
+		);
+		Test.stopTest();
+
+		Assert.areEqual(userId, acc.CreatedById);
+	}
 }


### PR DESCRIPTION
Use JSON parsing logic for makeRelationships() to give setReadOnlyFields() the possibility to handle existing child records on an instance.
This should help with setting up easier builder patterns that don't what to think about what they want to call first when creating mock objects for testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/164)
<!-- Reviewable:end -->
