### PR TITLE
fix: make fflib_MethodCountRecorder fields and methods non-static

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
@@ -10,6 +10,13 @@
 @NamespaceAccessible
 public class fflib_AnyOrder extends fflib_MethodVerifier
 {
+
+	private final fflib_MethodCountRecorder methodCountRecorder;
+
+	public fflib_AnyOrder(fflib_MethodCountRecorder methodCountRecorder) {
+		this.methodCountRecorder = methodCountRecorder;
+	}
+
 	/*
 	 * Verifies a method was invoked the expected number of times, with the expected arguments.
 	 * @param qualifiedMethod The method to be verified.
@@ -22,7 +29,7 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 		fflib_VerificationMode verificationMode)
 	{
 		List<fflib_IMatcher> expectedMatchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
-		List<fflib_MethodArgValues> actualArguments = fflib_MethodCountRecorder.getMethodArgumentsByTypeName().get(qm);
+		List<fflib_MethodArgValues> actualArguments = methodCountRecorder.getMethodArgumentsByTypeName().get(qm);
 
 		Integer methodCount = getMethodCount(expectedArguments, expectedMatchers, actualArguments);
 

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
@@ -52,7 +52,7 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 
 		this.methodCountRecorder = new fflib_MethodCountRecorder();
 		this.verificationMode = new fflib_VerificationMode();
-		this.methodVerifier = new fflib_AnyOrder();
+		this.methodVerifier = new fflib_AnyOrder(methodCountRecorder);
 
 		this.methodReturnValueRecorder = new fflib_MethodReturnValueRecorder();
 
@@ -138,7 +138,7 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	public void verifyMethodCall(fflib_InvocationOnMock mockInvocation)
 	{
 		this.methodVerifier.verifyMethodCall(mockInvocation, verificationMode);
-		this.methodVerifier = new fflib_AnyOrder();
+		this.methodVerifier = new fflib_AnyOrder(methodCountRecorder);
 
 		this.verifying = false;
 	}
@@ -179,6 +179,14 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	public void recordMethod(fflib_InvocationOnMock mockInvocation)
 	{
 		methodCountRecorder.recordMethod(mockInvocation);
+	}
+
+	/**
+	 * Retrieve method calls on mock objects that were recorded, in the order in which they were recorded.
+	 * @return The list of methods called in order.
+	 */
+	public List<fflib_InvocationOnMock> getOrderedMethodCalls() {
+		return methodCountRecorder.getOrderedMethodCalls();
 	}
 
 	/**
@@ -296,6 +304,15 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 		}
 
 		return null;
+	}
+
+	/**
+	 * Creates an instance of {@link fflib_InOrder} linked to this ApexMocks instance.
+	 * @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
+	 * @return an {@link fflib_InOrder} instance
+	 */
+	public fflib_InOrder inOrder(List<Object> unorderedMockInstances) {
+		return new fflib_InOrder(this, unorderedMockInstances);
 	}
 
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
@@ -25,6 +25,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	 * Construct the InOrder instance.
 	 * @param mocks The apex mock object instance.
 	 * @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
+	 * @deprecated Obtain an instance by calling {@link fflib_ApexMocks#inOrder(List&lt;Object&gt;)}
 	 */
 	@NamespaceAccessible
 	public fflib_InOrder(fflib_ApexMocks mocks, List<Object> unorderedMockInstances)
@@ -92,7 +93,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		if(hasNextInteraction(unorderedMockInstances, idxMethodCall))
 		{
 			fflib_InvocationOnMock invocation =
-				fflib_MethodCountRecorder.getOrderedMethodCalls().get(idxMethodCall -1);
+				mocks.getOrderedMethodCalls().get(idxMethodCall -1);
 
 			throw new fflib_ApexMocks.ApexMocksException(
 				'No more Interactions were expected after the ' + invocation.getMethod() +' method.');
@@ -128,7 +129,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	{
 		String inOrder = ' in order';
 		List<fflib_IMatcher> matchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
-		List<fflib_InvocationOnMock> actualInvocations = fflib_MethodCountRecorder.getOrderedMethodCalls();
+		List<fflib_InvocationOnMock> actualInvocations = mocks.getOrderedMethodCalls();
 		List<fflib_MethodArgValues> actualArguments = new List<fflib_MethodArgValues>();
 		for (fflib_InvocationOnMock invocation : actualInvocations)
 		{
@@ -208,9 +209,9 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	{
 		Integer interactionsCouter = 0;
 
-		for (Integer i = idxMethodCall, len = fflib_MethodCountRecorder.getOrderedMethodCalls().size(); i<len; i++)
+		for (Integer i = idxMethodCall, len = mocks.getOrderedMethodCalls().size(); i<len; i++)
 		{
-			fflib_InvocationOnMock invocation = fflib_MethodCountRecorder.getOrderedMethodCalls().get(i);
+			fflib_InvocationOnMock invocation = mocks.getOrderedMethodCalls().get(i);
 			for (Object mockInstance : unorderedMockInstances)
 			{
 				if (invocation.getMock() === mockInstance
@@ -233,9 +234,9 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		Integer lastInteracionIndex = 0;
 
 		//going all through the orderedMethodCalls to find all the interaction of the method
-		for (Integer i = idxMethodCall, len = fflib_MethodCountRecorder.getOrderedMethodCalls().size(); i<len; i++)
+		for (Integer i = idxMethodCall, len = mocks.getOrderedMethodCalls().size(); i<len; i++)
 		{
-			fflib_InvocationOnMock invocation = fflib_MethodCountRecorder.getOrderedMethodCalls().get(i);
+			fflib_InvocationOnMock invocation = mocks.getOrderedMethodCalls().get(i);
 			for (Object mockInstance : unorderedMockInstances)
 			{
 				if (invocation.getMock() === mockInstance
@@ -287,7 +288,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	private fflib_InvocationOnMock getNextMethodCall(Boolean updateIdxMethodCall)
 	{
 		Integer idx = 0;
-		for (fflib_InvocationOnMock invocation : fflib_MethodCountRecorder.getOrderedMethodCalls())
+		for (fflib_InvocationOnMock invocation : mocks.getOrderedMethodCalls())
 		{
 			if (idx == idxMethodCall)
 			{
@@ -330,7 +331,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	{
 		Integer idx = 0;
 
-		for (fflib_InvocationOnMock methodCall : fflib_MethodCountRecorder.getOrderedMethodCalls())
+		for (fflib_InvocationOnMock methodCall : mocks.getOrderedMethodCalls())
 		{
 			if (isForMockInstance(methodCall))
 			{

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
@@ -16,17 +16,17 @@ public with sharing class fflib_MethodCountRecorder
 	 *
 	 * Object: map of count by method call argument.
 	 */
-	private static Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> methodArgumentsByTypeName =
+	private Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> methodArgumentsByTypeName =
 		new Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>>();
 
-	private static List<fflib_InvocationOnMock> orderedMethodCalls =
+	private List<fflib_InvocationOnMock> orderedMethodCalls =
 		new List<fflib_InvocationOnMock>();
 
 	/**
 	 * Getter for the list of the methods ordered calls.
 	 * @return The list of methods called in order.
 	 */
-	public static List<fflib_InvocationOnMock> getOrderedMethodCalls()
+	public List<fflib_InvocationOnMock> getOrderedMethodCalls()
 	{
 		return orderedMethodCalls;
 	}
@@ -35,7 +35,7 @@ public with sharing class fflib_MethodCountRecorder
 	 * Getter for the map of the method's calls with the related arguments.
 	 * @return The map of methods called with the arguments.
 	 */
-	public static Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getMethodArgumentsByTypeName()
+	public Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getMethodArgumentsByTypeName()
 	{
 		return methodArgumentsByTypeName;
 	}

--- a/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
@@ -12,7 +12,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -50,7 +50,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -74,7 +74,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -109,7 +109,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -144,7 +144,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-0');
@@ -163,7 +163,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-0');
@@ -200,7 +200,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 
@@ -225,7 +225,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -247,7 +247,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -286,7 +286,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -322,7 +322,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -342,7 +342,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -362,7 +362,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -400,7 +400,7 @@ private class fflib_InOrderTest
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList thirdMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 
-		fflib_InOrder inOrder = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock, secondMock });
+		fflib_InOrder inOrder = MY_MOCKS.inOrder(new List<Object>{ firstMock, secondMock });
 
 		// When
 		firstMock.add('1-1');
@@ -435,8 +435,8 @@ private class fflib_InOrderTest
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList thirdMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
-		fflib_InOrder inOrder2 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock, secondMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
+		fflib_InOrder inOrder2 = MY_MOCKS.inOrder(new List<Object>{ firstMock, secondMock });
 
 		// When
 		firstMock.add('1-1');
@@ -474,7 +474,7 @@ private class fflib_InOrderTest
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -507,7 +507,7 @@ private class fflib_InOrderTest
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		String customErrorMesage = 'Some custom error message';
 
@@ -542,7 +542,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -573,7 +573,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -605,7 +605,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -628,7 +628,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -651,7 +651,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -690,7 +690,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -729,7 +729,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -754,7 +754,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1', '1-1', '1-1', '1-1');
@@ -781,7 +781,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1', '1-1', '1-1', '1-1');
@@ -809,8 +809,8 @@ private class fflib_InOrderTest
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
-		fflib_InOrder inOrder2 = new fflib_InOrder(MY_MOCKS, new List<Object>{ secondMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
+		fflib_InOrder inOrder2 = MY_MOCKS.inOrder(new List<Object>{ secondMock });
 
 		// When
 		firstMock.add('1-1');
@@ -835,7 +835,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -860,7 +860,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -886,7 +886,7 @@ private class fflib_InOrderTest
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		secondMock.add('1-2');
@@ -898,7 +898,7 @@ private class fflib_InOrderTest
 	static void thatStrictVerificationCanBePerformed()
 	{
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -916,7 +916,7 @@ private class fflib_InOrderTest
 	static void thatMixedVerificationDoNotInterfierWithOtherImplementationChecking()
 	{
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -939,7 +939,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1'); //consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
@@ -962,7 +962,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1'); //consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
@@ -985,7 +985,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1'); //consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
@@ -1023,7 +1023,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1'); //consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
@@ -1066,7 +1066,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1088,7 +1088,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1103,7 +1103,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1120,7 +1120,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1152,7 +1152,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1189,7 +1189,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1211,7 +1211,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1249,7 +1249,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1287,7 +1287,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1313,7 +1313,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1340,7 +1340,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1372,7 +1372,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1401,7 +1401,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1441,7 +1441,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1467,7 +1467,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1507,7 +1507,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1529,7 +1529,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1567,7 +1567,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1605,7 +1605,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1629,7 +1629,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1669,7 +1669,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1695,7 +1695,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1721,7 +1721,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
 		firstMock.add('1-1');
@@ -1761,7 +1761,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
 		firstMock.get2(1, '1-1');
@@ -1782,7 +1782,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
 		firstMock.get2(1, '1-1');
@@ -1808,7 +1808,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
 		firstMock.get2(1, '1-1');


### PR DESCRIPTION
This prevents loss of recorded invocations after an asynchronous flow runs as part of a unit test.

This ZIP file contains a small SFDX project that demonstrates the problem with the current ApexMocks code.
[platform-event-mock-issue.zip](https://github.com/user-attachments/files/26098553/platform-event-mock-issue.zip)

The proposed change would save the recorded method method invocations in a non-static variable, which Salesforce _does_ preserve correctly when an asynchronous flow runs as part of a unit test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/166)
<!-- Reviewable:end -->
