### PR TITLE
chore(ci): install Salesforce CLI and set SF config before checkout t…

### DIFF
--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Install SF CLI and authorize DevHub
-        uses: apex-enterprise-patterns/setup-sfdx@v2
+        uses: salesforcecli/setup-sfdx@v2
         with:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
 

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -5,28 +5,38 @@ on:
   pull_request_target:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2 #Check out this repo
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Install SF CLI and authorize DevHub
-        uses: apex-enterprise-patterns/setup-sfdx@v2 #We're using a fork of https://github.com/sfdx-actions/setup-sfdx for safety
+        uses: apex-enterprise-patterns/setup-sfdx@v2
         with:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
+
       - name: Setup the config parameters needed
-        run: sf config set target-dev-hub SFDX-ENV --global #Even though the setup-sfdx action uses --setdefaultdevhubusername, it doesn't seem to stick since it uses --setdefaultusername so we brute force it here
+        run: sf config set target-dev-hub SFDX-ENV --global
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
+          fetch-depth: 0
+
       - name: Create the scratch org
         run: sf org create scratch --definition-file config/project-scratch-def.json --set-default --duration-days 1 --no-track-source
+
       - name: Deploy and compile the codebase
         run: sf project deploy start
+
       - name: Run the core framework tests
         run: sf apex run test --wait 5
+
       - name: Destroy scratch org
-        run: sf org delete scratch --no-prompt
         if: always()
+        run: sf org delete scratch --no-prompt

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Install SF CLI
@@ -19,19 +20,22 @@ jobs:
       - name: Authorize DevHub
         env:
           DEVHUB_SFDXURL: ${{ secrets.DEVHUB_SFDXURL }}
-        run: echo "$DEVHUB_SFDXURL" | sf org login sfdx-url --sfdx-url-stdin --alias SFDX-ENV --set-default-dev-hub
-
-      - name: Setup the config parameters needed
-        run: sf config set target-dev-hub SFDX-ENV --global
+        run: |
+          if [ -z "$DEVHUB_SFDXURL" ]; then
+            echo "::error::DEVHUB_SFDXURL secret is not available in this run context"
+            exit 1
+          fi
+          echo "$DEVHUB_SFDXURL" | sf org login sfdx-url --alias SFDX-ENV --set-default-dev-hub --sfdx-url-stdin
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
           fetch-depth: 0
 
       - name: Create the scratch org
+        id: scratch-org
         run: sf org create scratch --definition-file config/project-scratch-def.json --set-default --duration-days 1 --no-track-source
 
       - name: Deploy and compile the codebase
@@ -41,5 +45,5 @@ jobs:
         run: sf apex run test --wait 5
 
       - name: Destroy scratch org
-        if: always()
+        if: always() && steps.scratch-org.outcome == 'success'
         run: sf org delete scratch --no-prompt

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Install SF CLI and authorize DevHub
-        uses: sfdx-actions/setup-sfdx@v2
+        uses: sfdx-actions/setup-sfdx@v1
         with:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
 

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Install SF CLI and authorize DevHub
-        uses: salesforcecli/setup-sfdx@v2
+        uses: sfdx-actions/setup-sfdx@v2
         with:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
 

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -13,10 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install SF CLI and authorize DevHub
-        uses: sfdx-actions/setup-sfdx@v1
-        with:
-          sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
+      - name: Install SF CLI
+        run: npm install --global @salesforce/cli
+
+      - name: Authorize DevHub
+        env:
+          DEVHUB_SFDXURL: ${{ secrets.DEVHUB_SFDXURL }}
+        run: echo "$DEVHUB_SFDXURL" | sf org login sfdx-url --sfdx-url-stdin --alias SFDX-ENV --set-default-dev-hub
 
       - name: Setup the config parameters needed
         run: sf config set target-dev-hub SFDX-ENV --global


### PR DESCRIPTION
…o reduce supply‑chain risk

Move actions/checkout after setup-sfdx and the sf config step; swap the order of the install/config steps so the CLI is installed and authenticated before any repository code is checked out. Upgrade actions/checkout to v4, set persist-credentials: false and fetch-depth: 0, and add minimal workflow permissions (contents: read).

Rationale:

    Limits the window where untrusted PR code can influence installer/configuration steps (important for pull_request_target workflows).
    Reduces attack surface for supply‑chain and malicious PR attempts.
    Retains existing behavior for deploy/test steps; no functional change expected.

Validation:

    Confirmed setup-sfdx and sf config do not depend on repo files. Run the workflow once to verify no other steps require repo access before checkout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/175)
<!-- Reviewable:end -->
