### PR TITLE
fix: pmd suppression pass for code-analyzer cleanup

### DIFF
--- a/sfdx-source/apex-mocks/main/classes/fflib_Answer.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_Answer.cls
@@ -8,6 +8,7 @@
  *	@group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions')
 public interface fflib_Answer
 {
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
@@ -8,6 +8,7 @@
  *	@group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class fflib_AnyOrder extends fflib_MethodVerifier
 {
 	/*

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
@@ -6,6 +6,7 @@
  * @group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.AvoidBooleanMethodParameters, PMD.ExcessiveParameterList, PMD.CyclomaticComplexity, PMD.CognitiveComplexity, PMD.ExcessivePublicCount, PMD.ClassNamingConventions, PMD.PropertyNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_ApexMocks implements System.StubProvider
 {
 	public static final Integer NEVER = 0;

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksConfig.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksConfig.cls
@@ -3,6 +3,7 @@
  */
 @IsTest
 @NamespaceAccessible
+@SuppressWarnings('PMD.AvoidBooleanMethodParameters, PMD.ClassNamingConventions, PMD.PropertyNamingConventions')
 public class fflib_ApexMocksConfig
 {
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ExcessiveParameterList, PMD.ClassNamingConventions, PMD.ApexDoc')
 public class fflib_ApexMocksUtils
 {
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_ArgumentCaptor.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ArgumentCaptor.cls
@@ -32,6 +32,7 @@
  * 	@group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_ArgumentCaptor
 {
 	protected List<Object> argumentsCaptured = new List<Object>();

--- a/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_IDGenerator
 {
 	private static Integer fakeIdCount = 0;

--- a/sfdx-source/apex-mocks/main/classes/fflib_IMatcher.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_IMatcher.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions')
 public interface fflib_IMatcher
 {
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
@@ -7,6 +7,7 @@
  * @group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.CognitiveComplexity, PMD.AvoidDeeplyNestedIfStmts, PMD.ClassNamingConventions, PMD.ExcessiveParameterList')
 public with sharing class fflib_InOrder extends fflib_MethodVerifier
 {
 	private final List<Object> unorderedMockInstances;

--- a/sfdx-source/apex-mocks/main/classes/fflib_Inheritor.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_Inheritor.cls
@@ -3,6 +3,7 @@
  */
 @isTest
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexDoc')
 public class fflib_Inheritor implements IA, IB, IC
 {
 	public interface IA {String doA();}

--- a/sfdx-source/apex-mocks/main/classes/fflib_InvocationOnMock.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_InvocationOnMock.cls
@@ -8,6 +8,7 @@
  *	@group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class fflib_InvocationOnMock
 {
 	private fflib_QualifiedMethod qm;

--- a/sfdx-source/apex-mocks/main/classes/fflib_Match.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_Match.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.AvoidBooleanMethodParameters, PMD.ExcessiveParameterList, PMD.CyclomaticComplexity, PMD.CognitiveComplexity, PMD.ExcessivePublicCount, PMD.ClassNamingConventions, PMD.FieldNamingConventions, PMD.ApexDoc, PMD.ExcessiveClassLength')
 public class fflib_Match
 {
 	private static List<fflib_IMatcher> matchers = new List<fflib_IMatcher>();

--- a/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
@@ -31,6 +31,7 @@
  * E.g. Don't construct Eq(Object toMatch), instead call fflib_Match.eq(Object toMatch).
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.AvoidBooleanMethodParameters, PMD.ExcessiveParameterList, PMD.CyclomaticComplexity, PMD.CognitiveComplexity, PMD.AvoidDeeplyNestedIfStmts, PMD.ClassNamingConventions, PMD.ApexDoc, PMD.ExcessiveClassLength')
 public with sharing class fflib_MatcherDefinitions
 {
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_MatchersReturnValue.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatchersReturnValue.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_MatchersReturnValue
 {
 	public List<fflib_IMatcher> matchers;

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodArgValues.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodArgValues.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_MethodArgValues
 {
 	public List<Object> argValues;

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
@@ -6,6 +6,7 @@
  * @group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class fflib_MethodCountRecorder
 {
 	/*

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValue.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValue.cls
@@ -30,6 +30,7 @@
  */
 @isTest
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.FieldNamingConventions, PMD.PropertyNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_MethodReturnValue
 {
 	private StandardAnswer basicAnswer = new StandardAnswer();

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValueRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValueRecorder.cls
@@ -28,6 +28,7 @@
  * @group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.AvoidBooleanMethodParameters, PMD.ClassNamingConventions, PMD.PropertyNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_MethodReturnValueRecorder
 {
 	public Boolean Stubbing { get; set; }

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodVerifier.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodVerifier.cls
@@ -7,6 +7,7 @@
  *	@group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ExcessiveParameterList, PMD.ClassNamingConventions')
 public abstract class fflib_MethodVerifier
 {
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
@@ -2,6 +2,7 @@
  * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ExcessiveParameterList, PMD.CognitiveComplexity, PMD.ClassNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_QualifiedMethod
 {
 	public final Object mockInstance;

--- a/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethodAndArgValues.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethodAndArgValues.cls
@@ -6,6 +6,7 @@
  * @group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_QualifiedMethodAndArgValues
 {
 	private final fflib_QualifiedMethod qm;

--- a/sfdx-source/apex-mocks/main/classes/fflib_System.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_System.cls
@@ -8,6 +8,7 @@
  */
 
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions')
 public class fflib_System
 {
 	/**

--- a/sfdx-source/apex-mocks/main/classes/fflib_VerificationMode.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_VerificationMode.cls
@@ -8,6 +8,7 @@
  *	@group Core
  */
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.FieldNamingConventions, PMD.PropertyNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_VerificationMode
 {
 	public Integer VerifyMin {get; set;}

--- a/sfdx-source/apex-mocks/test/classes/fflib_AnswerTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_AnswerTest.cls
@@ -6,6 +6,7 @@
  * @nodoc
  */
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc')
 private class fflib_AnswerTest
 {
 

--- a/sfdx-source/apex-mocks/test/classes/fflib_AnyOrderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_AnyOrderTest.cls
@@ -6,6 +6,7 @@
  * @nodoc
  */
 @isTest
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc')
 private class fflib_AnyOrderTest
 {
 	/*

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksTest.cls
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
  */
 @isTest
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.NcssCount, PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc, PMD.NcssTypeCount')
 private class fflib_ApexMocksTest
 {
 	private static final fflib_ApexMocks MY_MOCKS = new fflib_ApexMocks();

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc')
 public class fflib_ApexMocksUtilsTest
 {
 	public static Schema.FieldSet findAnyFieldSet()

--- a/sfdx-source/apex-mocks/test/classes/fflib_ArgumentCaptorTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ArgumentCaptorTest.cls
@@ -5,6 +5,7 @@
  * @nodoc
  */
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs')
 private class fflib_ArgumentCaptorTest
 {
 	@isTest

--- a/sfdx-source/apex-mocks/test/classes/fflib_IDGeneratorTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_IDGeneratorTest.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs')
 private class fflib_IDGeneratorTest
 {
 	@isTest

--- a/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
@@ -3,6 +3,7 @@
  */
 
 @isTest
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.NcssCount, PMD.ClassNamingConventions, PMD.FieldNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs, PMD.NcssTypeCount')
 private class fflib_InOrderTest
 {
 	private static fflib_ApexMocks MY_MOCKS = new fflib_ApexMocks();

--- a/sfdx-source/apex-mocks/test/classes/fflib_InheritorTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_InheritorTest.cls
@@ -2,6 +2,7 @@
  * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
  */
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs')
 public class fflib_InheritorTest
 {
  	@isTest

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatchTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatchTest.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @isTest
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.NcssCount, PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc')
 public with sharing class fflib_MatchTest
 {
 	@isTest

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
  @isTest
+@SuppressWarnings('PMD.CyclomaticComplexity, PMD.NcssCount, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc')
 public class fflib_MatcherDefinitionsTest
 {
 	private static final List<fflib_IMatcher> INTERNAL_MATCHERS = new List<fflib_IMatcher>{

--- a/sfdx-source/apex-mocks/test/classes/fflib_MethodArgValuesTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MethodArgValuesTest.cls
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs')
 public with sharing class fflib_MethodArgValuesTest
 {
 	@isTest

--- a/sfdx-source/apex-mocks/test/classes/fflib_MyList.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MyList.cls
@@ -6,6 +6,7 @@
  * @nodoc
  */
 @isTest
+@SuppressWarnings('PMD.EmptyStatementBlock, PMD.ExcessiveParameterList, PMD.ClassNamingConventions, PMD.ApexDoc')
 public with sharing class fflib_MyList implements IList
 {
 	public interface IList

--- a/sfdx-source/apex-mocks/test/classes/fflib_QualifiedMethodAndArgValuesTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_QualifiedMethodAndArgValuesTest.cls
@@ -1,4 +1,5 @@
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs')
 public class fflib_QualifiedMethodAndArgValuesTest
 {
     @isTest

--- a/sfdx-source/apex-mocks/test/classes/fflib_QualifiedMethodTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_QualifiedMethodTest.cls
@@ -2,6 +2,7 @@
  * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
  */
 @isTest
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs')
 public with sharing class fflib_QualifiedMethodTest
 {
 	@isTest

--- a/sfdx-source/apex-mocks/test/classes/fflib_SystemTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_SystemTest.cls
@@ -2,6 +2,7 @@
  * Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
  */
 @IsTest
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.ApexUnitTestClassShouldHaveRunAs')
 private class fflib_SystemTest
 {
 	@IsTest


### PR DESCRIPTION
This PR establishes the initial Code Analyzer baseline discussed in [#172](https://github.com/apex-enterprise-patterns/fflib-apex-mocks/issues/172).
  
It adds the documented top-level `@SuppressWarnings` markers as discussed. The change covers 38 production and test classes. The before/after `pmd:all` results are included below; remaining findings can be addressed in follow-up PRs.

# Code Analyzer comparison

Rule selector: `pmd:all`
Before: `origin/master`
After: feature/code-analyzer-suppression

| Severity | Severity Level | Rule | Before | After | Delta |
|---:|---|---|---:|---:|---:|
| 2 | High | EagerlyLoadedDescribeSObjectResult | 1 | 1 | 0 |
| 3 | Moderate | ApexAssertionsShouldIncludeMessage | 1 | 1 | 0 |
| 3 | Moderate | ApexUnitTestClassShouldHaveAsserts | 109 | 109 | 0 |
| 3 | Moderate | AvoidBooleanMethodParameters | 38 | 0 | -38 |
| 3 | Moderate | AvoidDeeplyNestedIfStmts | 4 | 1 | -3 |
| 3 | Moderate | AvoidHardcodingId | 14 | 14 | 0 |
| 3 | Moderate | ClassNamingConventions | 43 | 0 | -43 |
| 3 | Moderate | CognitiveComplexity | 7 | 0 | -7 |
| 3 | Moderate | CyclomaticComplexity | 11 | 0 | -11 |
| 3 | Moderate | EmptyStatementBlock | 6 | 0 | -6 |
| 3 | Moderate | ExcessiveClassLength | 2 | 0 | -2 |
| 3 | Moderate | ExcessiveParameterList | 21 | 0 | -21 |
| 3 | Moderate | ExcessivePublicCount | 2 | 0 | -2 |
| 3 | Moderate | FieldNamingConventions | 10 | 0 | -10 |
| 3 | Moderate | IfElseStmtsMustUseBraces | 6 | 6 | 0 |
| 3 | Moderate | IfStmtsMustUseBraces | 5 | 5 | 0 |
| 3 | Moderate | MethodNamingConventions | 57 | 0 | -57 |
| 3 | Moderate | NcssCount | 4 | 0 | -4 |
| 3 | Moderate | OneDeclarationPerLine | 2 | 2 | 0 |
| 3 | Moderate | PropertyNamingConventions | 10 | 0 | -10 |
| 3 | Moderate | StdCyclomaticComplexity | 4 | 4 | 0 |
| 3 | Moderate | UnusedLocalVariable | 99 | 99 | 0 |
| 4 | Low | AnnotationsNamingConventions | 490 | 485 | -5 |
| 4 | Low | ApexDoc | 180 | 0 | -180 |
| 4 | Low | ApexUnitTestClassShouldHaveRunAs | 484 | 0 | -484 |
| 4 | Low | AvoidDebugStatements | 1 | 1 | 0 |
| 4 | Low | DebugsShouldUseLoggingLevel | 1 | 1 | 0 |
| 4 | Low | NcssMethodCount | 1 | 1 | 0 |
| 4 | Low | NcssTypeCount | 2 | 0 | -2 |
| | | **Total** | **1615** | **730** | **-885** |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/174)
<!-- Reviewable:end -->
