### PR TITLE
fflib_MethodCountRecorder async fix with backward-compatible static API (supersedes #166)

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
@@ -10,6 +10,13 @@
 @NamespaceAccessible
 public class fflib_AnyOrder extends fflib_MethodVerifier
 {
+
+	private final fflib_MethodCountRecorder methodCountRecorder;
+
+	public fflib_AnyOrder(fflib_MethodCountRecorder methodCountRecorder) {
+		this.methodCountRecorder = methodCountRecorder;
+	}
+
 	/*
 	 * Verifies a method was invoked the expected number of times, with the expected arguments.
 	 * @param qualifiedMethod The method to be verified.
@@ -22,7 +29,7 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 		fflib_VerificationMode verificationMode)
 	{
 		List<fflib_IMatcher> expectedMatchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
-		List<fflib_MethodArgValues> actualArguments = fflib_MethodCountRecorder.getMethodArgumentsByTypeName().get(qm);
+		List<fflib_MethodArgValues> actualArguments = methodCountRecorder.getMethodArgumentsByTypeName().get(qm);
 
 		Integer methodCount = getMethodCount(expectedArguments, expectedMatchers, actualArguments);
 

--- a/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
@@ -29,7 +29,7 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 		fflib_VerificationMode verificationMode)
 	{
 		List<fflib_IMatcher> expectedMatchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
-		List<fflib_MethodArgValues> actualArguments = methodCountRecorder.getMethodArgumentsByTypeName().get(qm);
+		List<fflib_MethodArgValues> actualArguments = methodCountRecorder.getInstanceMethodArgumentsByTypeName().get(qm);
 
 		Integer methodCount = getMethodCount(expectedArguments, expectedMatchers, actualArguments);
 

--- a/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
@@ -13,6 +13,15 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 
 	private final fflib_MethodCountRecorder methodCountRecorder;
 
+	/**
+	 * Retained for backward compatibility with the published API. Verifies against
+	 * the globally shared (static) recorder state.
+	 * @deprecated Use {@link #fflib_AnyOrder(fflib_MethodCountRecorder)} instead.
+	 */
+	public fflib_AnyOrder() {
+		this.methodCountRecorder = null;
+	}
+
 	public fflib_AnyOrder(fflib_MethodCountRecorder methodCountRecorder) {
 		this.methodCountRecorder = methodCountRecorder;
 	}
@@ -29,7 +38,11 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 		fflib_VerificationMode verificationMode)
 	{
 		List<fflib_IMatcher> expectedMatchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
-		List<fflib_MethodArgValues> actualArguments = methodCountRecorder.getInstanceMethodArgumentsByTypeName().get(qm);
+		Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> argumentsByTypeName =
+			(methodCountRecorder != null)
+				? methodCountRecorder.getInstanceMethodArgumentsByTypeName()
+				: fflib_MethodCountRecorder.getMethodArgumentsByTypeName();
+		List<fflib_MethodArgValues> actualArguments = argumentsByTypeName.get(qm);
 
 		Integer methodCount = getMethodCount(expectedArguments, expectedMatchers, actualArguments);
 

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
@@ -52,7 +52,7 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 
 		this.methodCountRecorder = new fflib_MethodCountRecorder();
 		this.verificationMode = new fflib_VerificationMode();
-		this.methodVerifier = new fflib_AnyOrder();
+		this.methodVerifier = new fflib_AnyOrder(methodCountRecorder);
 
 		this.methodReturnValueRecorder = new fflib_MethodReturnValueRecorder();
 
@@ -138,7 +138,7 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	public void verifyMethodCall(fflib_InvocationOnMock mockInvocation)
 	{
 		this.methodVerifier.verifyMethodCall(mockInvocation, verificationMode);
-		this.methodVerifier = new fflib_AnyOrder();
+		this.methodVerifier = new fflib_AnyOrder(methodCountRecorder);
 
 		this.verifying = false;
 	}
@@ -179,6 +179,14 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	public void recordMethod(fflib_InvocationOnMock mockInvocation)
 	{
 		methodCountRecorder.recordMethod(mockInvocation);
+	}
+
+	/**
+	 * Retrieve method calls on mock objects that were recorded, in the order in which they were recorded.
+	 * @return The list of methods called in order.
+	 */
+	public List<fflib_InvocationOnMock> getOrderedMethodCalls() {
+		return methodCountRecorder.getOrderedMethodCalls();
 	}
 
 	/**
@@ -296,6 +304,15 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 		}
 
 		return null;
+	}
+
+	/**
+	 * Creates an instance of {@link fflib_InOrder} linked to this ApexMocks instance.
+	 * @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
+	 * @return an {@link fflib_InOrder} instance
+	 */
+	public fflib_InOrder inOrder(List<Object> unorderedMockInstances) {
+		return new fflib_InOrder(this, unorderedMockInstances);
 	}
 
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
@@ -186,7 +186,7 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	 * @return The list of methods called in order.
 	 */
 	public List<fflib_InvocationOnMock> getOrderedMethodCalls() {
-		return methodCountRecorder.getOrderedMethodCalls();
+		return methodCountRecorder.getInstanceOrderedMethodCalls();
 	}
 
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
@@ -25,6 +25,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	 * Construct the InOrder instance.
 	 * @param mocks The apex mock object instance.
 	 * @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
+	 * @deprecated Obtain an instance by calling {@link fflib_ApexMocks#inOrder(List&lt;Object&gt;)}
 	 */
 	@NamespaceAccessible
 	public fflib_InOrder(fflib_ApexMocks mocks, List<Object> unorderedMockInstances)
@@ -92,7 +93,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		if(hasNextInteraction(unorderedMockInstances, idxMethodCall))
 		{
 			fflib_InvocationOnMock invocation =
-				fflib_MethodCountRecorder.getOrderedMethodCalls().get(idxMethodCall -1);
+				mocks.getOrderedMethodCalls().get(idxMethodCall -1);
 
 			throw new fflib_ApexMocks.ApexMocksException(
 				'No more Interactions were expected after the ' + invocation.getMethod() +' method.');
@@ -128,7 +129,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	{
 		String inOrder = ' in order';
 		List<fflib_IMatcher> matchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
-		List<fflib_InvocationOnMock> actualInvocations = fflib_MethodCountRecorder.getOrderedMethodCalls();
+		List<fflib_InvocationOnMock> actualInvocations = mocks.getOrderedMethodCalls();
 		List<fflib_MethodArgValues> actualArguments = new List<fflib_MethodArgValues>();
 		for (fflib_InvocationOnMock invocation : actualInvocations)
 		{
@@ -208,9 +209,9 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	{
 		Integer interactionsCouter = 0;
 
-		for (Integer i = idxMethodCall, len = fflib_MethodCountRecorder.getOrderedMethodCalls().size(); i<len; i++)
+		for (Integer i = idxMethodCall, len = mocks.getOrderedMethodCalls().size(); i<len; i++)
 		{
-			fflib_InvocationOnMock invocation = fflib_MethodCountRecorder.getOrderedMethodCalls().get(i);
+			fflib_InvocationOnMock invocation = mocks.getOrderedMethodCalls().get(i);
 			for (Object mockInstance : unorderedMockInstances)
 			{
 				if (invocation.getMock() === mockInstance
@@ -233,9 +234,9 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		Integer lastInteracionIndex = 0;
 
 		//going all through the orderedMethodCalls to find all the interaction of the method
-		for (Integer i = idxMethodCall, len = fflib_MethodCountRecorder.getOrderedMethodCalls().size(); i<len; i++)
+		for (Integer i = idxMethodCall, len = mocks.getOrderedMethodCalls().size(); i<len; i++)
 		{
-			fflib_InvocationOnMock invocation = fflib_MethodCountRecorder.getOrderedMethodCalls().get(i);
+			fflib_InvocationOnMock invocation = mocks.getOrderedMethodCalls().get(i);
 			for (Object mockInstance : unorderedMockInstances)
 			{
 				if (invocation.getMock() === mockInstance
@@ -287,7 +288,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	private fflib_InvocationOnMock getNextMethodCall(Boolean updateIdxMethodCall)
 	{
 		Integer idx = 0;
-		for (fflib_InvocationOnMock invocation : fflib_MethodCountRecorder.getOrderedMethodCalls())
+		for (fflib_InvocationOnMock invocation : mocks.getOrderedMethodCalls())
 		{
 			if (idx == idxMethodCall)
 			{
@@ -330,7 +331,7 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	{
 		Integer idx = 0;
 
-		for (fflib_InvocationOnMock methodCall : fflib_MethodCountRecorder.getOrderedMethodCalls())
+		for (fflib_InvocationOnMock methodCall : mocks.getOrderedMethodCalls())
 		{
 			if (isForMockInstance(methodCall))
 			{

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
@@ -16,17 +16,17 @@ public with sharing class fflib_MethodCountRecorder
 	 *
 	 * Object: map of count by method call argument.
 	 */
-	private static Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> methodArgumentsByTypeName =
+	private Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> methodArgumentsByTypeName =
 		new Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>>();
 
-	private static List<fflib_InvocationOnMock> orderedMethodCalls =
+	private List<fflib_InvocationOnMock> orderedMethodCalls =
 		new List<fflib_InvocationOnMock>();
 
 	/**
 	 * Getter for the list of the methods ordered calls.
 	 * @return The list of methods called in order.
 	 */
-	public static List<fflib_InvocationOnMock> getOrderedMethodCalls()
+	public List<fflib_InvocationOnMock> getOrderedMethodCalls()
 	{
 		return orderedMethodCalls;
 	}
@@ -35,7 +35,7 @@ public with sharing class fflib_MethodCountRecorder
 	 * Getter for the map of the method's calls with the related arguments.
 	 * @return The map of methods called with the arguments.
 	 */
-	public static Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getMethodArgumentsByTypeName()
+	public Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getMethodArgumentsByTypeName()
 	{
 		return methodArgumentsByTypeName;
 	}

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
@@ -16,17 +16,19 @@ public with sharing class fflib_MethodCountRecorder
 	 *
 	 * Object: map of count by method call argument.
 	 */
-	private Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> methodArgumentsByTypeName =
+	private final Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> methodArgumentsByTypeName =
 		new Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>>();
 
-	private List<fflib_InvocationOnMock> orderedMethodCalls =
+	private final List<fflib_InvocationOnMock> orderedMethodCalls =
 		new List<fflib_InvocationOnMock>();
+
+	private static final fflib_MethodCountRecorder STATIC_RECORDER = new fflib_MethodCountRecorder();
 
 	/**
 	 * Getter for the list of the methods ordered calls.
 	 * @return The list of methods called in order.
 	 */
-	public List<fflib_InvocationOnMock> getOrderedMethodCalls()
+	public List<fflib_InvocationOnMock> getInstanceOrderedMethodCalls()
 	{
 		return orderedMethodCalls;
 	}
@@ -35,9 +37,29 @@ public with sharing class fflib_MethodCountRecorder
 	 * Getter for the map of the method's calls with the related arguments.
 	 * @return The map of methods called with the arguments.
 	 */
-	public Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getMethodArgumentsByTypeName()
+	public Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getInstanceMethodArgumentsByTypeName()
 	{
 		return methodArgumentsByTypeName;
+	}
+
+	/**
+	 * Getter for the list of the methods ordered calls.
+	 * @return The list of methods called in order.
+	 * @deprecated Use {@link #getInstanceOrderedMethodCalls()} instead.
+	 */
+	public static List<fflib_InvocationOnMock> getOrderedMethodCalls()
+	{
+		return STATIC_RECORDER.getInstanceOrderedMethodCalls();
+	}
+
+	/**
+	 * Getter for the map of the method's calls with the related arguments.
+	 * @return The map of methods called with the arguments.
+	 * @deprecated Use {@link #getInstanceMethodArgumentsByTypeName()} instead.
+	 */
+	public static Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getMethodArgumentsByTypeName()
+	{
+		return STATIC_RECORDER.getInstanceMethodArgumentsByTypeName();
 	}
 
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
@@ -68,6 +68,21 @@ public with sharing class fflib_MethodCountRecorder
 	 */
 	public void recordMethod(fflib_InvocationOnMock invocation)
 	{
+		// Primary, async-safe recording lives on this instance (held by the owning
+		// fflib_ApexMocks), so it survives Platform Event triggered async flows.
+		record(invocation);
+
+		// Also mirror into the static singleton so the deprecated static getters
+		// retain their historical (globally shared) behaviour for callers that
+		// still rely on the published static API.
+		if (this != STATIC_RECORDER)
+		{
+			STATIC_RECORDER.record(invocation);
+		}
+	}
+
+	private void record(fflib_InvocationOnMock invocation)
+	{
 		List<fflib_MethodArgValues> methodArgs =
 			methodArgumentsByTypeName.get(invocation.getMethod());
 

--- a/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
@@ -12,7 +12,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -50,7 +50,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -74,7 +74,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -109,7 +109,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -144,7 +144,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-0');
@@ -163,7 +163,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-0');
@@ -200,7 +200,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 
@@ -225,7 +225,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -247,7 +247,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -286,7 +286,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -322,7 +322,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -342,7 +342,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -362,7 +362,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -400,7 +400,7 @@ private class fflib_InOrderTest
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList thirdMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 
-		fflib_InOrder inOrder = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock, secondMock });
+		fflib_InOrder inOrder = MY_MOCKS.inOrder(new List<Object>{ firstMock, secondMock });
 
 		// When
 		firstMock.add('1-1');
@@ -435,8 +435,8 @@ private class fflib_InOrderTest
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList thirdMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
-		fflib_InOrder inOrder2 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock, secondMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
+		fflib_InOrder inOrder2 = MY_MOCKS.inOrder(new List<Object>{ firstMock, secondMock });
 
 		// When
 		firstMock.add('1-1');
@@ -474,7 +474,7 @@ private class fflib_InOrderTest
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -507,7 +507,7 @@ private class fflib_InOrderTest
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		String customErrorMesage = 'Some custom error message';
 
@@ -542,7 +542,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -573,7 +573,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -605,7 +605,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -628,7 +628,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -651,7 +651,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -690,7 +690,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -729,7 +729,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -754,7 +754,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1', '1-1', '1-1', '1-1');
@@ -781,7 +781,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1', '1-1', '1-1', '1-1');
@@ -809,8 +809,8 @@ private class fflib_InOrderTest
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
-		fflib_InOrder inOrder2 = new fflib_InOrder(MY_MOCKS, new List<Object>{ secondMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
+		fflib_InOrder inOrder2 = MY_MOCKS.inOrder(new List<Object>{ secondMock });
 
 		// When
 		firstMock.add('1-1');
@@ -835,7 +835,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -860,7 +860,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -886,7 +886,7 @@ private class fflib_InOrderTest
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
 		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		secondMock.add('1-2');
@@ -898,7 +898,7 @@ private class fflib_InOrderTest
 	static void thatStrictVerificationCanBePerformed()
 	{
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -916,7 +916,7 @@ private class fflib_InOrderTest
 	static void thatMixedVerificationDoNotInterfierWithOtherImplementationChecking()
 	{
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -939,7 +939,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1'); //consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
@@ -962,7 +962,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1'); //consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
@@ -985,7 +985,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1'); //consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
@@ -1023,7 +1023,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1'); //consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
@@ -1066,7 +1066,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1088,7 +1088,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1103,7 +1103,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1120,7 +1120,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1152,7 +1152,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1189,7 +1189,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1211,7 +1211,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1249,7 +1249,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1287,7 +1287,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1313,7 +1313,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1340,7 +1340,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1372,7 +1372,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1401,7 +1401,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1441,7 +1441,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1467,7 +1467,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1507,7 +1507,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1529,7 +1529,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1567,7 +1567,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1605,7 +1605,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1629,7 +1629,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1669,7 +1669,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1695,7 +1695,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
 		firstMock.add('1-1');
@@ -1721,7 +1721,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
 		firstMock.add('1-1');
@@ -1761,7 +1761,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
 		firstMock.get2(1, '1-1');
@@ -1782,7 +1782,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
 		firstMock.get2(1, '1-1');
@@ -1808,7 +1808,7 @@ private class fflib_InOrderTest
 	{
 		// Given
 		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_InOrder inOrder1 = new fflib_InOrder(MY_MOCKS, new List<Object>{ firstMock });
+		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
 		firstMock.get2(1, '1-1');

--- a/sfdx-source/apex-mocks/test/classes/fflib_MethodCountRecorderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MethodCountRecorderTest.cls
@@ -1,0 +1,114 @@
+/*
+ Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
+ */
+
+/**
+ * @nodoc
+ *
+ * Regression coverage for the backward-compatible (deprecated) entry points retained
+ * when fflib_MethodCountRecorder moved to instance based recording:
+ *   - the static getOrderedMethodCalls() / getMethodArgumentsByTypeName() getters, and
+ *   - the no-arg fflib_AnyOrder() constructor that falls back to the static recorder.
+ * These paths are not exercised by the rest of the suite (everything internal now uses
+ * the instance API), so this class guards against them silently regressing.
+ */
+@isTest
+private class fflib_MethodCountRecorderTest
+{
+	@isTest
+	private static void recordMethodPopulatesInstanceState()
+	{
+		// Given
+		fflib_QualifiedMethod qm = new fflib_QualifiedMethod('MyType', 'myMethod', new List<Type>{ String.class });
+		fflib_InvocationOnMock invocation = buildInvocation(qm, 'bob');
+		fflib_MethodCountRecorder recorder = new fflib_MethodCountRecorder();
+
+		// When
+		recorder.recordMethod(invocation);
+
+		// Then
+		System.Assert.areEqual(
+			1,
+			recorder.getInstanceOrderedMethodCalls().size(),
+			'The invocation should be recorded against the instance ordered calls');
+		System.Assert.isTrue(
+			recorder.getInstanceMethodArgumentsByTypeName().containsKey(qm),
+			'The instance arguments map should contain the recorded method');
+	}
+
+	@isTest
+	private static void recordMethodMirrorsIntoDeprecatedStaticGetters()
+	{
+		// Given the static getters start empty for this transaction
+		System.Assert.isTrue(
+			fflib_MethodCountRecorder.getOrderedMethodCalls().isEmpty(),
+			'The static ordered calls should start empty');
+
+		fflib_QualifiedMethod qm = new fflib_QualifiedMethod('MyType', 'myMethod', new List<Type>{ String.class });
+		fflib_InvocationOnMock invocation = buildInvocation(qm, 'bob');
+
+		// When recording through an instance (as fflib_ApexMocks does)
+		new fflib_MethodCountRecorder().recordMethod(invocation);
+
+		// Then the deprecated static getters mirror that recording rather than returning empty
+		System.Assert.areEqual(
+			1,
+			fflib_MethodCountRecorder.getOrderedMethodCalls().size(),
+			'The deprecated static ordered calls getter should mirror the recorded invocation');
+		System.Assert.isTrue(
+			fflib_MethodCountRecorder.getMethodArgumentsByTypeName().containsKey(qm),
+			'The deprecated static arguments getter should mirror the recorded method');
+	}
+
+	@isTest
+	private static void deprecatedAnyOrderConstructorVerifiesViaStaticRecorder()
+	{
+		// Given an invocation mirrored into the static recorder
+		fflib_QualifiedMethod qm = new fflib_QualifiedMethod('MyType', 'myMethod', new List<Type>{ String.class });
+		fflib_InvocationOnMock invocation = buildInvocation(qm, 'bob');
+		new fflib_MethodCountRecorder().recordMethod(invocation);
+
+		// When verifying through the deprecated no-arg constructor (uses the static recorder state)
+		fflib_AnyOrder verifier = new fflib_AnyOrder();
+		fflib_VerificationMode once = new fflib_ApexMocks().times(1);
+
+		// Then the verification passes (recorded exactly once) - reaching the assert means no exception was thrown
+		verifier.verifyMethodCall(invocation, once);
+		System.Assert.areEqual(
+			1,
+			fflib_MethodCountRecorder.getOrderedMethodCalls().size(),
+			'The static recorder backing the deprecated verifier should hold the single recorded call');
+	}
+
+	@isTest
+	private static void deprecatedAnyOrderConstructorReportsUnexpectedCountViaStaticRecorder()
+	{
+		// Given a single recorded invocation
+		fflib_QualifiedMethod qm = new fflib_QualifiedMethod('MyType', 'myMethod', new List<Type>{ String.class });
+		fflib_InvocationOnMock invocation = buildInvocation(qm, 'bob');
+		new fflib_MethodCountRecorder().recordMethod(invocation);
+
+		// When verifying for two calls through the deprecated no-arg constructor
+		fflib_AnyOrder verifier = new fflib_AnyOrder();
+		fflib_VerificationMode twice = new fflib_ApexMocks().times(2);
+
+		// Then it should fail because only one call was recorded in the static recorder
+		try
+		{
+			verifier.verifyMethodCall(invocation, twice);
+			System.Assert.fail('An exception was expected because the method was recorded only once');
+		}
+		catch (fflib_ApexMocks.ApexMocksException ex)
+		{
+			System.Assert.isTrue(
+				ex.getMessage().startsWith('EXPECTED COUNT: 2'),
+				'Unexpected verify fail message: ' + ex.getMessage());
+		}
+	}
+
+	private static fflib_InvocationOnMock buildInvocation(fflib_QualifiedMethod qm, String arg)
+	{
+		fflib_MethodArgValues args = new fflib_MethodArgValues(new List<Object>{ arg });
+		return new fflib_InvocationOnMock(qm, args, 'mockInstance');
+	}
+}

--- a/sfdx-source/apex-mocks/test/classes/fflib_MethodCountRecorderTest.cls-meta.xml
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MethodCountRecorderTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Summary

Supersedes #166 (closes #166) and addresses #167.

Reimplements @fransf-wtax's fix that makes `fflib_MethodCountRecorder` state instance based, so recorded invocations survive a Platform Event triggered async flow within a unit test. Rebased onto current `master`.

Adds the change requested by @john-storey-devops on #166: the static `getOrderedMethodCalls()` / `getMethodArgumentsByTypeName()` API is retained (no source-breaking change) and now delegates to a private static recorder instance, while the async-safe instance state is exposed via new `getInstanceOrderedMethodCalls()` / `getInstanceMethodArgumentsByTypeName()` entry points. `fflib_AnyOrder` and `fflib_ApexMocks` are pointed at the instance entry points; the static getters are marked `@deprecated`.

## Changes

* `fflib_MethodCountRecorder.cls` — instance based recording; deprecated static getters delegate to a private static recorder instance
* `fflib_AnyOrder.cls` / `fflib_ApexMocks.cls` — use the new instance entry points

## Test plan

* `RunLocalTests` on a scratch org: 472/472 passing

---

Credit to @fransf-wtax for the original fix in #166.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/171)
<!-- Reviewable:end -->
