### PR TITLE
setReadOnlyFields() child record support (supersedes #164)

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
@@ -199,11 +199,17 @@ public class fflib_ApexMocksUtils
 		}
 
 		public void nextToken(JSONParser fromStream, Integer depth, JSONGenerator toStream) {
-			// Inject children?
+			// Inject the additional fields when the current SObject closes
 			JSONToken currentToken = fromStream.getCurrentToken();
 			if(depth == 1 && currentToken == JSONToken.END_OBJECT ) {
 				for(String field : properties.keySet()) {
-					toStream.writeObjectField(field, properties.get(field));
+					Object value = properties.get(field);
+					// writeObjectField throws on null, so write an explicit null field instead
+					if(value == null) {
+						toStream.writeNullField(field);
+					} else {
+						toStream.writeObjectField(field, value);
+					}
 				}
 			}
 		}

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
@@ -114,13 +114,12 @@ public class fflib_ApexMocksUtils
 	 */
 	@NamespaceAccessible
 	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<String, Object> properties) {
+		JSONParser parser = JSON.createParser((JSON.serialize(objInstance)));
+		JSONGenerator combinedOutput = JSON.createGenerator(false);
 
-		Map<String, Object> mergedMap = new Map<String, Object>(objInstance.getPopulatedFieldsAsMap());
-		// Merge the values from the properties map into the fields already set on the object
-		mergedMap.putAll(properties);
-		// Serialize the merged map, and then deserialize it as the desired object type.
-		String jsonString = JSON.serializePretty(mergedMap);
-		return (SObject) JSON.deserialize(jsonString, deserializeType);
+		// parse the source object and inject new fields into the resulting JSON
+		streamTokens(parser, combinedOutput, new InjectFieldsEventHandler(properties) );
+		return JSON.deserialize(combinedOutput.getAsString(), deserializeType);
 	}
 
 	/**
@@ -183,6 +182,29 @@ public class fflib_ApexMocksUtils
 				streamTokens(childrenParser, toStream, null);
 				toStream.writeEndObject();
 				childListIdx++;
+			}
+		}
+	}
+
+	/**
+	 * Monitors stream events for end of object for the current SObject
+	 *   then injects new fields into the stream
+	 */
+	private class InjectFieldsEventHandler implements JSONParserEvents
+	{
+		Map<String, Object> properties;
+
+		public InjectFieldsEventHandler(Map<String, Object> properties) {
+			this.properties = properties;
+		}
+
+		public void nextToken(JSONParser fromStream, Integer depth, JSONGenerator toStream) {
+			// Inject children?
+			JSONToken currentToken = fromStream.getCurrentToken();
+			if(depth == 1 && currentToken == JSONToken.END_OBJECT ) {
+				for(String field : properties.keySet()) {
+					toStream.writeObjectField(field, properties.get(field));
+				}
 			}
 		}
 	}

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
@@ -337,4 +337,47 @@ public class fflib_ApexMocksUtilsTest
 
 		System.Assert.areEqual(acc.Name, t.What.Name);
 	}
+
+	@isTest
+	static void setReadOnlyFields_WithChildren_FieldSetSuccessfully() {
+		// Given
+		Contact cont = new Contact(
+			Id = fflib_IDGenerator.generate(Contact.SObjectType),
+			LastName = 'ContactName'
+		);
+
+		Opportunity opp = new Opportunity(
+			Id = fflib_IDGenerator.generate(Opportunity.SObjectType),
+			Name = 'OpportunityName'
+		);
+
+		Account acc = new Account();
+
+		Id userId = fflib_IDGenerator.generate((new User()).getSObjectType());
+
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
+			List<Account>.class,
+			new List<Account>{ acc },
+			Contact.AccountId,
+			new List<List<Contact>>{ new List<Contact>{cont} }
+		))[0];
+
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
+			List<Account>.class,
+			new List<Account>{ acc },
+			Opportunity.AccountId,
+			new List<List<Opportunity>>{ new List<Opportunity>{opp} }
+		))[0];
+
+		// When
+		Test.startTest();
+		acc = (Account)fflib_ApexMocksUtils.setReadOnlyFields(
+				acc,
+				Account.class,
+				new Map<SObjectField, Object>{Account.CreatedById => userId}
+		);
+		Test.stopTest();
+
+		Assert.areEqual(userId, acc.CreatedById);
+	}
 }

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
@@ -380,4 +380,251 @@ public class fflib_ApexMocksUtilsTest
 
 		Assert.areEqual(userId, acc.CreatedById);
 	}
+
+	@isTest
+	static void setReadOnlyFields_WithChildren_PreservesChildRelationships()
+	{
+		// Given
+		Contact cont = new Contact(
+			Id = fflib_IDGenerator.generate(Contact.SObjectType),
+			LastName = 'ContactName'
+		);
+
+		Opportunity opp = new Opportunity(
+			Id = fflib_IDGenerator.generate(Opportunity.SObjectType),
+			Name = 'OpportunityName'
+		);
+
+		Account acc = new Account();
+
+		Id userId = fflib_IDGenerator.generate((new User()).getSObjectType());
+
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
+			List<Account>.class,
+			new List<Account>{ acc },
+			Contact.AccountId,
+			new List<List<Contact>>{ new List<Contact>{ cont } }
+		))[0];
+
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
+			List<Account>.class,
+			new List<Account>{ acc },
+			Opportunity.AccountId,
+			new List<List<Opportunity>>{ new List<Opportunity>{ opp } }
+		))[0];
+
+		// When
+		Test.startTest();
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
+			acc,
+			Account.class,
+			new Map<SObjectField, Object>{ Account.CreatedById => userId }
+		);
+		Test.stopTest();
+
+		// Then
+		System.Assert.areEqual(userId, acc.CreatedById);
+		System.Assert.areNotEqual(null, acc.Contacts);
+		System.Assert.areEqual(1, acc.Contacts.size());
+		System.Assert.areEqual(cont.Id, acc.Contacts[0].Id);
+		System.Assert.areEqual(cont.LastName, acc.Contacts[0].LastName);
+		System.Assert.areNotEqual(null, acc.Opportunities);
+		System.Assert.areEqual(1, acc.Opportunities.size());
+		System.Assert.areEqual(opp.Id, acc.Opportunities[0].Id);
+		System.Assert.areEqual(opp.Name, acc.Opportunities[0].Name);
+	}
+
+	@isTest
+	static void setReadOnlyFields_WithChildren_PreservesWritableFields()
+	{
+		// Given - Name and NumberOfEmployees are updateable=true; CreatedById is updateable=false (the injected field)
+		Contact cont = new Contact(
+			Id = fflib_IDGenerator.generate(Contact.SObjectType),
+			LastName = 'ContactName'
+		);
+
+		Account acc = new Account(
+			Id = fflib_IDGenerator.generate(Account.SObjectType),
+			Name = 'AccName',
+			NumberOfEmployees = 7
+		);
+
+		Id userId = fflib_IDGenerator.generate((new User()).getSObjectType());
+
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
+			List<Account>.class,
+			new List<Account>{ acc },
+			Contact.AccountId,
+			new List<List<Contact>>{ new List<Contact>{ cont } }
+		))[0];
+
+		// When
+		Test.startTest();
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
+			acc,
+			Account.class,
+			new Map<SObjectField, Object>{ Account.CreatedById => userId }
+		);
+		Test.stopTest();
+
+		// Then - writable fields (updateable=true) must survive the round-trip
+		System.Assert.areEqual('AccName', acc.Name);
+		System.Assert.areEqual(7, acc.NumberOfEmployees);
+		System.Assert.areEqual(userId, acc.CreatedById);
+		System.Assert.areEqual(1, acc.Contacts.size());
+		System.Assert.areEqual(cont.LastName, acc.Contacts[0].LastName);
+	}
+
+	@isTest
+	static void setReadOnlyFields_OverwritesExistingNonUpdateableField()
+	{
+		// Given - CreatedById is updateable=false; second call should replace the injected value
+		Account acc = new Account();
+		Id firstUserId = fflib_IDGenerator.generate((new User()).getSObjectType());
+		Id secondUserId = fflib_IDGenerator.generate((new User()).getSObjectType());
+
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
+			acc,
+			Account.class,
+			new Map<SObjectField, Object>{ Account.CreatedById => firstUserId }
+		);
+
+		// When - field already present in serialized JSON; properties map should overwrite it
+		Test.startTest();
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
+			acc,
+			Account.class,
+			new Map<SObjectField, Object>{ Account.CreatedById => secondUserId }
+		);
+		Test.stopTest();
+
+		// Then
+		System.Assert.areEqual(secondUserId, acc.CreatedById);
+	}
+
+	@isTest
+	static void setReadOnlyFields_EmptyProperties_PreservesRecord()
+	{
+		// Given
+		Contact cont = new Contact(
+			Id = fflib_IDGenerator.generate(Contact.SObjectType),
+			LastName = 'ContactName'
+		);
+
+		Account acc = new Account(
+			Id = fflib_IDGenerator.generate(Account.SObjectType),
+			Name = 'AccName',
+			NumberOfEmployees = 7
+		);
+
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
+			List<Account>.class,
+			new List<Account>{ acc },
+			Contact.AccountId,
+			new List<List<Contact>>{ new List<Contact>{ cont } }
+		))[0];
+
+		// When
+		Test.startTest();
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
+			acc,
+			Account.class,
+			new Map<String, Object>()
+		);
+		Test.stopTest();
+
+		// Then
+		System.Assert.areEqual('AccName', acc.Name);
+		System.Assert.areEqual(7, acc.NumberOfEmployees);
+		System.Assert.areEqual(1, acc.Contacts.size());
+		System.Assert.areEqual(cont.LastName, acc.Contacts[0].LastName);
+	}
+
+	@isTest
+	static void setReadOnlyFields_WithChildren_NonUpdateableNumericFieldSetSuccessfully()
+	{
+		// Given - mirrors issue #163: inject a non-updateable numeric field (ExpectedRevenue: updateable=false, type=currency)
+		// on a parent that already has children via makeRelationship
+		OpportunityLineItem oli = new OpportunityLineItem(
+			Id = fflib_IDGenerator.generate(OpportunityLineItem.SObjectType),
+			UnitPrice = 10,
+			Quantity = 1
+		);
+
+		Opportunity opp = new Opportunity(
+			Id = fflib_IDGenerator.generate(Opportunity.SObjectType),
+			Name = 'OpportunityName'
+		);
+
+		Decimal expectedRevenue = 4200;
+
+		opp = ((List<Opportunity>) fflib_ApexMocksUtils.makeRelationship(
+			List<Opportunity>.class,
+			new List<Opportunity>{ opp },
+			OpportunityLineItem.OpportunityId,
+			new List<List<OpportunityLineItem>>{ new List<OpportunityLineItem>{ oli } }
+		))[0];
+
+		// When
+		Test.startTest();
+		opp = (Opportunity) fflib_ApexMocksUtils.setReadOnlyFields(
+			opp,
+			Opportunity.class,
+			new Map<SObjectField, Object>{ Opportunity.ExpectedRevenue => expectedRevenue }
+		);
+		Test.stopTest();
+
+		// Then
+		System.Assert.areEqual(expectedRevenue, opp.ExpectedRevenue);
+		System.Assert.areEqual('OpportunityName', opp.Name);
+		System.Assert.areEqual(1, opp.OpportunityLineItems.size());
+		System.Assert.areEqual(oli.Id, opp.OpportunityLineItems[0].Id);
+	}
+
+	@isTest
+	static void setReadOnlyFields_MultipleProperties_AllFieldsSet()
+	{
+		// Given
+		Account acc = new Account();
+		Id userId = fflib_IDGenerator.generate((new User()).getSObjectType());
+		DateTime lastRefDate = DateTime.newInstanceGmt(2020, 1, 7, 23, 30, 0);
+
+		// When
+		Test.startTest();
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
+			acc,
+			Account.class,
+			new Map<SObjectField, Object>{
+				Account.CreatedById => userId,
+				Account.LastReferencedDate => lastRefDate,
+				Account.IsDeleted => true
+			}
+		);
+		Test.stopTest();
+
+		// Then
+		System.Assert.areEqual(userId, acc.CreatedById);
+		System.Assert.areEqual(lastRefDate, acc.LastReferencedDate);
+		System.Assert.areEqual(true, acc.IsDeleted);
+	}
+
+	@isTest
+	static void setReadOnlyFields_NullPropertyValue_FieldSetToNull()
+	{
+		// Given - LastReferencedDate is updateable=false; null must round-trip via writeNullField
+		Account acc = new Account(Name = 'AccName');
+
+		// When
+		Test.startTest();
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
+			acc,
+			Account.class,
+			new Map<SObjectField, Object>{ Account.LastReferencedDate => null }
+		);
+		Test.stopTest();
+
+		// Then
+		System.Assert.areEqual(null, acc.LastReferencedDate);
+		System.Assert.areEqual('AccName', acc.Name);
+	}
 }


### PR DESCRIPTION
## Summary

Supersedes #164 (closes #164) and addresses #163.

Reimplements `setReadOnlyFields()` using the same JSON streaming approach as `makeRelationship()`, so existing child records on an SObject are preserved when injecting non-updateable fields. This avoids the `JSONException` that occurred when merging via `getPopulatedFieldsAsMap()` + serialize/deserialize.

This branch is rebased on current `master` and includes additional fixes and tests not present on the original PR branch:

- **Null injection fix:** the streaming implementation called `writeObjectField(field, null)`, which throws `NullPointerException`. Uses `writeNullField(field)` instead to match pre-change behavior.
- **Regression tests:** expanded `fflib_ApexMocksUtilsTest` coverage for child relationship preservation, writable field preservation, multi-field injection, empty properties, non-updateable numeric fields, and explicit null values.

## Changes

- `fflib_ApexMocksUtils.cls` — `InjectFieldsEventHandler` streams field injection at `depth == 1` on `END_OBJECT`
- `fflib_ApexMocksUtilsTest.cls` — original child-record test from #164 plus seven additional regression tests

## Test plan

- [x] `fflib_ApexMocksUtilsTest` — 18/18 passing
- [x] Full org `RunLocalTests` — 480/480 passing
- [x] `fflib_ApexMocksUtils` at 100% coverage

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/169)
<!-- Reviewable:end -->
