### PR TITLE
[afmt] Measure PMD cleanup from house-style formatting

### DIFF
--- a/.afmt.toml
+++ b/.afmt.toml
@@ -1,0 +1,10 @@
+# fflib ApexMocks house style.
+# Keep the existing long-line convention; afmt's structural formatting is the
+# purpose of this pass, not a source-wide line-wrapping change.
+max_width = 250
+indent_size = 4
+brace_style = "allman"
+wrap_single_statements = true
+indent_style = "tab"
+javadoc_star_column = "flush"
+normalize_annotation_casing = true

--- a/.afmt.toml
+++ b/.afmt.toml
@@ -6,5 +6,5 @@ indent_size = 4
 brace_style = "allman"
 wrap_single_statements = true
 indent_style = "tab"
-javadoc_star_column = "flush"
+javadoc_star_column = "offset"
 normalize_annotation_casing = true

--- a/sfdx-source/apex-mocks/main/classes/fflib_Answer.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_Answer.cls
@@ -3,18 +3,18 @@ Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* Interface for the answering framework.
-* This interface must be implemented inside the test class and implement the call back method answer.
-* @group Core
-*/
+ * Interface for the answering framework.
+ * This interface must be implemented inside the test class and implement the call back method answer.
+ * @group Core
+ */
 @NamespaceAccessible
 public interface fflib_Answer
 {
 	/**
-	* Method to be implemented in the test class to implement the call back method.
-	* @param invocation The invocation on the mock.
-	* @throws The exception to be thrown.
-	* @return The value to be returned.
-	*/
+	 * Method to be implemented in the test class to implement the call back method.
+	 * @param invocation The invocation on the mock.
+	 * @throws The exception to be thrown.
+	 * @return The value to be returned.
+	 */
 	Object answer(fflib_InvocationOnMock invocation);
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_Answer.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_Answer.cls
@@ -1,20 +1,20 @@
 /*
- Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- *	Interface for the answering framework.
- *	This interface must be implemented inside the test class and implement the call back method answer.
- *	@group Core
- */
+* Interface for the answering framework.
+* This interface must be implemented inside the test class and implement the call back method answer.
+* @group Core
+*/
 @NamespaceAccessible
 public interface fflib_Answer
 {
 	/**
-	 *	Method to be implemented in the test class to implement the call back method.
-	 *	@param invocation The invocation on the mock.
-	 *	@throws The exception to be thrown.
-	 *	@return The value to be returned.
-	 */
+	* Method to be implemented in the test class to implement the call back method.
+	* @param invocation The invocation on the mock.
+	* @throws The exception to be thrown.
+	* @return The value to be returned.
+	*/
 	Object answer(fflib_InvocationOnMock invocation);
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
@@ -1,47 +1,42 @@
 /*
- Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- *	'Classic' invocation verifier - checks that a method was called with the given arguments the expected number of times.
- *	The order of method calls is not important.
- *	@group Core
- */
+* 'Classic' invocation verifier - checks that a method was called with the given arguments the expected number of times.
+* The order of method calls is not important.
+* @group Core
+*/
 @NamespaceAccessible
 public class fflib_AnyOrder extends fflib_MethodVerifier
 {
-
 	private final fflib_MethodCountRecorder methodCountRecorder;
 
 	/**
-	 * Retained for backward compatibility with the published API. Verifies against
-	 * the globally shared (static) recorder state.
-	 * @deprecated Use {@link #fflib_AnyOrder(fflib_MethodCountRecorder)} instead.
-	 */
-	public fflib_AnyOrder() {
+	* Retained for backward compatibility with the published API. Verifies against
+	* the globally shared (static) recorder state.
+	* @deprecated Use {@link #fflib_AnyOrder(fflib_MethodCountRecorder)} instead.
+	*/
+	public fflib_AnyOrder()
+	{
 		this.methodCountRecorder = null;
 	}
 
-	public fflib_AnyOrder(fflib_MethodCountRecorder methodCountRecorder) {
+	public fflib_AnyOrder(fflib_MethodCountRecorder methodCountRecorder)
+	{
 		this.methodCountRecorder = methodCountRecorder;
 	}
 
 	/*
-	 * Verifies a method was invoked the expected number of times, with the expected arguments.
-	 * @param qualifiedMethod The method to be verified.
-	 * @param methodArg The arguments of the method that needs to be verified.
-	 * @param verificationMode The verification mode that holds the setting about how the verification should be performed.
-	 */
-	protected override void verify(
-		fflib_QualifiedMethod qm,
-		fflib_MethodArgValues expectedArguments,
-		fflib_VerificationMode verificationMode)
+	* Verifies a method was invoked the expected number of times, with the expected arguments.
+	* @param qualifiedMethod The method to be verified.
+	* @param methodArg The arguments of the method that needs to be verified.
+	* @param verificationMode The verification mode that holds the setting about how the verification should be performed.
+	*/
+	protected override void verify(fflib_QualifiedMethod qm, fflib_MethodArgValues expectedArguments, fflib_VerificationMode verificationMode)
 	{
 		List<fflib_IMatcher> expectedMatchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
-		Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> argumentsByTypeName =
-			(methodCountRecorder != null)
-				? methodCountRecorder.getInstanceMethodArgumentsByTypeName()
-				: fflib_MethodCountRecorder.getMethodArgumentsByTypeName();
+		Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> argumentsByTypeName = (methodCountRecorder != null) ? methodCountRecorder.getInstanceMethodArgumentsByTypeName() : fflib_MethodCountRecorder.getMethodArgumentsByTypeName();
 		List<fflib_MethodArgValues> actualArguments = argumentsByTypeName.get(qm);
 
 		Integer methodCount = getMethodCount(expectedArguments, expectedMatchers, actualArguments);
@@ -49,7 +44,7 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 		String qualifier = '';
 		Integer expectedCount = null;
 
-		if((verificationMode.VerifyMin == verificationMode.VerifyMax) && methodCount != verificationMode.VerifyMin)
+		if ((verificationMode.VerifyMin == verificationMode.VerifyMax) && methodCount != verificationMode.VerifyMin)
 		{
 			expectedCount = verificationMode.VerifyMin;
 		}
@@ -83,7 +78,7 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 					if (fflib_Match.matchesAllArgs(args, matchers))
 					{
 						capture(matchers);
-						retval ++;
+						retval++;
 					}
 				}
 			}
@@ -100,27 +95,29 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 	{
 		Integer count = 0;
 
-		for(fflib_MethodArgValues arg: methodArgs)
+		for (fflib_MethodArgValues arg : methodArgs)
 		{
-			if( arg == methodArg) count++;
+			if (arg == methodArg)
+			{
+				count++;
+			}
 		}
 
 		return count;
 	}
 
 	/*
-	 * Method that validate the verification mode used in the verify.
-	 * Not all the methods from the fflib_VerificationMode are implemented for the different classes that extends the fflib_MethodVerifier.
-	 * The error is thrown at run time, so this method is called in the method that actually performs the verify.
-	 * @param verificationMode The verification mode that have to been verified.
-	 * @throws Exception with message for the fflib_VerificationMode not implemented.
-	 */
+	* Method that validate the verification mode used in the verify.
+	* Not all the methods from the fflib_VerificationMode are implemented for the different classes that extends the fflib_MethodVerifier.
+	* The error is thrown at run time, so this method is called in the method that actually performs the verify.
+	* @param verificationMode The verification mode that have to been verified.
+	* @throws Exception with message for the fflib_VerificationMode not implemented.
+	*/
 	protected override void validateMode(fflib_VerificationMode verificationMode)
 	{
-		if(verificationMode.Method == fflib_VerificationMode.ModeName.CALLS)
+		if (verificationMode.Method == fflib_VerificationMode.ModeName.CALLS)
 		{
-			throw new fflib_ApexMocks.ApexMocksException(
-				'The calls() method is available only in the InOrder Verification.');
+			throw new fflib_ApexMocks.ApexMocksException('The calls() method is available only in the InOrder Verification.');
 		}
 	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_AnyOrder.cls
@@ -3,20 +3,20 @@ Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* 'Classic' invocation verifier - checks that a method was called with the given arguments the expected number of times.
-* The order of method calls is not important.
-* @group Core
-*/
+ * 'Classic' invocation verifier - checks that a method was called with the given arguments the expected number of times.
+ * The order of method calls is not important.
+ * @group Core
+ */
 @NamespaceAccessible
 public class fflib_AnyOrder extends fflib_MethodVerifier
 {
 	private final fflib_MethodCountRecorder methodCountRecorder;
 
 	/**
-	* Retained for backward compatibility with the published API. Verifies against
-	* the globally shared (static) recorder state.
-	* @deprecated Use {@link #fflib_AnyOrder(fflib_MethodCountRecorder)} instead.
-	*/
+	 * Retained for backward compatibility with the published API. Verifies against
+	 * the globally shared (static) recorder state.
+	 * @deprecated Use {@link #fflib_AnyOrder(fflib_MethodCountRecorder)} instead.
+	 */
 	public fflib_AnyOrder()
 	{
 		this.methodCountRecorder = null;

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
@@ -1,10 +1,10 @@
 /*
- Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- * @group Core
- */
+* @group Core
+*/
 @NamespaceAccessible
 public with sharing class fflib_ApexMocks implements System.StubProvider
 {
@@ -17,7 +17,8 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	private fflib_VerificationMode verificationMode;
 	private fflib_Answer myAnswer;
 
-	public Boolean verifying { get; set; }
+	public Boolean verifying
+	{ get; set; }
 
 	public Boolean Stubbing
 	{
@@ -25,7 +26,6 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 		{
 			return methodReturnValueRecorder.Stubbing;
 		}
-
 		private set;
 	}
 
@@ -35,7 +35,6 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 		{
 			return methodReturnValueRecorder.DoThrowWhenExceptions;
 		}
-
 		set
 		{
 			methodReturnValueRecorder.DoThrowWhenExceptions = value;
@@ -43,8 +42,8 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Construct an ApexMocks instance.
-	 */
+	* Construct an ApexMocks instance.
+	*/
 	@NamespaceAccessible
 	public fflib_ApexMocks()
 	{
@@ -60,10 +59,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-     * Creates mock object of given class or interface.
-     * @param classToMock class or interface to mock.
-     * @return mock object.
-     */
+	* Creates mock object of given class or interface.
+	* @param classToMock class or interface to mock.
+	* @return mock object.
+	*/
 	@NamespaceAccessible
 	public Object mock(Type classToMock)
 	{
@@ -71,21 +70,20 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Inherited from StubProvider.
-	 * @param stubbedObject The stubbed object.
-	 * @param stubbedMethodName The name of the invoked method.
-	 * @param returnType The return type of the invoked method.
-	 * @param listOfParamTypes A list of the parameter types of the invoked method.
-	 * @param listOfParamNames A list of the parameter names of the invoked method.
-	 * @param listOfArgs The actual argument values passed into this method at runtime.
-	 * @return The stubbed return value. Null by default, unless you prepared one that matches this method and argument values in stubbing.
-	 */
+	* Inherited from StubProvider.
+	* @param stubbedObject The stubbed object.
+	* @param stubbedMethodName The name of the invoked method.
+	* @param returnType The return type of the invoked method.
+	* @param listOfParamTypes A list of the parameter types of the invoked method.
+	* @param listOfParamNames A list of the parameter names of the invoked method.
+	* @param listOfArgs The actual argument values passed into this method at runtime.
+	* @return The stubbed return value. Null by default, unless you prepared one that matches this method and argument values in stubbing.
+	*/
 	@NamespaceAccessible
-	public Object handleMethodCall(Object stubbedObject, String stubbedMethodName, Type returnType,
-		List<type> listOfParamTypes, List<String> listOfParamNames, List<Object> listOfArgs)
-    {
-        return mockNonVoidMethod(stubbedObject, stubbedMethodName, listOfParamTypes, listOfArgs);
-    }
+	public Object handleMethodCall(Object stubbedObject, String stubbedMethodName, Type returnType, List<type> listOfParamTypes, List<String> listOfParamNames, List<Object> listOfArgs)
+	{
+		return mockNonVoidMethod(stubbedObject, stubbedMethodName, listOfParamTypes, listOfArgs);
+	}
 
 	@NamespaceAccessible
 	public static String extractTypeName(Object mockInstance)
@@ -94,10 +92,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Verify a method was called on a mock object.
-	 * @param mockInstance The mock object instance.
-	 * @return The mock object instance.
-	 */
+	* Verify a method was called on a mock object.
+	* @param mockInstance The mock object instance.
+	* @return The mock object instance.
+	*/
 	@NamespaceAccessible
 	public Object verify(Object mockInstance)
 	{
@@ -105,11 +103,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Verify a method was called on a mock object.
-	 * @param mockInstance The mock object instance.
-	 * @param verificationMode Defines the constraints for performing the verification (e.g. the minimum and maximum expected invocation counts).
-	 * @return The mock object instance.
-	 */
+	* Verify a method was called on a mock object.
+	* @param mockInstance The mock object instance.
+	* @param verificationMode Defines the constraints for performing the verification (e.g. the minimum and maximum expected invocation counts).
+	* @return The mock object instance.
+	*/
 	@NamespaceAccessible
 	public Object verify(Object mockInstance, fflib_VerificationMode verificationMode)
 	{
@@ -120,11 +118,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Verify a method was called on a mock object.
-	 * @param mockInstance The mock object instance.
-	 * @param times The number of times you expect the method to have been called.
-	 * @return The mock object instance.
-	 */
+	* Verify a method was called on a mock object.
+	* @param mockInstance The mock object instance.
+	* @param times The number of times you expect the method to have been called.
+	* @return The mock object instance.
+	*/
 	@NamespaceAccessible
 	public Object verify(Object mockInstance, Integer times)
 	{
@@ -132,9 +130,9 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Verfiy a method was called on a mock object.
-	 * @param mockInvocation The invocation on the mock containing information about the method and the arguments.
-	 */
+	* Verfiy a method was called on a mock object.
+	* @param mockInvocation The invocation on the mock containing information about the method and the arguments.
+	*/
 	public void verifyMethodCall(fflib_InvocationOnMock mockInvocation)
 	{
 		this.methodVerifier.verifyMethodCall(mockInvocation, verificationMode);
@@ -144,8 +142,8 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Tell ApexMocks framework you are about to start stubbing using when() calls.
-	 */
+	* Tell ApexMocks framework you are about to start stubbing using when() calls.
+	*/
 	@NamespaceAccessible
 	public void startStubbing()
 	{
@@ -153,8 +151,8 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Tell ApexMocks framework you are about to stop stubbing using when() calls.
-	 */
+	* Tell ApexMocks framework you are about to stop stubbing using when() calls.
+	*/
 	@NamespaceAccessible
 	public void stopStubbing()
 	{
@@ -162,10 +160,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Setup when stubbing for a mock object instance.
-	 * @param ignoredRetVal This is the return value from the method called on the mockInstance, and is ignored here since we are about to setup
-	 *        the stubbed return value using thenReturn() (see MethodReturnValue class below).
-	 */
+	* Setup when stubbing for a mock object instance.
+	* @param ignoredRetVal This is the return value from the method called on the mockInstance, and is ignored here since we are about to setup
+	* the stubbed return value using thenReturn() (see MethodReturnValue class below).
+	*/
 	@NamespaceAccessible
 	public fflib_MethodReturnValue when(Object ignoredRetVal)
 	{
@@ -173,59 +171,60 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Record a method was called on a mock object.
-	 * @param mockInvocation The invocation on the mock containing information about the method and the arguments.
-	 */
+	* Record a method was called on a mock object.
+	* @param mockInvocation The invocation on the mock containing information about the method and the arguments.
+	*/
 	public void recordMethod(fflib_InvocationOnMock mockInvocation)
 	{
 		methodCountRecorder.recordMethod(mockInvocation);
 	}
 
 	/**
-	 * Retrieve method calls on mock objects that were recorded, in the order in which they were recorded.
-	 * @return The list of methods called in order.
-	 */
-	public List<fflib_InvocationOnMock> getOrderedMethodCalls() {
+	* Retrieve method calls on mock objects that were recorded, in the order in which they were recorded.
+	* @return The list of methods called in order.
+	*/
+	public List<fflib_InvocationOnMock> getOrderedMethodCalls()
+	{
 		return methodCountRecorder.getInstanceOrderedMethodCalls();
 	}
 
 	/**
-	 * Prepare a stubbed method return value.
-	 * @param mockInvocation The invocation on the mock containing information about the method and the arguments.
-	 * @return The MethodReturnValue instance.
-	 */
+	* Prepare a stubbed method return value.
+	* @param mockInvocation The invocation on the mock containing information about the method and the arguments.
+	* @return The MethodReturnValue instance.
+	*/
 	public fflib_MethodReturnValue prepareMethodReturnValue(fflib_InvocationOnMock mockInvocation)
 	{
 		return methodReturnValueRecorder.prepareMethodReturnValue(mockInvocation);
 	}
 
 	/**
-	 * Get the method return value for the given method call.
-	 * @param mockInvocation The invocation on the mock containing information about the method and the arguments.
-	 * @return The MethodReturnValue instance.
-	 */
+	* Get the method return value for the given method call.
+	* @param mockInvocation The invocation on the mock containing information about the method and the arguments.
+	* @return The MethodReturnValue instance.
+	*/
 	public fflib_MethodReturnValue getMethodReturnValue(fflib_InvocationOnMock mockInvocation)
 	{
 		return methodReturnValueRecorder.getMethodReturnValue(mockInvocation);
 	}
 
 	/**
-	 * Setup exception stubbing for a void method.
-	 * @param e The exception to throw.
-	 * @param mockInstance The mock object instance.
-	 */
+	* Setup exception stubbing for a void method.
+	* @param e The exception to throw.
+	* @param mockInstance The mock object instance.
+	*/
 	@NamespaceAccessible
 	public Object doThrowWhen(Exception e, Object mockInstance)
 	{
-		methodReturnValueRecorder.prepareDoThrowWhenExceptions(new List<Exception>{e});
+		methodReturnValueRecorder.prepareDoThrowWhenExceptions(new List<Exception>{ e });
 		return mockInstance;
 	}
 
 	/**
-	 * Setup exception stubbing for a void method.
-	 * @param exps The list of exceptions to throw.
-	 * @param mockInstance The mock object instance.
-	 */
+	* Setup exception stubbing for a void method.
+	* @param exps The list of exceptions to throw.
+	* @param mockInstance The mock object instance.
+	*/
 	@NamespaceAccessible
 	public Object doThrowWhen(List<Exception> exps, Object mockInstance)
 	{
@@ -234,10 +233,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Setup answer stubbing for a void method.
-	 * @param answer The answer to invoke.
-	 * @param mockInstance The mock object instance.
-	 */
+	* Setup answer stubbing for a void method.
+	* @param answer The answer to invoke.
+	* @param mockInstance The mock object instance.
+	*/
 	@NamespaceAccessible
 	public Object doAnswer(fflib_Answer answer, Object mockInstance)
 	{
@@ -246,26 +245,26 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Mock a void method. Called by generated mock instance classes, not directly by a developers
-	 * code.
-	 * @param mockInstance The mock object instance.
-	 * @param methodName The method for which to prepare a return value.
-	 * @param methodArgTypes The method argument types for which to prepare a return value.
-	 * @param methodArgValues The method argument values for which to prepare a return value.
-	 */
+	* Mock a void method. Called by generated mock instance classes, not directly by a developers
+	* code.
+	* @param mockInstance The mock object instance.
+	* @param methodName The method for which to prepare a return value.
+	* @param methodArgTypes The method argument types for which to prepare a return value.
+	* @param methodArgValues The method argument values for which to prepare a return value.
+	*/
 	public void mockVoidMethod(Object mockInstance, String methodName, List<Type> methodArgTypes, List<Object> methodArgValues)
 	{
 		mockNonVoidMethod(mockInstance, methodName, methodArgTypes, methodArgValues);
 	}
 
 	/**
-	 * Mock a non-void method. Called by generated mock instance classes, not directly by a developers
-	 * code.
-	 * @param mockInstance The mock object instance.
-	 * @param methodName The method for which to prepare a return value.
-	 * @param methodArgTypes The method argument types for which to prepare a return value.
-	 * @param methodArgValues The method argument values for which to prepare a return value.
-	 */
+	* Mock a non-void method. Called by generated mock instance classes, not directly by a developers
+	* code.
+	* @param mockInstance The mock object instance.
+	* @param methodName The method for which to prepare a return value.
+	* @param methodArgTypes The method argument types for which to prepare a return value.
+	* @param methodArgValues The method argument values for which to prepare a return value.
+	*/
 	public Object mockNonVoidMethod(Object mockInstance, String methodName, List<Type> methodArgTypes, List<Object> methodArgValues)
 	{
 		fflib_QualifiedMethod qm = new fflib_QualifiedMethod(extractTypeName(mockInstance), methodName, methodArgTypes, mockInstance);
@@ -281,14 +280,14 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 		{
 			fflib_MethodReturnValue methotReturnValue = prepareMethodReturnValue(invocation);
 
-			if(DoThrowWhenExceptions != null)
+			if (DoThrowWhenExceptions != null)
 			{
 				methotReturnValue.thenThrowMulti(DoThrowWhenExceptions);
 				DoThrowWhenExceptions = null;
 				return null;
 			}
 
-			if(this.myAnswer != null)
+			if (this.myAnswer != null)
 			{
 				methotReturnValue.thenAnswer(this.myAnswer);
 				this.myAnswer = null;
@@ -307,21 +306,21 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Creates an instance of {@link fflib_InOrder} linked to this ApexMocks instance.
-	 * @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
-	 * @return an {@link fflib_InOrder} instance
-	 */
-	public fflib_InOrder inOrder(List<Object> unorderedMockInstances) {
+	* Creates an instance of {@link fflib_InOrder} linked to this ApexMocks instance.
+	* @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
+	* @return an {@link fflib_InOrder} instance
+	*/
+	public fflib_InOrder inOrder(List<Object> unorderedMockInstances)
+	{
 		return new fflib_InOrder(this, unorderedMockInstances);
 	}
 
 	/**
-	 * Custom exception class for ApexMocks
-	 */
+	* Custom exception class for ApexMocks
+	*/
 	@NamespaceAccessible
 	public class ApexMocksException extends Exception
 	{
-
 	}
 
 	private Object returnValue(fflib_InvocationOnMock invocation)
@@ -330,15 +329,14 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 
 		if (methodReturnValue != null)
 		{
-			if(methodReturnValue.Answer == null)
+			if (methodReturnValue.Answer == null)
 			{
-				throw new fflib_ApexMocks.ApexMocksException(
-  					'The stubbing is not correct, no return values have been set.');
+				throw new fflib_ApexMocks.ApexMocksException('The stubbing is not correct, no return values have been set.');
 			}
 
 			Object returnedValue = methodReturnValue.Answer.answer(invocation);
 
-			if(returnedValue == null)
+			if (returnedValue == null)
 			{
 				return null;
 			}
@@ -355,17 +353,17 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Sets how many times the method is expected to be called.
-	 * For InOrder verification we copy Mockito behavior which is as follows;
-	 * <ul>
-	 * <li>Consume the specified number of matching invocations, ignoring non-matching invocations in between</li>
-	 * <li>Fail an assert if the very next invocation matches, but additional matches can still exist so long as at least one non-matching invocation exists before them</li>
-	 * </ul>
-	 * For example if you had a(); a(); b(); a();
-	 * then inOrder.verify(myMock, 2)).a(); or inOrder.verify(myMock, 3)).a(); would pass but not inOrder.verify(myMock, 1)).a();
-	 * @param times The number of times you expect the method to have been called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets how many times the method is expected to be called.
+	* For InOrder verification we copy Mockito behavior which is as follows;
+	* <ul>
+	* <li>Consume the specified number of matching invocations, ignoring non-matching invocations in between</li>
+	* <li>Fail an assert if the very next invocation matches, but additional matches can still exist so long as at least one non-matching invocation exists before them</li>
+	* </ul>
+	* For example if you had a(); a(); b(); a();
+	* then inOrder.verify(myMock, 2)).a(); or inOrder.verify(myMock, 3)).a(); would pass but not inOrder.verify(myMock, 1)).a();
+	* @param times The number of times you expect the method to have been called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode times(Integer times)
 	{
@@ -373,11 +371,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Sets how many times the method is expected to be called for an InOrder verifier. Available Only with the InOrder verification.
-	 * A verification mode using calls will not fail if the method is called more times than expected.
-	 * @param times The number of times you expect the method to have been called in the InOrder verifying ( no greedy verify).
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets how many times the method is expected to be called for an InOrder verifier. Available Only with the InOrder verification.
+	* A verification mode using calls will not fail if the method is called more times than expected.
+	* @param times The number of times you expect the method to have been called in the InOrder verifying ( no greedy verify).
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode calls(Integer times)
 	{
@@ -385,10 +383,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Sets a custom assert message for the verify.
-	 * @param customAssertMessage The custom message for the assert in case the assert is false. The custom message is queued to the default message.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets a custom assert message for the verify.
+	* @param customAssertMessage The custom message for the assert in case the assert is false. The custom message is queued to the default message.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode description(String customAssertMessage)
 	{
@@ -396,11 +394,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Sets the minimum number of times the method is expected to be called.
-	 * With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
-	 * @param atLeastTimes The minimum number of times you expect the method to have been called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets the minimum number of times the method is expected to be called.
+	* With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
+	* @param atLeastTimes The minimum number of times you expect the method to have been called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode atLeast(Integer atLeastTimes)
 	{
@@ -408,10 +406,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Sets the maximum number of times the method is expected to be called. Not available in the InOrder verification.
-	 * @param atMostTimes The maximum number of times the method is expected to be called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets the maximum number of times the method is expected to be called. Not available in the InOrder verification.
+	* @param atMostTimes The maximum number of times the method is expected to be called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode atMost(Integer atMostTimes)
 	{
@@ -419,10 +417,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Sets that the method is called at least once.
-	 * With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets that the method is called at least once.
+	* With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode atLeastOnce()
 	{
@@ -430,11 +428,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Sets the range of how many times the method is expected to be called. Not available in the InOrder verification.
-	 * @param atLeastTimes The minimum number of times you expect the method to have been called.
-	 * @param atMostTimes The maximum number of times the method is expected to be called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets the range of how many times the method is expected to be called. Not available in the InOrder verification.
+	* @param atLeastTimes The minimum number of times you expect the method to have been called.
+	* @param atMostTimes The maximum number of times the method is expected to be called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode between(Integer atLeastTimes, Integer atMostTimes)
 	{
@@ -442,9 +440,9 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Sets that the method is not expected to be called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets that the method is not expected to be called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode never()
 	{
@@ -452,22 +450,22 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	 * Sets the fflib_VerificationMode object.
-	 * To internal use only.
-	 * Used to pass the verification mode that has been set in the  verify of the fflib_InOrder class.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets the fflib_VerificationMode object.
+	* To internal use only.
+	* Used to pass the verification mode that has been set in the  verify of the fflib_InOrder class.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	public void setOrderedVerifier(fflib_InOrder verifyOrderingMode)
 	{
 		this.methodVerifier = verifyOrderingMode;
 	}
-	
+
 	/**
-	 * A simple override to suppress the default toString logic, which is noisy and rarely useful.
-	 * In some cases, the Salesforce default implementation of toString here can cause internal Salesforce errors
-	 * if it has circular references.
-	 * @return "fflib_ApexMocks" String literal
-	 */
+	* A simple override to suppress the default toString logic, which is noisy and rarely useful.
+	* In some cases, the Salesforce default implementation of toString here can cause internal Salesforce errors
+	* if it has circular references.
+	* @return "fflib_ApexMocks" String literal
+	*/
 	public override String toString()
 	{
 		return 'fflib_ApexMocks';

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocks.cls
@@ -3,8 +3,8 @@ Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* @group Core
-*/
+ * @group Core
+ */
 @NamespaceAccessible
 public with sharing class fflib_ApexMocks implements System.StubProvider
 {
@@ -42,8 +42,8 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Construct an ApexMocks instance.
-	*/
+	 * Construct an ApexMocks instance.
+	 */
 	@NamespaceAccessible
 	public fflib_ApexMocks()
 	{
@@ -59,10 +59,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Creates mock object of given class or interface.
-	* @param classToMock class or interface to mock.
-	* @return mock object.
-	*/
+	 * Creates mock object of given class or interface.
+	 * @param classToMock class or interface to mock.
+	 * @return mock object.
+	 */
 	@NamespaceAccessible
 	public Object mock(Type classToMock)
 	{
@@ -70,15 +70,15 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Inherited from StubProvider.
-	* @param stubbedObject The stubbed object.
-	* @param stubbedMethodName The name of the invoked method.
-	* @param returnType The return type of the invoked method.
-	* @param listOfParamTypes A list of the parameter types of the invoked method.
-	* @param listOfParamNames A list of the parameter names of the invoked method.
-	* @param listOfArgs The actual argument values passed into this method at runtime.
-	* @return The stubbed return value. Null by default, unless you prepared one that matches this method and argument values in stubbing.
-	*/
+	 * Inherited from StubProvider.
+	 * @param stubbedObject The stubbed object.
+	 * @param stubbedMethodName The name of the invoked method.
+	 * @param returnType The return type of the invoked method.
+	 * @param listOfParamTypes A list of the parameter types of the invoked method.
+	 * @param listOfParamNames A list of the parameter names of the invoked method.
+	 * @param listOfArgs The actual argument values passed into this method at runtime.
+	 * @return The stubbed return value. Null by default, unless you prepared one that matches this method and argument values in stubbing.
+	 */
 	@NamespaceAccessible
 	public Object handleMethodCall(Object stubbedObject, String stubbedMethodName, Type returnType, List<type> listOfParamTypes, List<String> listOfParamNames, List<Object> listOfArgs)
 	{
@@ -92,10 +92,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Verify a method was called on a mock object.
-	* @param mockInstance The mock object instance.
-	* @return The mock object instance.
-	*/
+	 * Verify a method was called on a mock object.
+	 * @param mockInstance The mock object instance.
+	 * @return The mock object instance.
+	 */
 	@NamespaceAccessible
 	public Object verify(Object mockInstance)
 	{
@@ -103,11 +103,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Verify a method was called on a mock object.
-	* @param mockInstance The mock object instance.
-	* @param verificationMode Defines the constraints for performing the verification (e.g. the minimum and maximum expected invocation counts).
-	* @return The mock object instance.
-	*/
+	 * Verify a method was called on a mock object.
+	 * @param mockInstance The mock object instance.
+	 * @param verificationMode Defines the constraints for performing the verification (e.g. the minimum and maximum expected invocation counts).
+	 * @return The mock object instance.
+	 */
 	@NamespaceAccessible
 	public Object verify(Object mockInstance, fflib_VerificationMode verificationMode)
 	{
@@ -118,11 +118,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Verify a method was called on a mock object.
-	* @param mockInstance The mock object instance.
-	* @param times The number of times you expect the method to have been called.
-	* @return The mock object instance.
-	*/
+	 * Verify a method was called on a mock object.
+	 * @param mockInstance The mock object instance.
+	 * @param times The number of times you expect the method to have been called.
+	 * @return The mock object instance.
+	 */
 	@NamespaceAccessible
 	public Object verify(Object mockInstance, Integer times)
 	{
@@ -130,9 +130,9 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Verfiy a method was called on a mock object.
-	* @param mockInvocation The invocation on the mock containing information about the method and the arguments.
-	*/
+	 * Verfiy a method was called on a mock object.
+	 * @param mockInvocation The invocation on the mock containing information about the method and the arguments.
+	 */
 	public void verifyMethodCall(fflib_InvocationOnMock mockInvocation)
 	{
 		this.methodVerifier.verifyMethodCall(mockInvocation, verificationMode);
@@ -142,8 +142,8 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Tell ApexMocks framework you are about to start stubbing using when() calls.
-	*/
+	 * Tell ApexMocks framework you are about to start stubbing using when() calls.
+	 */
 	@NamespaceAccessible
 	public void startStubbing()
 	{
@@ -151,8 +151,8 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Tell ApexMocks framework you are about to stop stubbing using when() calls.
-	*/
+	 * Tell ApexMocks framework you are about to stop stubbing using when() calls.
+	 */
 	@NamespaceAccessible
 	public void stopStubbing()
 	{
@@ -160,10 +160,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Setup when stubbing for a mock object instance.
-	* @param ignoredRetVal This is the return value from the method called on the mockInstance, and is ignored here since we are about to setup
-	* the stubbed return value using thenReturn() (see MethodReturnValue class below).
-	*/
+	 * Setup when stubbing for a mock object instance.
+	 * @param ignoredRetVal This is the return value from the method called on the mockInstance, and is ignored here since we are about to setup
+	 * the stubbed return value using thenReturn() (see MethodReturnValue class below).
+	 */
 	@NamespaceAccessible
 	public fflib_MethodReturnValue when(Object ignoredRetVal)
 	{
@@ -171,48 +171,48 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Record a method was called on a mock object.
-	* @param mockInvocation The invocation on the mock containing information about the method and the arguments.
-	*/
+	 * Record a method was called on a mock object.
+	 * @param mockInvocation The invocation on the mock containing information about the method and the arguments.
+	 */
 	public void recordMethod(fflib_InvocationOnMock mockInvocation)
 	{
 		methodCountRecorder.recordMethod(mockInvocation);
 	}
 
 	/**
-	* Retrieve method calls on mock objects that were recorded, in the order in which they were recorded.
-	* @return The list of methods called in order.
-	*/
+	 * Retrieve method calls on mock objects that were recorded, in the order in which they were recorded.
+	 * @return The list of methods called in order.
+	 */
 	public List<fflib_InvocationOnMock> getOrderedMethodCalls()
 	{
 		return methodCountRecorder.getInstanceOrderedMethodCalls();
 	}
 
 	/**
-	* Prepare a stubbed method return value.
-	* @param mockInvocation The invocation on the mock containing information about the method and the arguments.
-	* @return The MethodReturnValue instance.
-	*/
+	 * Prepare a stubbed method return value.
+	 * @param mockInvocation The invocation on the mock containing information about the method and the arguments.
+	 * @return The MethodReturnValue instance.
+	 */
 	public fflib_MethodReturnValue prepareMethodReturnValue(fflib_InvocationOnMock mockInvocation)
 	{
 		return methodReturnValueRecorder.prepareMethodReturnValue(mockInvocation);
 	}
 
 	/**
-	* Get the method return value for the given method call.
-	* @param mockInvocation The invocation on the mock containing information about the method and the arguments.
-	* @return The MethodReturnValue instance.
-	*/
+	 * Get the method return value for the given method call.
+	 * @param mockInvocation The invocation on the mock containing information about the method and the arguments.
+	 * @return The MethodReturnValue instance.
+	 */
 	public fflib_MethodReturnValue getMethodReturnValue(fflib_InvocationOnMock mockInvocation)
 	{
 		return methodReturnValueRecorder.getMethodReturnValue(mockInvocation);
 	}
 
 	/**
-	* Setup exception stubbing for a void method.
-	* @param e The exception to throw.
-	* @param mockInstance The mock object instance.
-	*/
+	 * Setup exception stubbing for a void method.
+	 * @param e The exception to throw.
+	 * @param mockInstance The mock object instance.
+	 */
 	@NamespaceAccessible
 	public Object doThrowWhen(Exception e, Object mockInstance)
 	{
@@ -221,10 +221,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Setup exception stubbing for a void method.
-	* @param exps The list of exceptions to throw.
-	* @param mockInstance The mock object instance.
-	*/
+	 * Setup exception stubbing for a void method.
+	 * @param exps The list of exceptions to throw.
+	 * @param mockInstance The mock object instance.
+	 */
 	@NamespaceAccessible
 	public Object doThrowWhen(List<Exception> exps, Object mockInstance)
 	{
@@ -233,10 +233,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Setup answer stubbing for a void method.
-	* @param answer The answer to invoke.
-	* @param mockInstance The mock object instance.
-	*/
+	 * Setup answer stubbing for a void method.
+	 * @param answer The answer to invoke.
+	 * @param mockInstance The mock object instance.
+	 */
 	@NamespaceAccessible
 	public Object doAnswer(fflib_Answer answer, Object mockInstance)
 	{
@@ -245,26 +245,26 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Mock a void method. Called by generated mock instance classes, not directly by a developers
-	* code.
-	* @param mockInstance The mock object instance.
-	* @param methodName The method for which to prepare a return value.
-	* @param methodArgTypes The method argument types for which to prepare a return value.
-	* @param methodArgValues The method argument values for which to prepare a return value.
-	*/
+	 * Mock a void method. Called by generated mock instance classes, not directly by a developers
+	 * code.
+	 * @param mockInstance The mock object instance.
+	 * @param methodName The method for which to prepare a return value.
+	 * @param methodArgTypes The method argument types for which to prepare a return value.
+	 * @param methodArgValues The method argument values for which to prepare a return value.
+	 */
 	public void mockVoidMethod(Object mockInstance, String methodName, List<Type> methodArgTypes, List<Object> methodArgValues)
 	{
 		mockNonVoidMethod(mockInstance, methodName, methodArgTypes, methodArgValues);
 	}
 
 	/**
-	* Mock a non-void method. Called by generated mock instance classes, not directly by a developers
-	* code.
-	* @param mockInstance The mock object instance.
-	* @param methodName The method for which to prepare a return value.
-	* @param methodArgTypes The method argument types for which to prepare a return value.
-	* @param methodArgValues The method argument values for which to prepare a return value.
-	*/
+	 * Mock a non-void method. Called by generated mock instance classes, not directly by a developers
+	 * code.
+	 * @param mockInstance The mock object instance.
+	 * @param methodName The method for which to prepare a return value.
+	 * @param methodArgTypes The method argument types for which to prepare a return value.
+	 * @param methodArgValues The method argument values for which to prepare a return value.
+	 */
 	public Object mockNonVoidMethod(Object mockInstance, String methodName, List<Type> methodArgTypes, List<Object> methodArgValues)
 	{
 		fflib_QualifiedMethod qm = new fflib_QualifiedMethod(extractTypeName(mockInstance), methodName, methodArgTypes, mockInstance);
@@ -306,18 +306,18 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Creates an instance of {@link fflib_InOrder} linked to this ApexMocks instance.
-	* @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
-	* @return an {@link fflib_InOrder} instance
-	*/
+	 * Creates an instance of {@link fflib_InOrder} linked to this ApexMocks instance.
+	 * @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
+	 * @return an {@link fflib_InOrder} instance
+	 */
 	public fflib_InOrder inOrder(List<Object> unorderedMockInstances)
 	{
 		return new fflib_InOrder(this, unorderedMockInstances);
 	}
 
 	/**
-	* Custom exception class for ApexMocks
-	*/
+	 * Custom exception class for ApexMocks
+	 */
 	@NamespaceAccessible
 	public class ApexMocksException extends Exception
 	{
@@ -353,17 +353,17 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Sets how many times the method is expected to be called.
-	* For InOrder verification we copy Mockito behavior which is as follows;
-	* <ul>
-	* <li>Consume the specified number of matching invocations, ignoring non-matching invocations in between</li>
-	* <li>Fail an assert if the very next invocation matches, but additional matches can still exist so long as at least one non-matching invocation exists before them</li>
-	* </ul>
-	* For example if you had a(); a(); b(); a();
-	* then inOrder.verify(myMock, 2)).a(); or inOrder.verify(myMock, 3)).a(); would pass but not inOrder.verify(myMock, 1)).a();
-	* @param times The number of times you expect the method to have been called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets how many times the method is expected to be called.
+	 * For InOrder verification we copy Mockito behavior which is as follows;
+	 * <ul>
+	 * <li>Consume the specified number of matching invocations, ignoring non-matching invocations in between</li>
+	 * <li>Fail an assert if the very next invocation matches, but additional matches can still exist so long as at least one non-matching invocation exists before them</li>
+	 * </ul>
+	 * For example if you had a(); a(); b(); a();
+	 * then inOrder.verify(myMock, 2)).a(); or inOrder.verify(myMock, 3)).a(); would pass but not inOrder.verify(myMock, 1)).a();
+	 * @param times The number of times you expect the method to have been called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode times(Integer times)
 	{
@@ -371,11 +371,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Sets how many times the method is expected to be called for an InOrder verifier. Available Only with the InOrder verification.
-	* A verification mode using calls will not fail if the method is called more times than expected.
-	* @param times The number of times you expect the method to have been called in the InOrder verifying ( no greedy verify).
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets how many times the method is expected to be called for an InOrder verifier. Available Only with the InOrder verification.
+	 * A verification mode using calls will not fail if the method is called more times than expected.
+	 * @param times The number of times you expect the method to have been called in the InOrder verifying ( no greedy verify).
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode calls(Integer times)
 	{
@@ -383,10 +383,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Sets a custom assert message for the verify.
-	* @param customAssertMessage The custom message for the assert in case the assert is false. The custom message is queued to the default message.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets a custom assert message for the verify.
+	 * @param customAssertMessage The custom message for the assert in case the assert is false. The custom message is queued to the default message.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode description(String customAssertMessage)
 	{
@@ -394,11 +394,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Sets the minimum number of times the method is expected to be called.
-	* With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
-	* @param atLeastTimes The minimum number of times you expect the method to have been called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets the minimum number of times the method is expected to be called.
+	 * With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
+	 * @param atLeastTimes The minimum number of times you expect the method to have been called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode atLeast(Integer atLeastTimes)
 	{
@@ -406,10 +406,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Sets the maximum number of times the method is expected to be called. Not available in the InOrder verification.
-	* @param atMostTimes The maximum number of times the method is expected to be called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets the maximum number of times the method is expected to be called. Not available in the InOrder verification.
+	 * @param atMostTimes The maximum number of times the method is expected to be called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode atMost(Integer atMostTimes)
 	{
@@ -417,10 +417,10 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Sets that the method is called at least once.
-	* With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets that the method is called at least once.
+	 * With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode atLeastOnce()
 	{
@@ -428,11 +428,11 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Sets the range of how many times the method is expected to be called. Not available in the InOrder verification.
-	* @param atLeastTimes The minimum number of times you expect the method to have been called.
-	* @param atMostTimes The maximum number of times the method is expected to be called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets the range of how many times the method is expected to be called. Not available in the InOrder verification.
+	 * @param atLeastTimes The minimum number of times you expect the method to have been called.
+	 * @param atMostTimes The maximum number of times the method is expected to be called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode between(Integer atLeastTimes, Integer atMostTimes)
 	{
@@ -440,9 +440,9 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Sets that the method is not expected to be called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets that the method is not expected to be called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode never()
 	{
@@ -450,22 +450,22 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	}
 
 	/**
-	* Sets the fflib_VerificationMode object.
-	* To internal use only.
-	* Used to pass the verification mode that has been set in the  verify of the fflib_InOrder class.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets the fflib_VerificationMode object.
+	 * To internal use only.
+	 * Used to pass the verification mode that has been set in the  verify of the fflib_InOrder class.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	public void setOrderedVerifier(fflib_InOrder verifyOrderingMode)
 	{
 		this.methodVerifier = verifyOrderingMode;
 	}
 
 	/**
-	* A simple override to suppress the default toString logic, which is noisy and rarely useful.
-	* In some cases, the Salesforce default implementation of toString here can cause internal Salesforce errors
-	* if it has circular references.
-	* @return "fflib_ApexMocks" String literal
-	*/
+	 * A simple override to suppress the default toString logic, which is noisy and rarely useful.
+	 * In some cases, the Salesforce default implementation of toString here can cause internal Salesforce errors
+	 * if it has circular references.
+	 * @return "fflib_ApexMocks" String literal
+	 */
 	public override String toString()
 	{
 		return 'fflib_ApexMocks';

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksConfig.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksConfig.cls
@@ -6,12 +6,12 @@
 public class fflib_ApexMocksConfig
 {
 	/**
-	* When false, stubbed behaviour and invocation counts are shared among all test spies.
-	* - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedDependently
-	* - This is the default for backwards compatibility.
-	* When true, each test spy instance has its own stubbed behaviour and invocations.
-	* - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedIndependently
-	*/
+	 * When false, stubbed behaviour and invocation counts are shared among all test spies.
+	 * - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedDependently
+	 * - This is the default for backwards compatibility.
+	 * When true, each test spy instance has its own stubbed behaviour and invocations.
+	 * - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedIndependently
+	 */
 	@NamespaceAccessible
 	public static Boolean HasIndependentMocks
 	{ get; set; }

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksConfig.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksConfig.cls
@@ -1,19 +1,20 @@
 /*
- * Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+* Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 @IsTest
 @NamespaceAccessible
 public class fflib_ApexMocksConfig
 {
 	/**
-	 * When false, stubbed behaviour and invocation counts are shared among all test spies.
-	 * - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedDependently
-	 * - This is the default for backwards compatibility.
-	 * When true, each test spy instance has its own stubbed behaviour and invocations.
-	 * - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedIndependently
-	 */
+	* When false, stubbed behaviour and invocation counts are shared among all test spies.
+	* - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedDependently
+	* - This is the default for backwards compatibility.
+	* When true, each test spy instance has its own stubbed behaviour and invocations.
+	* - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedIndependently
+	*/
 	@NamespaceAccessible
-	public static Boolean HasIndependentMocks {get; set;}
+	public static Boolean HasIndependentMocks
+	{ get; set; }
 
 	static
 	{

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
@@ -1,72 +1,72 @@
 /**
- * Copyright (c) 2014-2016, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2014-2016, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 @NamespaceAccessible
 public class fflib_ApexMocksUtils
 {
 	/**
-	 * This is taken from https://gist.github.com/afawcett/8dbfc0e1d8c43c982881.
-	 *
-	 * This method works on the principle that serializing and deserialising child records is supported
-	 *
-	 *   System.assertEquals(1, ((List<Master__c>) 
-	 *    JSON.deserialize(
-	 *	    JSON.serialize(
-	 *         [select Id, Name, 
-	 *            (select Id, Name from Children__r) from Master__c]), List<Master__c>.class))
-	 *               [0].Children__r.size());
-	 *
-	 * This method results internally in constructing this JSON, before deserialising it back into SObject's
-	 *
-	 *		[
-	 *		    {
-	 *		        "attributes": {
-	 *		            "type": "Master__c",
-	 *		            "url": "/services/data/v32.0/sobjects/Master__c/a0YG0000005Jn5uMAC"
-	 *		        },
-	 *		        "Name": "Fred",
-	 *		        "Id": "a0YG0000005Jn5uMAC",
-	 *		        "Children__r": {
-	 *		            "totalSize": 1,
-	 *		            "done": true,
-	 *		            "records": [
-	 *		                {
-	 *		                    "attributes": {
-	 *		                        "type": "Child__c",
-	 *		                        "url": "/services/data/v32.0/sobjects/Child__c/a0ZG0000006JGPAMA4"
-	 *		                    },
-	 *		                    "Name": "Bob",
-	 *		                    "Id": "a0ZG0000006JGPAMA4",
-	 *		                    "Master__c": "a0YG0000005Jn5uMAC"
-	 *		                }
-	 *		            ]
-	 *		        }
-	 * 		]
-	 */
-	public static Object makeRelationship(Type parentsType, List<SObject> parents, SObjectField relationshipField, List<List<SObject>> children) {
-
+	* This is taken from https://gist.github.com/afawcett/8dbfc0e1d8c43c982881.
+	*
+	* This method works on the principle that serializing and deserialising child records is supported
+	*
+	* System.assertEquals(1, ((List<Master__c>)
+	* JSON.deserialize(
+	* JSON.serialize(
+	* [select Id, Name,
+	* (select Id, Name from Children__r) from Master__c]), List<Master__c>.class))
+	* [0].Children__r.size());
+	*
+	* This method results internally in constructing this JSON, before deserialising it back into SObject's
+	*
+	* [
+	* {
+	* "attributes": {
+	* "type": "Master__c",
+	* "url": "/services/data/v32.0/sobjects/Master__c/a0YG0000005Jn5uMAC"
+	* },
+	* "Name": "Fred",
+	* "Id": "a0YG0000005Jn5uMAC",
+	* "Children__r": {
+	* "totalSize": 1,
+	* "done": true,
+	* "records": [
+	* {
+	* "attributes": {
+	* "type": "Child__c",
+	* "url": "/services/data/v32.0/sobjects/Child__c/a0ZG0000006JGPAMA4"
+	* },
+	* "Name": "Bob",
+	* "Id": "a0ZG0000006JGPAMA4",
+	* "Master__c": "a0YG0000005Jn5uMAC"
+	* }
+	* ]
+	* }
+	* ]
+	*/
+	public static Object makeRelationship(Type parentsType, List<SObject> parents, SObjectField relationshipField, List<List<SObject>> children)
+	{
 		// Find out more about this relationship...
 		String relationshipFieldName = relationshipField.getDescribe().getName();
 		DescribeSObjectResult parentDescribe = parents.getSObjectType().getDescribe();
@@ -74,17 +74,12 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	 * Generic overload to makeRelationship. Enables creation of
-	 * relationships in a loosely-coupled manner. 
-	 */
+	* Generic overload to makeRelationship. Enables creation of
+	* relationships in a loosely-coupled manner.
+	*/
 	@NamespaceAccessible
-	public static Object makeRelationship(
-			String parentTypeName,
-			String childTypeName,
-			List<SObject> parents,
-			String relationshipFieldName,
-			List<List<SObject>> children) {
-
+	public static Object makeRelationship(String parentTypeName, String childTypeName, List<SObject> parents, String relationshipFieldName, List<List<SObject>> children)
+	{
 		// Find out more about this relationship...
 		SObjectType parentType = getType(parentTypeName);
 		SObjectField relationshipField = getField(childTypeName, relationshipFieldName);
@@ -94,14 +89,15 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	 * Gives the ability to set test values on formula
-	 * and other read-only fields of mock SObjects
-	 */
+	* Gives the ability to set test values on formula
+	* and other read-only fields of mock SObjects
+	*/
 	@NamespaceAccessible
-	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<SObjectField, Object> properties) {
-
+	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<SObjectField, Object> properties)
+	{
 		Map<String, Object> fieldNameMap = new Map<String, Object>();
-		for (SObjectField field : properties.keySet()) {
+		for (SObjectField field : properties.keySet())
+		{
 			// Resolve the fieldNames from the FieldTokens
 			fieldNameMap.put(field.getDescribe().getName(), properties.get(field));
 		}
@@ -109,34 +105,32 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	 * Generic overload to setReadOnlyFields. Enables setting test
-	 * values on read-only fields by their name
-	 */
+	* Generic overload to setReadOnlyFields. Enables setting test
+	* values on read-only fields by their name
+	*/
 	@NamespaceAccessible
-	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<String, Object> properties) {
+	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<String, Object> properties)
+	{
 		JSONParser parser = JSON.createParser((JSON.serialize(objInstance)));
 		JSONGenerator combinedOutput = JSON.createGenerator(false);
 
 		// parse the source object and inject new fields into the resulting JSON
-		streamTokens(parser, combinedOutput, new InjectFieldsEventHandler(properties) );
+		streamTokens(parser, combinedOutput, new InjectFieldsEventHandler(properties));
 		return JSON.deserialize(combinedOutput.getAsString(), deserializeType);
 	}
 
 	/**
-	 * Helper Methods
-	 */
-	private static Object deserializeParentsAndChildren(
-		Type parentsType,
-		DescribeSObjectResult parentDescribe,
-		SObjectField relationshipField,
-		List<SObject> parents,
-		List<List<SObject>> children
-	) {
+	* Helper Methods
+	*/
+	private static Object deserializeParentsAndChildren(Type parentsType, DescribeSObjectResult parentDescribe, SObjectField relationshipField, List<SObject> parents, List<List<SObject>> children)
+	{
 		List<Schema.ChildRelationship> childRelationships = parentDescribe.getChildRelationships();
 
 		String relationshipName = null;
-		for(Schema.ChildRelationship childRelationship : childRelationships) {
-			if(childRelationship.getField() == relationshipField) {
+		for (Schema.ChildRelationship childRelationship : childRelationships)
+		{
+			if (childRelationship.getField() == relationshipField)
+			{
 				relationshipName = childRelationship.getRelationshipName();
 				break;
 			}
@@ -145,17 +139,17 @@ public class fflib_ApexMocksUtils
 		// Stream the parsed JSON representation of the parent objects back out, injecting children as it goes
 		JSONParser parentsParser = JSON.createParser(JSON.serialize(parents));
 		JSONParser childrenParser = JSON.createParser(JSON.serialize(children));
-		JSONGenerator combinedOutput = JSON.createGenerator(false);		
-		streamTokens(parentsParser, combinedOutput, new InjectChildrenEventHandler(childrenParser, relationshipName, children) );
+		JSONGenerator combinedOutput = JSON.createGenerator(false);
+		streamTokens(parentsParser, combinedOutput, new InjectChildrenEventHandler(childrenParser, relationshipName, children));
 
 		// Derserialise back into SObject list complete with children
 		return JSON.deserialize(combinedOutput.getAsString(), parentsType);
 	}
 
 	/**
-	 * Monitors stream events for end of object for each SObject contained in the parent list
-	 *   then injects the respective childs record list into the stream
-	 */
+	* Monitors stream events for end of object for each SObject contained in the parent list
+	* then injects the respective childs record list into the stream
+	*/
 	private class InjectChildrenEventHandler implements JSONParserEvents
 	{
 		private JSONParser childrenParser;
@@ -163,17 +157,20 @@ public class fflib_ApexMocksUtils
 		private List<List<SObject>> children;
 		private Integer childListIdx = 0;
 
-		public InjectChildrenEventHandler(JSONParser childrenParser, String relationshipName, List<List<SObject>> children) {
+		public InjectChildrenEventHandler(JSONParser childrenParser, String relationshipName, List<List<SObject>> children)
+		{
 			this.childrenParser = childrenParser;
 			this.relationshipName = relationshipName;
 			this.children = children;
 			this.childrenParser.nextToken(); // Consume the outer array token
 		}
 
-		public void nextToken(JSONParser fromStream, Integer depth, JSONGenerator toStream) {
+		public void nextToken(JSONParser fromStream, Integer depth, JSONGenerator toStream)
+		{
 			// Inject children?
 			JSONToken currentToken = fromStream.getCurrentToken();
-			if(depth == 2 && currentToken == JSONToken.END_OBJECT ) {
+			if (depth == 2 && currentToken == JSONToken.END_OBJECT)
+			{
 				toStream.writeFieldName(relationshipName);
 				toStream.writeStartObject();
 				toStream.writeNumberField('totalSize', children[childListIdx].size());
@@ -187,29 +184,37 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	 * Monitors stream events for end of object for the current SObject
-	 *   then injects new fields into the stream
-	 */
+	* Monitors stream events for end of object for the current SObject
+	* then injects new fields into the stream
+	*/
 	private class InjectFieldsEventHandler implements JSONParserEvents
 	{
 		Map<String, Object> properties = new Map<String, Object>();
 
-		public InjectFieldsEventHandler(Map<String, Object> properties) {
-			if (properties != null && !properties.isEmpty()) {
+		public InjectFieldsEventHandler(Map<String, Object> properties)
+		{
+			if (properties != null && !properties.isEmpty())
+			{
 				this.properties.putAll(properties);
 			}
 		}
 
-		public void nextToken(JSONParser fromStream, Integer depth, JSONGenerator toStream) {
+		public void nextToken(JSONParser fromStream, Integer depth, JSONGenerator toStream)
+		{
 			// Inject the additional fields when the current SObject closes
 			JSONToken currentToken = fromStream.getCurrentToken();
-			if(depth == 1 && currentToken == JSONToken.END_OBJECT ) {
-				for(String field : properties.keySet()) {
+			if (depth == 1 && currentToken == JSONToken.END_OBJECT)
+			{
+				for (String field : properties.keySet())
+				{
 					Object value = properties.get(field);
 					// writeObjectField throws on null, so write an explicit null field instead
-					if(value == null) {
+					if (value == null)
+					{
 						toStream.writeNullField(field);
-					} else {
+					}
+					else
+					{
 						toStream.writeObjectField(field, value);
 					}
 				}
@@ -218,81 +223,95 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	 * Utility function to stream tokens from a reader to a write, while providing a basic eventing model
-	 */
+	* Utility function to stream tokens from a reader to a write, while providing a basic eventing model
+	*/
 	private static void streamTokens(JSONParser fromStream, JSONGenerator toStream, JSONParserEvents events)
 	{
 		Integer depth = 0;
 		while (fromStream.nextToken() != null)
 		{
 			// Give event handler chance to inject
-			if (events != null) {
+			if (events != null)
+			{
 				events.nextToken(fromStream, depth, toStream);
 			}
-				
+
 			// Forward to output stream
-			switch on fromStream.getCurrentToken() {
-				when START_ARRAY {
+			switch on fromStream.getCurrentToken()
+			{
+				when START_ARRAY
+				{
 					toStream.writeStartArray();
 					depth++;
 				}
-				when START_OBJECT {
+				when START_OBJECT
+				{
 					toStream.writeStartObject();
 					depth++;
 				}
-				when FIELD_NAME {
+				when FIELD_NAME
+				{
 					toStream.writeFieldName(fromStream.getCurrentName());
 				}
-				when VALUE_STRING, VALUE_FALSE, VALUE_TRUE, VALUE_NUMBER_FLOAT, VALUE_NUMBER_INT {
+				when VALUE_STRING, VALUE_FALSE, VALUE_TRUE, VALUE_NUMBER_FLOAT, VALUE_NUMBER_INT
+				{
 					toStream.writeString(fromStream.getText());
 				}
-			    when VALUE_NULL {
+				when VALUE_NULL
+				{
 					toStream.writeNull();
 				}
-				when END_OBJECT {
+				when END_OBJECT
+				{
 					toStream.writeEndObject();
 					depth--;
 				}
-				when END_ARRAY {
+				when END_ARRAY
+				{
 					toStream.writeEndArray();
 					depth--;
 				}
 			}
 			// Don't continue to stream beyond the initial starting point
-			if (depth == 0) 
+			if (depth == 0)
+			{
 				break;
+			}
 		}
 	}
 
 	/**
-	 * Basic event used during the above streaming
-	 */
+	* Basic event used during the above streaming
+	*/
 	private interface JSONParserEvents
 	{
 		void nextToken(JSONParser fromStream, Integer depth, JSONGenerator toStream);
 	}
 
 	/**
-	 * Gets the SObjectType by name
-	 */
-	private static Schema.SObjectType getType(String typeName) {
+	* Gets the SObjectType by name
+	*/
+	private static Schema.SObjectType getType(String typeName)
+	{
 		Map<String, Schema.SObjectType> gd = Schema.getGlobalDescribe();
 		SObjectType sobjType = gd.get(typeName);
-		if (sobjType == null) {
+		if (sobjType == null)
+		{
 			throw new fflib_ApexMocks.ApexMocksException('SObject type not found: ' + typeName);
 		}
 		return sobjType;
 	}
 
 	/**
-	 * Gets the SObjectField of an object by name
-	 */
-	private static Schema.SObjectField getField(String objectName, String fieldName) {
-
+	* Gets the SObjectField of an object by name
+	*/
+	private static Schema.SObjectField getField(String objectName, String fieldName)
+	{
 		SObjectType sobjType = getType(objectName);
 		Map<String, Schema.SObjectField> objectFields = sobjType.getDescribe().fields.getMap();
 		Schema.SObjectField sobjField = objectFields.get(fieldName);
-		if (sobjField == null) {
+		if (sobjField == null)
+		{
 			throw new fflib_ApexMocks.ApexMocksException('SObject field not found: ' + fieldName);
 		}
 		return sobjField;

--- a/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ApexMocksUtils.cls
@@ -1,70 +1,70 @@
 /**
-* Copyright (c) 2014-2016, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014-2016, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @NamespaceAccessible
 public class fflib_ApexMocksUtils
 {
 	/**
-	* This is taken from https://gist.github.com/afawcett/8dbfc0e1d8c43c982881.
-	*
-	* This method works on the principle that serializing and deserialising child records is supported
-	*
-	* System.assertEquals(1, ((List<Master__c>)
-	* JSON.deserialize(
-	* JSON.serialize(
-	* [select Id, Name,
-	* (select Id, Name from Children__r) from Master__c]), List<Master__c>.class))
-	* [0].Children__r.size());
-	*
-	* This method results internally in constructing this JSON, before deserialising it back into SObject's
-	*
-	* [
-	* {
-	* "attributes": {
-	* "type": "Master__c",
-	* "url": "/services/data/v32.0/sobjects/Master__c/a0YG0000005Jn5uMAC"
-	* },
-	* "Name": "Fred",
-	* "Id": "a0YG0000005Jn5uMAC",
-	* "Children__r": {
-	* "totalSize": 1,
-	* "done": true,
-	* "records": [
-	* {
-	* "attributes": {
-	* "type": "Child__c",
-	* "url": "/services/data/v32.0/sobjects/Child__c/a0ZG0000006JGPAMA4"
-	* },
-	* "Name": "Bob",
-	* "Id": "a0ZG0000006JGPAMA4",
-	* "Master__c": "a0YG0000005Jn5uMAC"
-	* }
-	* ]
-	* }
-	* ]
-	*/
+	 * This is taken from https://gist.github.com/afawcett/8dbfc0e1d8c43c982881.
+	 *
+	 * This method works on the principle that serializing and deserialising child records is supported
+	 *
+	 * System.assertEquals(1, ((List<Master__c>)
+	 * JSON.deserialize(
+	 * JSON.serialize(
+	 * [select Id, Name,
+	 * (select Id, Name from Children__r) from Master__c]), List<Master__c>.class))
+	 * [0].Children__r.size());
+	 *
+	 * This method results internally in constructing this JSON, before deserialising it back into SObject's
+	 *
+	 * [
+	 * {
+	 * "attributes": {
+	 * "type": "Master__c",
+	 * "url": "/services/data/v32.0/sobjects/Master__c/a0YG0000005Jn5uMAC"
+	 * },
+	 * "Name": "Fred",
+	 * "Id": "a0YG0000005Jn5uMAC",
+	 * "Children__r": {
+	 * "totalSize": 1,
+	 * "done": true,
+	 * "records": [
+	 * {
+	 * "attributes": {
+	 * "type": "Child__c",
+	 * "url": "/services/data/v32.0/sobjects/Child__c/a0ZG0000006JGPAMA4"
+	 * },
+	 * "Name": "Bob",
+	 * "Id": "a0ZG0000006JGPAMA4",
+	 * "Master__c": "a0YG0000005Jn5uMAC"
+	 * }
+	 * ]
+	 * }
+	 * ]
+	 */
 	public static Object makeRelationship(Type parentsType, List<SObject> parents, SObjectField relationshipField, List<List<SObject>> children)
 	{
 		// Find out more about this relationship...
@@ -74,9 +74,9 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	* Generic overload to makeRelationship. Enables creation of
-	* relationships in a loosely-coupled manner.
-	*/
+	 * Generic overload to makeRelationship. Enables creation of
+	 * relationships in a loosely-coupled manner.
+	 */
 	@NamespaceAccessible
 	public static Object makeRelationship(String parentTypeName, String childTypeName, List<SObject> parents, String relationshipFieldName, List<List<SObject>> children)
 	{
@@ -89,9 +89,9 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	* Gives the ability to set test values on formula
-	* and other read-only fields of mock SObjects
-	*/
+	 * Gives the ability to set test values on formula
+	 * and other read-only fields of mock SObjects
+	 */
 	@NamespaceAccessible
 	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<SObjectField, Object> properties)
 	{
@@ -105,9 +105,9 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	* Generic overload to setReadOnlyFields. Enables setting test
-	* values on read-only fields by their name
-	*/
+	 * Generic overload to setReadOnlyFields. Enables setting test
+	 * values on read-only fields by their name
+	 */
 	@NamespaceAccessible
 	public static Object setReadOnlyFields(SObject objInstance, Type deserializeType, Map<String, Object> properties)
 	{
@@ -120,8 +120,8 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	* Helper Methods
-	*/
+	 * Helper Methods
+	 */
 	private static Object deserializeParentsAndChildren(Type parentsType, DescribeSObjectResult parentDescribe, SObjectField relationshipField, List<SObject> parents, List<List<SObject>> children)
 	{
 		List<Schema.ChildRelationship> childRelationships = parentDescribe.getChildRelationships();
@@ -147,9 +147,9 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	* Monitors stream events for end of object for each SObject contained in the parent list
-	* then injects the respective childs record list into the stream
-	*/
+	 * Monitors stream events for end of object for each SObject contained in the parent list
+	 * then injects the respective childs record list into the stream
+	 */
 	private class InjectChildrenEventHandler implements JSONParserEvents
 	{
 		private JSONParser childrenParser;
@@ -184,9 +184,9 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	* Monitors stream events for end of object for the current SObject
-	* then injects new fields into the stream
-	*/
+	 * Monitors stream events for end of object for the current SObject
+	 * then injects new fields into the stream
+	 */
 	private class InjectFieldsEventHandler implements JSONParserEvents
 	{
 		Map<String, Object> properties = new Map<String, Object>();
@@ -223,8 +223,8 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	* Utility function to stream tokens from a reader to a write, while providing a basic eventing model
-	*/
+	 * Utility function to stream tokens from a reader to a write, while providing a basic eventing model
+	 */
 	private static void streamTokens(JSONParser fromStream, JSONGenerator toStream, JSONParserEvents events)
 	{
 		Integer depth = 0;
@@ -281,16 +281,16 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	* Basic event used during the above streaming
-	*/
+	 * Basic event used during the above streaming
+	 */
 	private interface JSONParserEvents
 	{
 		void nextToken(JSONParser fromStream, Integer depth, JSONGenerator toStream);
 	}
 
 	/**
-	* Gets the SObjectType by name
-	*/
+	 * Gets the SObjectType by name
+	 */
 	private static Schema.SObjectType getType(String typeName)
 	{
 		Map<String, Schema.SObjectType> gd = Schema.getGlobalDescribe();
@@ -303,8 +303,8 @@ public class fflib_ApexMocksUtils
 	}
 
 	/**
-	* Gets the SObjectField of an object by name
-	*/
+	 * Gets the SObjectField of an object by name
+	 */
 	private static Schema.SObjectField getField(String objectName, String fieldName)
 	{
 		SObjectType sobjType = getType(objectName);

--- a/sfdx-source/apex-mocks/main/classes/fflib_ArgumentCaptor.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ArgumentCaptor.cls
@@ -1,50 +1,50 @@
 /*
- * Copyright (c) 2016, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2016, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+*      this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+*      this list of conditions and the following disclaimer in the documentation
+*      and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+*      may be used to endorse or promote products derived from this software without
+*      specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 /**
- * 	This class implements the capturing framework for ApexMocks
- *	According to Mockito's syntax the type is passed in the capturer construction,
- *	however Apex cannot perform the auto casting that Java can.
- *	To be consistent with Mockito, the capturer does not perform any checks on the type of the argument.
- * 	@group Core
- */
+* This class implements the capturing framework for ApexMocks
+* According to Mockito's syntax the type is passed in the capturer construction,
+* however Apex cannot perform the auto casting that Java can.
+* To be consistent with Mockito, the capturer does not perform any checks on the type of the argument.
+* @group Core
+*/
 @NamespaceAccessible
 public with sharing class fflib_ArgumentCaptor
 {
 	protected List<Object> argumentsCaptured = new List<Object>();
 
 	/**
-	 *	Factory method to create a new fflib_ArgumentCaptor.
-	 * 	Takes the captured argument's Type for consistency with Mockito syntax.
-	 * 	The Type is IGNORED because we can't determine an object instance's Type at runtime unlike in Java.
-	 *	Rigorous type checking may be introduced in a future release, so you should specify the expected argument type correctly.
-	 *
-	 * 	@param 	ignoredCaptureType Type (class) of the captured argument
-	 * 	@return A new fflib_ArgumentCaptor.
-	 */
+	* Factory method to create a new fflib_ArgumentCaptor.
+	* Takes the captured argument's Type for consistency with Mockito syntax.
+	* The Type is IGNORED because we can't determine an object instance's Type at runtime unlike in Java.
+	* Rigorous type checking may be introduced in a future release, so you should specify the expected argument type correctly.
+	*
+	* @param 	ignoredCaptureType Type (class) of the captured argument
+	* @return A new fflib_ArgumentCaptor.
+	*/
 	@NamespaceAccessible
 	public static fflib_ArgumentCaptor forClass(Type ignoredCaptureType)
 	{
@@ -52,12 +52,12 @@ public with sharing class fflib_ArgumentCaptor
 	}
 
 	/**
-	 *	Use it to capture the argument. This method must be used inside verification.
-	 *	Internally, this method registers a special implementation of a Matcher.
-	 * 	This argument matcher stores the argument value so that you can use it later to perform assertions.
-	 *
-	 * 	@return a special matcher that matches any argument and remembers the value.
-	 */
+	* Use it to capture the argument. This method must be used inside verification.
+	* Internally, this method registers a special implementation of a Matcher.
+	* This argument matcher stores the argument value so that you can use it later to perform assertions.
+	*
+	* @return a special matcher that matches any argument and remembers the value.
+	*/
 	@NamespaceAccessible
 	public Object capture()
 	{
@@ -67,30 +67,29 @@ public with sharing class fflib_ArgumentCaptor
 	}
 
 	/**
-	 *	Returns the captured value of the argument. When capturing all arguments use getAllValues().
-	 *	If verified method was called multiple times then this method returns the latest captured value.
-	 *
-	 * 	@return	captured argument value.
-	 */
+	* Returns the captured value of the argument. When capturing all arguments use getAllValues().
+	* If verified method was called multiple times then this method returns the latest captured value.
+	*
+	* @return	captured argument value.
+	*/
 	@NamespaceAccessible
 	public Object getValue()
 	{
-		if( argumentsCaptured == null ||
-			argumentsCaptured.size() == 0)
+		if (argumentsCaptured == null || argumentsCaptured.size() == 0)
 		{
 			return null;
 		}
 
 		//returns the last argument called
-		return argumentsCaptured.get( argumentsCaptured.size() - 1 );
+		return argumentsCaptured.get(argumentsCaptured.size() - 1);
 	}
 
 	/**
-	 *	Returns all captured values. Use it when capturing multiple arguments or when the verified method was called multiple times.
-	 *	When capturing multiple arguments is called multiple times, this method returns a merged list of all values from all invocations.
-	 *
-	 * 	@return	Returns all captured values. Use it when capturing multiple arguments on the same call or when the verified method was called multiple times.
-	 */
+	* Returns all captured values. Use it when capturing multiple arguments or when the verified method was called multiple times.
+	* When capturing multiple arguments is called multiple times, this method returns a merged list of all values from all invocations.
+	*
+	* @return	Returns all captured values. Use it when capturing multiple arguments on the same call or when the verified method was called multiple times.
+	*/
 	@NamespaceAccessible
 	public List<Object> getAllValues()
 	{

--- a/sfdx-source/apex-mocks/main/classes/fflib_ArgumentCaptor.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_ArgumentCaptor.cls
@@ -25,26 +25,26 @@
 */
 
 /**
-* This class implements the capturing framework for ApexMocks
-* According to Mockito's syntax the type is passed in the capturer construction,
-* however Apex cannot perform the auto casting that Java can.
-* To be consistent with Mockito, the capturer does not perform any checks on the type of the argument.
-* @group Core
-*/
+ * This class implements the capturing framework for ApexMocks
+ * According to Mockito's syntax the type is passed in the capturer construction,
+ * however Apex cannot perform the auto casting that Java can.
+ * To be consistent with Mockito, the capturer does not perform any checks on the type of the argument.
+ * @group Core
+ */
 @NamespaceAccessible
 public with sharing class fflib_ArgumentCaptor
 {
 	protected List<Object> argumentsCaptured = new List<Object>();
 
 	/**
-	* Factory method to create a new fflib_ArgumentCaptor.
-	* Takes the captured argument's Type for consistency with Mockito syntax.
-	* The Type is IGNORED because we can't determine an object instance's Type at runtime unlike in Java.
-	* Rigorous type checking may be introduced in a future release, so you should specify the expected argument type correctly.
-	*
-	* @param 	ignoredCaptureType Type (class) of the captured argument
-	* @return A new fflib_ArgumentCaptor.
-	*/
+	 * Factory method to create a new fflib_ArgumentCaptor.
+	 * Takes the captured argument's Type for consistency with Mockito syntax.
+	 * The Type is IGNORED because we can't determine an object instance's Type at runtime unlike in Java.
+	 * Rigorous type checking may be introduced in a future release, so you should specify the expected argument type correctly.
+	 *
+	 * @param 	ignoredCaptureType Type (class) of the captured argument
+	 * @return A new fflib_ArgumentCaptor.
+	 */
 	@NamespaceAccessible
 	public static fflib_ArgumentCaptor forClass(Type ignoredCaptureType)
 	{
@@ -52,12 +52,12 @@ public with sharing class fflib_ArgumentCaptor
 	}
 
 	/**
-	* Use it to capture the argument. This method must be used inside verification.
-	* Internally, this method registers a special implementation of a Matcher.
-	* This argument matcher stores the argument value so that you can use it later to perform assertions.
-	*
-	* @return a special matcher that matches any argument and remembers the value.
-	*/
+	 * Use it to capture the argument. This method must be used inside verification.
+	 * Internally, this method registers a special implementation of a Matcher.
+	 * This argument matcher stores the argument value so that you can use it later to perform assertions.
+	 *
+	 * @return a special matcher that matches any argument and remembers the value.
+	 */
 	@NamespaceAccessible
 	public Object capture()
 	{
@@ -67,11 +67,11 @@ public with sharing class fflib_ArgumentCaptor
 	}
 
 	/**
-	* Returns the captured value of the argument. When capturing all arguments use getAllValues().
-	* If verified method was called multiple times then this method returns the latest captured value.
-	*
-	* @return	captured argument value.
-	*/
+	 * Returns the captured value of the argument. When capturing all arguments use getAllValues().
+	 * If verified method was called multiple times then this method returns the latest captured value.
+	 *
+	 * @return	captured argument value.
+	 */
 	@NamespaceAccessible
 	public Object getValue()
 	{
@@ -85,11 +85,11 @@ public with sharing class fflib_ArgumentCaptor
 	}
 
 	/**
-	* Returns all captured values. Use it when capturing multiple arguments or when the verified method was called multiple times.
-	* When capturing multiple arguments is called multiple times, this method returns a merged list of all values from all invocations.
-	*
-	* @return	Returns all captured values. Use it when capturing multiple arguments on the same call or when the verified method was called multiple times.
-	*/
+	 * Returns all captured values. Use it when capturing multiple arguments or when the verified method was called multiple times.
+	 * When capturing multiple arguments is called multiple times, this method returns a merged list of all values from all invocations.
+	 *
+	 * @return	Returns all captured values. Use it when capturing multiple arguments on the same call or when the verified method was called multiple times.
+	 */
 	@NamespaceAccessible
 	public List<Object> getAllValues()
 	{

--- a/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
@@ -1,28 +1,28 @@
 /**
-* Copyright (c) 2014, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @NamespaceAccessible
 public with sharing class fflib_IDGenerator
 {
@@ -30,8 +30,8 @@ public with sharing class fflib_IDGenerator
 	private static final String ID_PATTERN = '000000000000';
 
 	/**
-	* Generate a fake Salesforce Id for the given SObjectType
-	*/
+	 * Generate a fake Salesforce Id for the given SObjectType
+	 */
 	@NamespaceAccessible
 	public static Id generate(Schema.SObjectType sobjectType)
 	{

--- a/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_IDGenerator.cls
@@ -1,28 +1,28 @@
 /**
- * Copyright (c) 2014, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2014, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 @NamespaceAccessible
 public with sharing class fflib_IDGenerator
 {
@@ -30,8 +30,8 @@ public with sharing class fflib_IDGenerator
 	private static final String ID_PATTERN = '000000000000';
 
 	/**
-	 * Generate a fake Salesforce Id for the given SObjectType
-	 */
+	* Generate a fake Salesforce Id for the given SObjectType
+	*/
 	@NamespaceAccessible
 	public static Id generate(Schema.SObjectType sobjectType)
 	{

--- a/sfdx-source/apex-mocks/main/classes/fflib_IMatcher.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_IMatcher.cls
@@ -1,37 +1,37 @@
 /**
- * Copyright (c) 2014-2016, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2014-2016, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 @NamespaceAccessible
 public interface fflib_IMatcher
 {
 	/**
-	 * Whether or not the supplied argument is a match.
-	 * Any supplementary information (e.g. boundary conditions, objects to match to etc)
-	 * should be cached by the matcher constructor.
-	 * @param arg The argument value supplied to the method
-	 * @return Boolean True if the argument value is a match, false otherwise.
-	 */
+	* Whether or not the supplied argument is a match.
+	* Any supplementary information (e.g. boundary conditions, objects to match to etc)
+	* should be cached by the matcher constructor.
+	* @param arg The argument value supplied to the method
+	* @return Boolean True if the argument value is a match, false otherwise.
+	*/
 	Boolean matches(Object arg);
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_IMatcher.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_IMatcher.cls
@@ -1,37 +1,37 @@
 /**
-* Copyright (c) 2014-2016, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014-2016, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @NamespaceAccessible
 public interface fflib_IMatcher
 {
 	/**
-	* Whether or not the supplied argument is a match.
-	* Any supplementary information (e.g. boundary conditions, objects to match to etc)
-	* should be cached by the matcher constructor.
-	* @param arg The argument value supplied to the method
-	* @return Boolean True if the argument value is a match, false otherwise.
-	*/
+	 * Whether or not the supplied argument is a match.
+	 * Any supplementary information (e.g. boundary conditions, objects to match to etc)
+	 * should be cached by the matcher constructor.
+	 * @param arg The argument value supplied to the method
+	 * @return Boolean True if the argument value is a match, false otherwise.
+	 */
 	Boolean matches(Object arg);
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
@@ -1,32 +1,26 @@
 /*
- Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
-
+Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- * @group Core
- */
+* @group Core
+*/
 @NamespaceAccessible
 public with sharing class fflib_InOrder extends fflib_MethodVerifier
 {
 	private final List<Object> unorderedMockInstances;
 	private Integer idxMethodCall = 0;
 
-	private Set<fflib_VerificationMode.ModeName> notImplementedMethods =
-		new Set<fflib_VerificationMode.ModeName>
-		{
-			fflib_VerificationMode.ModeName.atMost,
-			fflib_VerificationMode.ModeName.between
-		};
+	private Set<fflib_VerificationMode.ModeName> notImplementedMethods = new Set<fflib_VerificationMode.ModeName>{ fflib_VerificationMode.ModeName.atMost, fflib_VerificationMode.ModeName.between };
 
 	private final fflib_ApexMocks mocks;
 
 	/**
-	 * Construct the InOrder instance.
-	 * @param mocks The apex mock object instance.
-	 * @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
-	 * @deprecated Obtain an instance by calling {@link fflib_ApexMocks#inOrder(List&lt;Object&gt;)}
-	 */
+	* Construct the InOrder instance.
+	* @param mocks The apex mock object instance.
+	* @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
+	* @deprecated Obtain an instance by calling {@link fflib_ApexMocks#inOrder(List&lt;Object&gt;)}
+	*/
 	@NamespaceAccessible
 	public fflib_InOrder(fflib_ApexMocks mocks, List<Object> unorderedMockInstances)
 	{
@@ -35,14 +29,14 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/**
-	 * Verify a method was called on a mock object.
-	 * It performs a no strict ordered verification.
-	 * The verification could be either greedy or not depending of the verificationMode passed.
-	 * Check the fflib_VerificationMode methods for details.
-	 * @param mockInstance The mock object instance.
-	 * @param verificationMode Defines the constraints for performing the verification (e.g. the minimum and maximum expected invocation counts).
-	 * @return The mock object instance.
-	 */
+	* Verify a method was called on a mock object.
+	* It performs a no strict ordered verification.
+	* The verification could be either greedy or not depending of the verificationMode passed.
+	* Check the fflib_VerificationMode methods for details.
+	* @param mockInstance The mock object instance.
+	* @param verificationMode Defines the constraints for performing the verification (e.g. the minimum and maximum expected invocation counts).
+	* @return The mock object instance.
+	*/
 	@NamespaceAccessible
 	public Object verify(Object mockInstance, fflib_VerificationMode verificationMode)
 	{
@@ -51,11 +45,11 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/**
-	 * Verify a method was called on a mock object.
-	 * It performs the default times(1) verification for the InOrder.
-	 * @param mockInstance The mock object instance.
-	 * @return The mock object instance.
-	 */
+	* Verify a method was called on a mock object.
+	* It performs the default times(1) verification for the InOrder.
+	* @param mockInstance The mock object instance.
+	* @return The mock object instance.
+	*/
 	@NamespaceAccessible
 	public Object verify(Object mockInstance)
 	{
@@ -64,13 +58,13 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/**
-	 * Verify a method was called on a mock object.
-	 * Wrapper for the new syntax call to be conformed to the old style notation
-	 * It performs the equivalent of times(times) verification for the InOrder.
-	 * @param mockInstance The mock object instance.
-	 * @param times The number of times you expect the method to have been called.
-	 * @return The mock object instance.
-	 */
+	* Verify a method was called on a mock object.
+	* Wrapper for the new syntax call to be conformed to the old style notation
+	* It performs the equivalent of times(times) verification for the InOrder.
+	* @param mockInstance The mock object instance.
+	* @param times The number of times you expect the method to have been called.
+	* @return The mock object instance.
+	*/
 	@NamespaceAccessible
 	public Object verify(Object mockInstance, Integer times)
 	{
@@ -79,53 +73,47 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/**
-	 * Verify that after the last successful verified method no more interactions happened on the inOrderMock instance.
-	 * @throws Exception with message to help to identify the last method called.
-	 */
+	* Verify that after the last successful verified method no more interactions happened on the inOrderMock instance.
+	* @throws Exception with message to help to identify the last method called.
+	*/
 	@NamespaceAccessible
 	public void verifyNoMoreInteractions()
 	{
-		if(idxMethodCall == 0)
+		if (idxMethodCall == 0)
 		{
 			verifyNoInteractions();
 		}
 
-		if(hasNextInteraction(unorderedMockInstances, idxMethodCall))
+		if (hasNextInteraction(unorderedMockInstances, idxMethodCall))
 		{
-			fflib_InvocationOnMock invocation =
-				mocks.getOrderedMethodCalls().get(idxMethodCall -1);
+			fflib_InvocationOnMock invocation = mocks.getOrderedMethodCalls().get(idxMethodCall - 1);
 
-			throw new fflib_ApexMocks.ApexMocksException(
-				'No more Interactions were expected after the ' + invocation.getMethod() +' method.');
+			throw new fflib_ApexMocks.ApexMocksException('No more Interactions were expected after the ' + invocation.getMethod() + ' method.');
 		}
 	}
 
 	/**
-	 * Verify that no interactions at all happened on the inOrderMock instance.
-	 * @throws Exception with message.
-	 */
+	* Verify that no interactions at all happened on the inOrderMock instance.
+	* @throws Exception with message.
+	*/
 	@NamespaceAccessible
 	public void verifyNoInteractions()
 	{
-		if(hasNextInteraction(unorderedMockInstances, 0))
+		if (hasNextInteraction(unorderedMockInstances, 0))
 		{
-			throw new fflib_ApexMocks.ApexMocksException(
-				'No Interactions expected on this InOrder Mock instance!');
+			throw new fflib_ApexMocks.ApexMocksException('No Interactions expected on this InOrder Mock instance!');
 		}
 	}
 
 	/*
-	 * Verifies a method was invoked the expected number of times, with the expected arguments.
-	 * The in-order verifier remembers the last method invocation it successfully verified,
-	 * and only considers subsequent method invocations for subsequent verifications.
-	 * @param qualifiedMethod The method to be verified.
-	 * @param expectedArguments The arguments of the method that needs to be verified.
-	 * @param verificationMode The verification mode that holds the setting about how the verification should be performed.
-	 */
-	protected override void verify(
-		fflib_QualifiedMethod qm,
-		fflib_MethodArgValues expectedArguments,
-		fflib_VerificationMode verificationMode)
+	* Verifies a method was invoked the expected number of times, with the expected arguments.
+	* The in-order verifier remembers the last method invocation it successfully verified,
+	* and only considers subsequent method invocations for subsequent verifications.
+	* @param qualifiedMethod The method to be verified.
+	* @param expectedArguments The arguments of the method that needs to be verified.
+	* @param verificationMode The verification mode that holds the setting about how the verification should be performed.
+	*/
+	protected override void verify(fflib_QualifiedMethod qm, fflib_MethodArgValues expectedArguments, fflib_VerificationMode verificationMode)
 	{
 		String inOrder = ' in order';
 		List<fflib_IMatcher> matchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(expectedArguments.argValues.size()) : null;
@@ -136,30 +124,31 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 			actualArguments.add(invocation.getMethodArgValues());
 		}
 
-		if( verificationMode.VerifyMin == 0 && verificationMode.VerifyMax == 0)
+		if (verificationMode.VerifyMin == 0 && verificationMode.VerifyMax == 0)
 		{
 			Integer methodCounts = countInteractions(matchers, qm, expectedArguments);
-			if(methodCounts != 0 )
+			if (methodCounts != 0)
+			{
 				throwException(qm, inOrder, fflib_ApexMocks.NEVER, '', methodCounts, verificationMode.CustomAssertMessage, expectedArguments, matchers, actualArguments);
+			}
 		}
 
-		Integer i=0;
-		for ( ; i<verificationMode.VerifyMin; i++ )
+		Integer i = 0;
+		for (; i < verificationMode.VerifyMin; i++)
 		{
-			if(!verifyMethodCalled(matchers, qm, expectedArguments))
+			if (!verifyMethodCalled(matchers, qm, expectedArguments))
 			{
 				throwException(qm, inOrder, verificationMode.VerifyMin, '', i, verificationMode.CustomAssertMessage, expectedArguments, matchers, actualArguments);
 			}
 		}
 
-		if( verificationMode.VerifyMin == verificationMode.VerifyMax )
+		if (verificationMode.VerifyMin == verificationMode.VerifyMax)
 		{
-			if(hasNextInteraction(unorderedMockInstances, idxMethodCall))
+			if (hasNextInteraction(unorderedMockInstances, idxMethodCall))
 			{
 				fflib_InvocationOnMock nextMethod = getNextMethodCall(false);
 
-				if(nextMethod.getMethod() == qm &&
-					argumentsMatch(nextMethod.getMethodArgValues(), matchers, expectedArguments))
+				if (nextMethod.getMethod() == qm && argumentsMatch(nextMethod.getMethodArgValues(), matchers, expectedArguments))
 				{
 					Integer methodCounts = i + countInteractions(matchers, qm, expectedArguments);
 					throwException(qm, inOrder, verificationMode.VerifyMin, '', methodCounts, verificationMode.CustomAssertMessage, expectedArguments, matchers, actualArguments);
@@ -170,23 +159,18 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		}
 
 		//consuming all the calls in case is the atLeast or atLeastOnce method
-		if(verificationMode.Method == fflib_VerificationMode.ModeName.atLeast
-			|| verificationMode.Method == fflib_VerificationMode.ModeName.atLeastOnce)
+		if (verificationMode.Method == fflib_VerificationMode.ModeName.atLeast || verificationMode.Method == fflib_VerificationMode.ModeName.atLeastOnce)
 		{
 			consumeInteractions(matchers, qm, expectedArguments);
 		}
 	}
 
-	private Boolean verifyMethodCalled(
-		List<fflib_IMatcher> matchers,
-		fflib_QualifiedMethod qm,
-		fflib_MethodArgValues methodArg)
+	private Boolean verifyMethodCalled(List<fflib_IMatcher> matchers, fflib_QualifiedMethod qm, fflib_MethodArgValues methodArg)
 	{
 		fflib_InvocationOnMock calledMethod = getNextMethodCall();
-		while(calledMethod != null)
+		while (calledMethod != null)
 		{
-			if(calledMethod.getMethod() == qm &&
-				argumentsMatch(calledMethod.getMethodArgValues(), matchers, methodArg))
+			if (calledMethod.getMethod() == qm && argumentsMatch(calledMethod.getMethodArgValues(), matchers, methodArg))
 			{
 				//it's our method
 				if (matchers != null)
@@ -202,21 +186,16 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		return false;
 	}
 
-	private Integer countInteractions(
-		List<fflib_IMatcher> matchers,
-		fflib_QualifiedMethod qualifiedMethod,
-		fflib_MethodArgValues methodArg)
+	private Integer countInteractions(List<fflib_IMatcher> matchers, fflib_QualifiedMethod qualifiedMethod, fflib_MethodArgValues methodArg)
 	{
 		Integer interactionsCouter = 0;
 
-		for (Integer i = idxMethodCall, len = mocks.getOrderedMethodCalls().size(); i<len; i++)
+		for (Integer i = idxMethodCall, len = mocks.getOrderedMethodCalls().size(); i < len; i++)
 		{
 			fflib_InvocationOnMock invocation = mocks.getOrderedMethodCalls().get(i);
 			for (Object mockInstance : unorderedMockInstances)
 			{
-				if (invocation.getMock() === mockInstance
-					&& (qualifiedMethod == invocation.getMethod())
-					&& (argumentsMatch(invocation.getMethodArgValues(), matchers, methodArg)))
+				if (invocation.getMock() === mockInstance && (qualifiedMethod == invocation.getMethod()) && (argumentsMatch(invocation.getMethodArgValues(), matchers, methodArg)))
 				{
 					interactionsCouter++;
 				}
@@ -226,22 +205,17 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		return interactionsCouter;
 	}
 
-	private void consumeInteractions(
-		List<fflib_IMatcher> matchers,
-		fflib_QualifiedMethod qualifiedMethod,
-		fflib_MethodArgValues methodArg)
+	private void consumeInteractions(List<fflib_IMatcher> matchers, fflib_QualifiedMethod qualifiedMethod, fflib_MethodArgValues methodArg)
 	{
 		Integer lastInteracionIndex = 0;
 
 		//going all through the orderedMethodCalls to find all the interaction of the method
-		for (Integer i = idxMethodCall, len = mocks.getOrderedMethodCalls().size(); i<len; i++)
+		for (Integer i = idxMethodCall, len = mocks.getOrderedMethodCalls().size(); i < len; i++)
 		{
 			fflib_InvocationOnMock invocation = mocks.getOrderedMethodCalls().get(i);
 			for (Object mockInstance : unorderedMockInstances)
 			{
-				if (invocation.getMock() === mockInstance
-					&& (qualifiedMethod == invocation.getMethod())
-					&& (argumentsMatch(invocation.getMethodArgValues(), matchers, methodArg)))
+				if (invocation.getMock() === mockInstance && (qualifiedMethod == invocation.getMethod()) && (argumentsMatch(invocation.getMethodArgValues(), matchers, methodArg)))
 				{
 					//it's our method
 					lastInteracionIndex = i;
@@ -257,21 +231,18 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		idxMethodCall = lastInteracionIndex + 1;
 	}
 
-	private Boolean argumentsMatch(
-		fflib_MethodArgValues calledMethodArg,
-		List<fflib_IMatcher> matchers,
-		fflib_MethodArgValues methodArg)
+	private Boolean argumentsMatch(fflib_MethodArgValues calledMethodArg, List<fflib_IMatcher> matchers, fflib_MethodArgValues methodArg)
 	{
 		//Check it was called with the right args.
 		if (matchers != null)
 		{
-			if(fflib_Match.matchesAllArgs(calledMethodArg, matchers))
+			if (fflib_Match.matchesAllArgs(calledMethodArg, matchers))
 			{
 				//Return now we've matched the method call
 				return true;
 			}
 		}
-		else if(calledMethodArg == methodArg)
+		else if (calledMethodArg == methodArg)
 		{
 			//Return now we've matched the method call
 			return true;
@@ -292,10 +263,12 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 		{
 			if (idx == idxMethodCall)
 			{
-				if(isForMockInstance(invocation))
+				if (isForMockInstance(invocation))
 				{
-					if(updateIdxMethodCall)
+					if (updateIdxMethodCall)
+					{
 						idxMethodCall++;
+					}
 					return invocation;
 				}
 			}
@@ -322,11 +295,11 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/*
-	 * Used by the fflib_InOrder invocation verifier to find further interactions with a given mock instances.
-	 * @param mockInstances The tracked mock instances - only methods called on these objects are counted as an invocation.
-	 * @param idxLastMethodCalled The index of the last matched method, used to offset the search for invocations so we don't double count invocations.
-	 * @return Whether or not there were further interactions.
-	 */
+	* Used by the fflib_InOrder invocation verifier to find further interactions with a given mock instances.
+	* @param mockInstances The tracked mock instances - only methods called on these objects are counted as an invocation.
+	* @param idxLastMethodCalled The index of the last matched method, used to offset the search for invocations so we don't double count invocations.
+	* @return Whether or not there were further interactions.
+	*/
 	private Boolean hasNextInteraction(List<Object> mockInstances, Integer idxLastMethodCalled)
 	{
 		Integer idx = 0;
@@ -347,18 +320,17 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/*
-	 * Method that validate the verification mode used in the verify.
-	 * Not all the methods from the fflib_VerificationMode are implemented for the different classes that extends the fflib_MethodVerifier.
-	 * The error is thrown at run time, so this method is called in the method that actually performs the verify.
-	 * @param verificationMode The verification mode that have to been verified.
-	 * @throws Exception with message for the fflib_VerificationMode not implemented.
-	 */
+	* Method that validate the verification mode used in the verify.
+	* Not all the methods from the fflib_VerificationMode are implemented for the different classes that extends the fflib_MethodVerifier.
+	* The error is thrown at run time, so this method is called in the method that actually performs the verify.
+	* @param verificationMode The verification mode that have to been verified.
+	* @throws Exception with message for the fflib_VerificationMode not implemented.
+	*/
 	protected override void validateMode(fflib_VerificationMode verificationMode)
 	{
-		if(notImplementedMethods.contains(verificationMode.Method))
+		if (notImplementedMethods.contains(verificationMode.Method))
 		{
-			throw new fflib_ApexMocks.ApexMocksException(
-				'The ' + verificationMode.Method.name() + ' method is not implemented for the fflib_InOrder class');
+			throw new fflib_ApexMocks.ApexMocksException('The ' + verificationMode.Method.name() + ' method is not implemented for the fflib_InOrder class');
 		}
 	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_InOrder.cls
@@ -3,8 +3,8 @@ Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* @group Core
-*/
+ * @group Core
+ */
 @NamespaceAccessible
 public with sharing class fflib_InOrder extends fflib_MethodVerifier
 {
@@ -16,11 +16,11 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	private final fflib_ApexMocks mocks;
 
 	/**
-	* Construct the InOrder instance.
-	* @param mocks The apex mock object instance.
-	* @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
-	* @deprecated Obtain an instance by calling {@link fflib_ApexMocks#inOrder(List&lt;Object&gt;)}
-	*/
+	 * Construct the InOrder instance.
+	 * @param mocks The apex mock object instance.
+	 * @param unorderedMockInstances One or more mock implementation classes (listed in any order), whose ordered method calls require verification.
+	 * @deprecated Obtain an instance by calling {@link fflib_ApexMocks#inOrder(List&lt;Object&gt;)}
+	 */
 	@NamespaceAccessible
 	public fflib_InOrder(fflib_ApexMocks mocks, List<Object> unorderedMockInstances)
 	{
@@ -29,14 +29,14 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/**
-	* Verify a method was called on a mock object.
-	* It performs a no strict ordered verification.
-	* The verification could be either greedy or not depending of the verificationMode passed.
-	* Check the fflib_VerificationMode methods for details.
-	* @param mockInstance The mock object instance.
-	* @param verificationMode Defines the constraints for performing the verification (e.g. the minimum and maximum expected invocation counts).
-	* @return The mock object instance.
-	*/
+	 * Verify a method was called on a mock object.
+	 * It performs a no strict ordered verification.
+	 * The verification could be either greedy or not depending of the verificationMode passed.
+	 * Check the fflib_VerificationMode methods for details.
+	 * @param mockInstance The mock object instance.
+	 * @param verificationMode Defines the constraints for performing the verification (e.g. the minimum and maximum expected invocation counts).
+	 * @return The mock object instance.
+	 */
 	@NamespaceAccessible
 	public Object verify(Object mockInstance, fflib_VerificationMode verificationMode)
 	{
@@ -45,11 +45,11 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/**
-	* Verify a method was called on a mock object.
-	* It performs the default times(1) verification for the InOrder.
-	* @param mockInstance The mock object instance.
-	* @return The mock object instance.
-	*/
+	 * Verify a method was called on a mock object.
+	 * It performs the default times(1) verification for the InOrder.
+	 * @param mockInstance The mock object instance.
+	 * @return The mock object instance.
+	 */
 	@NamespaceAccessible
 	public Object verify(Object mockInstance)
 	{
@@ -58,13 +58,13 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/**
-	* Verify a method was called on a mock object.
-	* Wrapper for the new syntax call to be conformed to the old style notation
-	* It performs the equivalent of times(times) verification for the InOrder.
-	* @param mockInstance The mock object instance.
-	* @param times The number of times you expect the method to have been called.
-	* @return The mock object instance.
-	*/
+	 * Verify a method was called on a mock object.
+	 * Wrapper for the new syntax call to be conformed to the old style notation
+	 * It performs the equivalent of times(times) verification for the InOrder.
+	 * @param mockInstance The mock object instance.
+	 * @param times The number of times you expect the method to have been called.
+	 * @return The mock object instance.
+	 */
 	@NamespaceAccessible
 	public Object verify(Object mockInstance, Integer times)
 	{
@@ -73,9 +73,9 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/**
-	* Verify that after the last successful verified method no more interactions happened on the inOrderMock instance.
-	* @throws Exception with message to help to identify the last method called.
-	*/
+	 * Verify that after the last successful verified method no more interactions happened on the inOrderMock instance.
+	 * @throws Exception with message to help to identify the last method called.
+	 */
 	@NamespaceAccessible
 	public void verifyNoMoreInteractions()
 	{
@@ -93,9 +93,9 @@ public with sharing class fflib_InOrder extends fflib_MethodVerifier
 	}
 
 	/**
-	* Verify that no interactions at all happened on the inOrderMock instance.
-	* @throws Exception with message.
-	*/
+	 * Verify that no interactions at all happened on the inOrderMock instance.
+	 * @throws Exception with message.
+	 */
 	@NamespaceAccessible
 	public void verifyNoInteractions()
 	{

--- a/sfdx-source/apex-mocks/main/classes/fflib_Inheritor.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_Inheritor.cls
@@ -1,15 +1,33 @@
 /*
- * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
- */
-@isTest
+* Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
+*/
+@IsTest
 @NamespaceAccessible
 public class fflib_Inheritor implements IA, IB, IC
 {
-	public interface IA {String doA();}
-    public interface IB {String doB();}
-    public interface IC {String doC();}
-    
-    public String doA(){return 'Did A';}
-    public String doB(){return 'Did B';}
-    public String doC(){return 'Did C';}
+	public interface IA
+	{
+		String doA();
+	}
+	public interface IB
+	{
+		String doB();
+	}
+	public interface IC
+	{
+		String doC();
+	}
+
+	public String doA()
+	{
+		return 'Did A';
+	}
+	public String doB()
+	{
+		return 'Did B';
+	}
+	public String doC()
+	{
+		return 'Did C';
+	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_InvocationOnMock.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_InvocationOnMock.cls
@@ -1,12 +1,12 @@
 /*
- Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- *	An invocation on a mock.
- *	A place holder for mock, the method that was called and the arguments that were passed.
- *	@group Core
- */
+* An invocation on a mock.
+* A place holder for mock, the method that was called and the arguments that were passed.
+* @group Core
+*/
 @NamespaceAccessible
 public with sharing class fflib_InvocationOnMock
 {
@@ -15,11 +15,11 @@ public with sharing class fflib_InvocationOnMock
 	private Object mockInstance;
 
 	/**
-	 *	Constructor for the class.
-	 *  @param qm The fflib_QualifiedMethod instance to be stored.
-	 *  @param args The fflib_MethodArgValues instance to be stored.
-	 *  @param mockInstance The mock instance to be stored.
-	 */
+	* Constructor for the class.
+	* @param qm The fflib_QualifiedMethod instance to be stored.
+	* @param args The fflib_MethodArgValues instance to be stored.
+	* @param mockInstance The mock instance to be stored.
+	*/
 	@NamespaceAccessible
 	public fflib_InvocationOnMock(fflib_QualifiedMethod qm, fflib_MethodArgValues args, Object mockInstance)
 	{
@@ -29,22 +29,23 @@ public with sharing class fflib_InvocationOnMock
 	}
 
 	/**
-	 *	Returns the argument at the given index.
-	 *  @param index The index of the wanted argument.
-	 *  @throws ApexMocksException in case the index is out of range.
-	 *  @return The argument at the given index.
-	 */
+	* Returns the argument at the given index.
+	* @param index The index of the wanted argument.
+	* @throws ApexMocksException in case the index is out of range.
+	* @return The argument at the given index.
+	*/
 	@NamespaceAccessible
 	public Object getArgument(Integer index)
 	{
 		validateIndex(index);
-		return methodArg.argValues[index];
+		return methodArg
+		.argValues[index];
 	}
 
 	/**
-	 *	Returns the list of arguments passed to the method.
-	 *  @return The list of arguments.
-	 */
+	* Returns the list of arguments passed to the method.
+	* @return The list of arguments.
+	*/
 	@NamespaceAccessible
 	public List<Object> getArguments()
 	{
@@ -52,9 +53,9 @@ public with sharing class fflib_InvocationOnMock
 	}
 
 	/**
-	 *	Returns fflib_MethodArgValues instance that represents the arguments passed to the method.
-	 *  @return The fflib_MethodArgValues instance that represents the arguments passed to the method.
-	 */
+	* Returns fflib_MethodArgValues instance that represents the arguments passed to the method.
+	* @return The fflib_MethodArgValues instance that represents the arguments passed to the method.
+	*/
 	@NamespaceAccessible
 	public fflib_MethodArgValues getMethodArgValues()
 	{
@@ -62,9 +63,9 @@ public with sharing class fflib_InvocationOnMock
 	}
 
 	/**
-	 *	Returns the fflib_QualifiedMethod instance that represent the fully qualified method called within the invocation.
-	 *	@return The method stored in the invocation.
-	 */
+	* Returns the fflib_QualifiedMethod instance that represent the fully qualified method called within the invocation.
+	* @return The method stored in the invocation.
+	*/
 	@NamespaceAccessible
 	public fflib_QualifiedMethod getMethod()
 	{
@@ -72,9 +73,9 @@ public with sharing class fflib_InvocationOnMock
 	}
 
 	/**
-	 *	Returns the mock object on which the invocation occurs.
-	 *	@return The mock object on which the invocation occurs.
-	 */
+	* Returns the mock object on which the invocation occurs.
+	* @return The mock object on which the invocation occurs.
+	*/
 	@NamespaceAccessible
 	public Object getMock()
 	{
@@ -83,9 +84,9 @@ public with sharing class fflib_InvocationOnMock
 
 	private void validateIndex(Integer index)
 	{
-		if(index < 0 || index >= methodArg.argValues.size())
+		if (index < 0 || index >= methodArg.argValues.size())
 		{
-			throw new fflib_ApexMocks.ApexMocksException('Invalid index, must be greater or equal to zero and less of ' + methodArg.argValues.size()+'.');
+			throw new fflib_ApexMocks.ApexMocksException('Invalid index, must be greater or equal to zero and less of ' + methodArg.argValues.size() + '.');
 		}
 	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_InvocationOnMock.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_InvocationOnMock.cls
@@ -3,10 +3,10 @@ Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* An invocation on a mock.
-* A place holder for mock, the method that was called and the arguments that were passed.
-* @group Core
-*/
+ * An invocation on a mock.
+ * A place holder for mock, the method that was called and the arguments that were passed.
+ * @group Core
+ */
 @NamespaceAccessible
 public with sharing class fflib_InvocationOnMock
 {
@@ -15,11 +15,11 @@ public with sharing class fflib_InvocationOnMock
 	private Object mockInstance;
 
 	/**
-	* Constructor for the class.
-	* @param qm The fflib_QualifiedMethod instance to be stored.
-	* @param args The fflib_MethodArgValues instance to be stored.
-	* @param mockInstance The mock instance to be stored.
-	*/
+	 * Constructor for the class.
+	 * @param qm The fflib_QualifiedMethod instance to be stored.
+	 * @param args The fflib_MethodArgValues instance to be stored.
+	 * @param mockInstance The mock instance to be stored.
+	 */
 	@NamespaceAccessible
 	public fflib_InvocationOnMock(fflib_QualifiedMethod qm, fflib_MethodArgValues args, Object mockInstance)
 	{
@@ -29,11 +29,11 @@ public with sharing class fflib_InvocationOnMock
 	}
 
 	/**
-	* Returns the argument at the given index.
-	* @param index The index of the wanted argument.
-	* @throws ApexMocksException in case the index is out of range.
-	* @return The argument at the given index.
-	*/
+	 * Returns the argument at the given index.
+	 * @param index The index of the wanted argument.
+	 * @throws ApexMocksException in case the index is out of range.
+	 * @return The argument at the given index.
+	 */
 	@NamespaceAccessible
 	public Object getArgument(Integer index)
 	{
@@ -43,9 +43,9 @@ public with sharing class fflib_InvocationOnMock
 	}
 
 	/**
-	* Returns the list of arguments passed to the method.
-	* @return The list of arguments.
-	*/
+	 * Returns the list of arguments passed to the method.
+	 * @return The list of arguments.
+	 */
 	@NamespaceAccessible
 	public List<Object> getArguments()
 	{
@@ -53,9 +53,9 @@ public with sharing class fflib_InvocationOnMock
 	}
 
 	/**
-	* Returns fflib_MethodArgValues instance that represents the arguments passed to the method.
-	* @return The fflib_MethodArgValues instance that represents the arguments passed to the method.
-	*/
+	 * Returns fflib_MethodArgValues instance that represents the arguments passed to the method.
+	 * @return The fflib_MethodArgValues instance that represents the arguments passed to the method.
+	 */
 	@NamespaceAccessible
 	public fflib_MethodArgValues getMethodArgValues()
 	{
@@ -63,9 +63,9 @@ public with sharing class fflib_InvocationOnMock
 	}
 
 	/**
-	* Returns the fflib_QualifiedMethod instance that represent the fully qualified method called within the invocation.
-	* @return The method stored in the invocation.
-	*/
+	 * Returns the fflib_QualifiedMethod instance that represent the fully qualified method called within the invocation.
+	 * @return The method stored in the invocation.
+	 */
 	@NamespaceAccessible
 	public fflib_QualifiedMethod getMethod()
 	{
@@ -73,9 +73,9 @@ public with sharing class fflib_InvocationOnMock
 	}
 
 	/**
-	* Returns the mock object on which the invocation occurs.
-	* @return The mock object on which the invocation occurs.
-	*/
+	 * Returns the mock object on which the invocation occurs.
+	 * @return The mock object on which the invocation occurs.
+	 */
 	@NamespaceAccessible
 	public Object getMock()
 	{

--- a/sfdx-source/apex-mocks/main/classes/fflib_Match.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_Match.cls
@@ -1,45 +1,45 @@
 /**
-* Copyright (c) 2014, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @NamespaceAccessible
 public class fflib_Match
 {
 	private static List<fflib_IMatcher> matchers = new List<fflib_IMatcher>();
 
 	/**
-	* Matching
-	* True when comparing method arg values to matchers, false when comparing absolute arg values.
-	*/
+	 * Matching
+	 * True when comparing method arg values to matchers, false when comparing absolute arg values.
+	 */
 	public static Boolean Matching = false;
 
 	/**
-	* Used internally by the mocking framework, you shouldn't need to call this method directly.
-	* Copies the registered matchers, and then switches matching mode off.
-	* @param expectedSize The expected number of matchers to be returned. If this does not match the actual value an expection is thrown.
-	* @return List<fflib_IMatcher> The registered matchers, collected while in matching mode.
-	*/
+	 * Used internally by the mocking framework, you shouldn't need to call this method directly.
+	 * Copies the registered matchers, and then switches matching mode off.
+	 * @param expectedSize The expected number of matchers to be returned. If this does not match the actual value an expection is thrown.
+	 * @return List<fflib_IMatcher> The registered matchers, collected while in matching mode.
+	 */
 	@NamespaceAccessible
 	public static List<fflib_IMatcher> getAndClearMatchers(Integer expectedSize)
 	{
@@ -66,13 +66,13 @@ public class fflib_Match
 	}
 
 	/**
-	* Used internally by the mocking framework, you shouldn't need to call this method directly.
-	* Compares all supplied method arg values to the supplied target matchers.
-	* @param methodArg The arguments supplied when the method was called
-	* @param targetMatchers The matchers the arguments need to be compared with
-	* @throws fflib_ApexMocks.ApexMocksException Thrown when methodArgValues is null/empty, targetMatchers is null, or their sizes don't match
-	* @return Boolean True if all arg values satisfy all of the supplied matchers.
-	*/
+	 * Used internally by the mocking framework, you shouldn't need to call this method directly.
+	 * Compares all supplied method arg values to the supplied target matchers.
+	 * @param methodArg The arguments supplied when the method was called
+	 * @param targetMatchers The matchers the arguments need to be compared with
+	 * @throws fflib_ApexMocks.ApexMocksException Thrown when methodArgValues is null/empty, targetMatchers is null, or their sizes don't match
+	 * @return Boolean True if all arg values satisfy all of the supplied matchers.
+	 */
 	@NamespaceAccessible
 	public static Boolean matchesAllArgs(fflib_MethodArgValues methodArg, List<fflib_IMatcher> targetMatchers)
 	{
@@ -117,11 +117,11 @@ public class fflib_Match
 	}
 
 	/**
-	* Registers a matcher which will be stubbed/verified against.
-	* @param matcher The matcher that needs to be compared
-	* @return Object Always returns null. This can then be cast into the correct arg type
-	* so that the right method is called on the mock objects.
-	*/
+	 * Registers a matcher which will be stubbed/verified against.
+	 * @param matcher The matcher that needs to be compared
+	 * @return Object Always returns null. This can then be cast into the correct arg type
+	 * so that the right method is called on the mock objects.
+	 */
 	@NamespaceAccessible
 	public static Object matches(fflib_IMatcher matcher)
 	{
@@ -132,154 +132,154 @@ public class fflib_Match
 	}
 
 	/**
-	* COMBINED MATCHER
-	* The allOf, anyOf and noneOf methods are overloaded to provide fluent matcher calls for up to 4 matcher conditions.
-	* To connect 5 or more, the List<Object> version directly.
-	*/
+	 * COMBINED MATCHER
+	 * The allOf, anyOf and noneOf methods are overloaded to provide fluent matcher calls for up to 4 matcher conditions.
+	 * To connect 5 or more, the List<Object> version directly.
+	 */
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches allOf
-	* @param o1 A dummy object returned by registering another matcher
-	* @param o2 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)public static Object allOf(Object o1, Object o2)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches allOf
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @param o2 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)public static Object allOf(Object o1, Object o2)
+	 */
 	public static Object allOf(Object o1, Object o2)
 	{
 		return allOf(new Object[]{ o1, o2 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches allOf
-	* @param o1 A dummy object returned by registering another matcher
-	* @param o2 A dummy object returned by registering another matcher
-	* @param o3 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches allOf
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @param o2 A dummy object returned by registering another matcher
+	 * @param o3 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object allOf(Object o1, Object o2, Object o3)
 	{
 		return allOf(new Object[]{ o1, o2, o3 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches allOf
-	* @param o1 A dummy object returned by registering another matcher
-	* @param o2 A dummy object returned by registering another matcher
-	* @param o3 A dummy object returned by registering another matcher
-	* @param o4 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches allOf
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @param o2 A dummy object returned by registering another matcher
+	 * @param o3 A dummy object returned by registering another matcher
+	 * @param o4 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object allOf(Object o1, Object o2, Object o3, Object o4)
 	{
 		return allOf(new Object[]{ o1, o2, o3, o4 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches allOf
-	* @param o A list of dummy objects returned by registering other matchers
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches allOf
+	 * @param o A list of dummy objects returned by registering other matchers
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object allOf(List<Object> o)
 	{
 		return combined(fflib_MatcherDefinitions.Connective.ALL, o);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyOf
-	* @param o1 A dummy object returned by registering another matcher
-	* @param o2 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyOf
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @param o2 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object anyOf(Object o1, Object o2)
 	{
 		return anyOf(new Object[]{ o1, o2 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyOf
-	* @param o1 A dummy object returned by registering another matcher
-	* @param o2 A dummy object returned by registering another matcher
-	* @param o3 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyOf
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @param o2 A dummy object returned by registering another matcher
+	 * @param o3 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object anyOf(Object o1, Object o2, Object o3)
 	{
 		return anyOf(new Object[]{ o1, o2, o3 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyOf
-	* @param o1 A dummy object returned by registering another matcher
-	* @param o2 A dummy object returned by registering another matcher
-	* @param o3 A dummy object returned by registering another matcher
-	* @param o4 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyOf
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @param o2 A dummy object returned by registering another matcher
+	 * @param o3 A dummy object returned by registering another matcher
+	 * @param o4 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object anyOf(Object o1, Object o2, Object o3, Object o4)
 	{
 		return anyOf(new Object[]{ o1, o2, o3, o4 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyOf
-	* @param o A list of dummy objects returned by registering other matchers
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyOf
+	 * @param o A list of dummy objects returned by registering other matchers
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object anyOf(List<Object> o)
 	{
 		return combined(fflib_MatcherDefinitions.Connective.AT_LEAST_ONE, o);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches isNot
-	* @param o1 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches isNot
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object isNot(Object o1)
 	{
 		return noneOf(new Object[]{ o1 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches noneOf
-	* @param o1 A dummy object returned by registering another matcher
-	* @param o2 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches noneOf
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @param o2 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object noneOf(Object o1, Object o2)
 	{
 		return noneOf(new Object[]{ o1, o2 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches noneOf
-	* @param o1 A dummy object returned by registering another matcher
-	* @param o2 A dummy object returned by registering another matcher
-	* @param o3 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches noneOf
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @param o2 A dummy object returned by registering another matcher
+	 * @param o3 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object noneOf(Object o1, Object o2, Object o3)
 	{
 		return noneOf(new Object[]{ o1, o2, o3 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches noneOf
-	* @param o1 A dummy object returned by registering another matcher
-	* @param o2 A dummy object returned by registering another matcher
-	* @param o3 A dummy object returned by registering another matcher
-	* @param o4 A dummy object returned by registering another matcher
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches noneOf
+	 * @param o1 A dummy object returned by registering another matcher
+	 * @param o2 A dummy object returned by registering another matcher
+	 * @param o3 A dummy object returned by registering another matcher
+	 * @param o4 A dummy object returned by registering another matcher
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object noneOf(Object o1, Object o2, Object o3, Object o4)
 	{
 		return noneOf(new Object[]{ o1, o2, o3, o4 });
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches noneOf
-	* @param o A list of dummy objects returned by registering other matchers
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches noneOf
+	 * @param o A list of dummy objects returned by registering other matchers
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object noneOf(List<Object> o)
 	{
 		return combined(fflib_MatcherDefinitions.Connective.NONE, o);
@@ -327,837 +327,837 @@ public class fflib_Match
 	}
 
 	/**
-	* ALL OTHER MATCHER METHODS
-	*/
+	 * ALL OTHER MATCHER METHODS
+	 */
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eq
-	* @param toMatch The Object to be compared
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eq
+	 * @param toMatch The Object to be compared
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object eq(Object toMatch)
 	{
 		return matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqBoolean
-	* @param toMatch The Boolean to be compared
-	* @return Boolean A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqBoolean
+	 * @param toMatch The Boolean to be compared
+	 * @return Boolean A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Boolean eqBoolean(Boolean toMatch)
 	{
 		return (Boolean) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqDate
-	* @param toMatch The Date to be compared
-	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqDate
+	 * @param toMatch The Date to be compared
+	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Date eqDate(Date toMatch)
 	{
 		return (Date) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqDatetime
-	* @param toMatch The Datetime to be compared
-	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqDatetime
+	 * @param toMatch The Datetime to be compared
+	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Datetime eqDatetime(Datetime toMatch)
 	{
 		return (Datetime) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqDecimal
-	* @param toMatch The Decimal to be compared
-	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqDecimal
+	 * @param toMatch The Decimal to be compared
+	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Decimal eqDecimal(Decimal toMatch)
 	{
 		return (Decimal) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqDouble
-	* @param toMatch The Double to be compared
-	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqDouble
+	 * @param toMatch The Double to be compared
+	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Double eqDouble(Double toMatch)
 	{
 		return (Double) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqId
-	* @param toMatch The Id to be compared
-	* @return Id A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqId
+	 * @param toMatch The Id to be compared
+	 * @return Id A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Id eqId(Id toMatch)
 	{
 		return (Id) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqInteger
-	* @param toMatch The Integer to be compared
-	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqInteger
+	 * @param toMatch The Integer to be compared
+	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Integer eqInteger(Integer toMatch)
 	{
 		return (Integer) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqList
-	* @param toMatch The List to be compared
-	* @return List A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqList
+	 * @param toMatch The List to be compared
+	 * @return List A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static List<Object> eqList(List<Object> toMatch)
 	{
 		return (List<Object>) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqLong
-	* @param toMatch The Long to be compared
-	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqLong
+	 * @param toMatch The Long to be compared
+	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Long eqLong(Long toMatch)
 	{
 		return (Long) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqSObjectField
-	* @param toMatch The SObjectField to be compared
-	* @return SObjectField A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqSObjectField
+	 * @param toMatch The SObjectField to be compared
+	 * @return SObjectField A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static SObjectField eqSObjectField(SObjectField toMatch)
 	{
 		return (SObjectField) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqSObjectType
-	* @param toMatch The SObjectType to be compared
-	* @return SObjectType A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqSObjectType
+	 * @param toMatch The SObjectType to be compared
+	 * @return SObjectType A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static SObjectType eqSObjectType(SObjectType toMatch)
 	{
 		return (SObjectType) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches eqString
-	* @param toMatch The String to be compared
-	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches eqString
+	 * @param toMatch The String to be compared
+	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static String eqString(String toMatch)
 	{
 		return (String) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches refEq
-	* @param toMatch The Object to be compared
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches refEq
+	 * @param toMatch The Object to be compared
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object refEq(Object toMatch)
 	{
 		return matches(new fflib_MatcherDefinitions.RefEq(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyBoolean
-	* @return Boolean A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyBoolean
+	 * @return Boolean A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Boolean anyBoolean()
 	{
 		return (Boolean) matches(new fflib_MatcherDefinitions.AnyBoolean());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyDate
-	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyDate
+	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Date anyDate()
 	{
 		return (Date) matches(new fflib_MatcherDefinitions.AnyDate());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyDatetime
-	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyDatetime
+	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Datetime anyDatetime()
 	{
 		return (Datetime) matches(new fflib_MatcherDefinitions.AnyDatetime());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyDecimal
-	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyDecimal
+	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Decimal anyDecimal()
 	{
 		return (Decimal) matches(new fflib_MatcherDefinitions.AnyDecimal());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyDouble
-	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyDouble
+	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Double anyDouble()
 	{
 		return (Double) matches(new fflib_MatcherDefinitions.AnyDouble());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyFieldSet
-	* @return Schema.FieldSet A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyFieldSet
+	 * @return Schema.FieldSet A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Schema.FieldSet anyFieldSet()
 	{
 		return (Schema.FieldSet) matches(new fflib_MatcherDefinitions.AnyFieldSet());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyId
-	* @return Id A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyId
+	 * @return Id A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Id anyId()
 	{
 		return (Id) matches(new fflib_MatcherDefinitions.AnyId());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyInteger
-	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyInteger
+	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Integer anyInteger()
 	{
 		return (Integer) matches(new fflib_MatcherDefinitions.AnyInteger());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyList
-	* @return List A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyList
+	 * @return List A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static List<Object> anyList()
 	{
 		return (List<Object>) matches(new fflib_MatcherDefinitions.AnyList());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyLong
-	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyLong
+	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Long anyLong()
 	{
 		return (Long) matches(new fflib_MatcherDefinitions.AnyLong());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyObject
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyObject
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object anyObject()
 	{
 		return matches(new fflib_MatcherDefinitions.AnyObject());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anyString
-	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anyString
+	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static String anyString()
 	{
 		return (String) matches(new fflib_MatcherDefinitions.AnyString());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anySObject
-	* @return SObject A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anySObject
+	 * @return SObject A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static SObject anySObject()
 	{
 		return (SObject) matches(new fflib_MatcherDefinitions.AnySObject());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anySObjectField
-	* @return SObjectField A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anySObjectField
+	 * @return SObjectField A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static SObjectField anySObjectField()
 	{
 		return (SObjectField) matches(new fflib_MatcherDefinitions.AnySObjectField());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches anySObjectType
-	* @return SObjectType A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches anySObjectType
+	 * @return SObjectType A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static SObjectType anySObjectType()
 	{
 		return (SObjectType) matches(new fflib_MatcherDefinitions.AnySObjectType());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches dateAfter (not inclusive)
-	* @param fromDate The Date to be compared
-	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches dateAfter (not inclusive)
+	 * @param fromDate The Date to be compared
+	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Date dateAfter(Date fromDate)
 	{
 		return dateAfter(fromDate, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches dateAfter
-	* @param fromDate The Date to be compared
-	* @param inclusive Whether or not a Date equal to fromDate should be considered a match
-	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches dateAfter
+	 * @param fromDate The Date to be compared
+	 * @param inclusive Whether or not a Date equal to fromDate should be considered a match
+	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Date dateAfter(Date fromDate, Boolean inclusive)
 	{
 		return (Date) matches(new fflib_MatcherDefinitions.DatetimeAfter(fromDate, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches dateBefore (not inclusive)
-	* @param toDate The Date to be compared
-	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches dateBefore (not inclusive)
+	 * @param toDate The Date to be compared
+	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Date dateBefore(Date toDate)
 	{
 		return dateBefore(toDate, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches dateBefore
-	* @param toDate The Date to be compared
-	* @param inclusive Whether or not a Date equal to toDate should be considered a match
-	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches dateBefore
+	 * @param toDate The Date to be compared
+	 * @param inclusive Whether or not a Date equal to toDate should be considered a match
+	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Date dateBefore(Date toDate, Boolean inclusive)
 	{
 		return (Date) matches(new fflib_MatcherDefinitions.DatetimeBefore(toDate, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches dateBetween (not inclusive)
-	* @param fromDate The lower bound Date to be compared
-	* @param toDate The upper bound Date to be compared
-	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches dateBetween (not inclusive)
+	 * @param fromDate The lower bound Date to be compared
+	 * @param toDate The upper bound Date to be compared
+	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Date dateBetween(Date fromDate, Date toDate)
 	{
 		return dateBetween(fromDate, false, toDate, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches dateBetween
-	* @param fromDate The lower bound Date to be compared
-	* @param inclusiveFrom Whether or not a Date equal to fromDate should be considered a match
-	* @param toDate The upper bound Date to be compared
-	* @param inclusiveTo Whether or not a Date equal to toDate should be considered a match
-	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches dateBetween
+	 * @param fromDate The lower bound Date to be compared
+	 * @param inclusiveFrom Whether or not a Date equal to fromDate should be considered a match
+	 * @param toDate The upper bound Date to be compared
+	 * @param inclusiveTo Whether or not a Date equal to toDate should be considered a match
+	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Date dateBetween(Date fromDate, Boolean inclusiveFrom, Date toDate, Boolean inclusiveTo)
 	{
 		return (Date) matches(new fflib_MatcherDefinitions.DatetimeBetween(fromDate, inclusiveFrom, toDate, inclusiveTo));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches datetimeAfter (not inclusive)
-	* @param fromDate The Datetime to be compared
-	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches datetimeAfter (not inclusive)
+	 * @param fromDate The Datetime to be compared
+	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Datetime datetimeAfter(Datetime fromDate)
 	{
 		return datetimeAfter(fromDate, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches datetimeAfter
-	* @param fromDate The Datetime to be compared
-	* @param inclusive Whether or not a Datetime equal to fromDate should be considered a match
-	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches datetimeAfter
+	 * @param fromDate The Datetime to be compared
+	 * @param inclusive Whether or not a Datetime equal to fromDate should be considered a match
+	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Datetime datetimeAfter(Datetime fromDate, Boolean inclusive)
 	{
 		return (Datetime) matches(new fflib_MatcherDefinitions.DatetimeAfter(fromDate, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches datetimeBefore (not inclusive)
-	* @param toDate The Datetime to be compared
-	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches datetimeBefore (not inclusive)
+	 * @param toDate The Datetime to be compared
+	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Datetime datetimeBefore(Datetime toDate)
 	{
 		return datetimeBefore(toDate, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches datetimeBefore
-	* @param toDate The Datetime to be compared
-	* @param inclusive Whether or not a Datetime equal to toDate should be considered a match
-	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches datetimeBefore
+	 * @param toDate The Datetime to be compared
+	 * @param inclusive Whether or not a Datetime equal to toDate should be considered a match
+	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Datetime datetimeBefore(Datetime toDate, Boolean inclusive)
 	{
 		return (Datetime) matches(new fflib_MatcherDefinitions.DatetimeBefore(toDate, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches datetimeBetween (not inclusive)
-	* @param fromDate The lower bound Datetime to be compared
-	* @param toDate The upper bound Datetime to be compared
-	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches datetimeBetween (not inclusive)
+	 * @param fromDate The lower bound Datetime to be compared
+	 * @param toDate The upper bound Datetime to be compared
+	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Datetime datetimeBetween(Datetime fromDate, Datetime toDate)
 	{
 		return datetimeBetween(fromDate, false, toDate, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches datetimeBetween
-	* @param fromDate The lower bound Datetime to be compared
-	* @param inclusiveFrom Whether or not a Datetime equal to fromDate should be considered a match
-	* @param toDate The upper bound Datetime to be compared
-	* @param inclusiveTo Whether or not a Datetime equal to toDate should be considered a match
-	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches datetimeBetween
+	 * @param fromDate The lower bound Datetime to be compared
+	 * @param inclusiveFrom Whether or not a Datetime equal to fromDate should be considered a match
+	 * @param toDate The upper bound Datetime to be compared
+	 * @param inclusiveTo Whether or not a Datetime equal to toDate should be considered a match
+	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Datetime datetimeBetween(Datetime fromDate, Boolean inclusiveFrom, Datetime toDate, Boolean inclusiveTo)
 	{
 		return (Datetime) matches(new fflib_MatcherDefinitions.DatetimeBetween(fromDate, inclusiveFrom, toDate, inclusiveTo));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches decimalBetween (not inclusive)
-	* @param lower The lower number to be compared
-	* @param upper The upper number to be compared
-	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches decimalBetween (not inclusive)
+	 * @param lower The lower number to be compared
+	 * @param upper The upper number to be compared
+	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Decimal decimalBetween(Decimal lower, Decimal upper)
 	{
 		return decimalBetween(lower, false, upper, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches decimalBetween
-	* @param lower The lower number to be compared
-	* @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
-	* @param upper The upper number to be compared
-	* @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
-	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches decimalBetween
+	 * @param lower The lower number to be compared
+	 * @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
+	 * @param upper The upper number to be compared
+	 * @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
+	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Decimal decimalBetween(Decimal lower, Boolean inclusiveLower, Decimal upper, Boolean inclusiveUpper)
 	{
 		return (Decimal) matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches decimalLessThan (not inclusive)
-	* @param toMatch The number to be compared
-	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches decimalLessThan (not inclusive)
+	 * @param toMatch The number to be compared
+	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Decimal decimalLessThan(Decimal toMatch)
 	{
 		return decimalLessThan(toMatch, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches decimalLessThan
-	* @param toMatch The number to be compared
-	* @param inclusive Whether or not a number equal to toMatch should be considered a match
-	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches decimalLessThan
+	 * @param toMatch The number to be compared
+	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
+	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Decimal decimalLessThan(Decimal toMatch, Boolean inclusive)
 	{
 		return (Decimal) matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches decimalMoreThan (not inclusive)
-	* @param toMatch The number to be compared
-	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches decimalMoreThan (not inclusive)
+	 * @param toMatch The number to be compared
+	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Decimal decimalMoreThan(Decimal toMatch)
 	{
 		return decimalMoreThan(toMatch, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches decimalMoreThan
-	* @param toMatch The number to be compared
-	* @param inclusive Whether or not a number equal to toMatch should be considered a match
-	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches decimalMoreThan
+	 * @param toMatch The number to be compared
+	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
+	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Decimal decimalMoreThan(Decimal toMatch, Boolean inclusive)
 	{
 		return (Decimal) matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches doubleBetween (not inclusive)
-	* @param lower The lower number to be compared
-	* @param upper The upper number to be compared
-	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches doubleBetween (not inclusive)
+	 * @param lower The lower number to be compared
+	 * @param upper The upper number to be compared
+	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Double doubleBetween(Double lower, Double upper)
 	{
 		return doubleBetween(lower, false, upper, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches doubleBetween
-	* @param lower The lower number to be compared
-	* @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
-	* @param upper The upper number to be compared
-	* @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
-	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches doubleBetween
+	 * @param lower The lower number to be compared
+	 * @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
+	 * @param upper The upper number to be compared
+	 * @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
+	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Double doubleBetween(Double lower, Boolean inclusiveLower, Double upper, Boolean inclusiveUpper)
 	{
 		return (Double) matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches doubleLessThan (not inclusive)
-	* @param toMatch The number to be compared
-	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches doubleLessThan (not inclusive)
+	 * @param toMatch The number to be compared
+	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Double doubleLessThan(Double toMatch)
 	{
 		return doubleLessThan(toMatch, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches doubleLessThan
-	* @param toMatch The number to be compared
-	* @param inclusive Whether or not a number equal to toMatch should be considered a match
-	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches doubleLessThan
+	 * @param toMatch The number to be compared
+	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
+	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Double doubleLessThan(Double toMatch, Boolean inclusive)
 	{
 		return (Double) matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches doubleMoreThan (not inclusive)
-	* @param toMatch The number to be compared
-	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches doubleMoreThan (not inclusive)
+	 * @param toMatch The number to be compared
+	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Double doubleMoreThan(Double toMatch)
 	{
 		return doubleMoreThan(toMatch, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches doubleMoreThan
-	* @param toMatch The number to be compared
-	* @param inclusive Whether or not a number equal to toMatch should be considered a match
-	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches doubleMoreThan
+	 * @param toMatch The number to be compared
+	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
+	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Double doubleMoreThan(Double toMatch, Boolean inclusive)
 	{
 		return (Double) matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches FieldSetEquivalentTo
-	* @param toMatch The fieldSet to be compared
-	* @return Schema.FieldSet A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches FieldSetEquivalentTo
+	 * @param toMatch The fieldSet to be compared
+	 * @return Schema.FieldSet A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Schema.FieldSet fieldSetEquivalentTo(Schema.FieldSet toMatch)
 	{
 		return (Schema.FieldSet) matches(new fflib_MatcherDefinitions.FieldSetEquivalentTo(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches integerBetween (not inclusive)
-	* @param lower The lower number to be compared
-	* @param upper The upper number to be compared
-	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches integerBetween (not inclusive)
+	 * @param lower The lower number to be compared
+	 * @param upper The upper number to be compared
+	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Integer integerBetween(Integer lower, Integer upper)
 	{
 		return integerBetween(lower, false, upper, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches integerBetween
-	* @param lower The lower number to be compared
-	* @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
-	* @param upper The upper number to be compared
-	* @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
-	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches integerBetween
+	 * @param lower The lower number to be compared
+	 * @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
+	 * @param upper The upper number to be compared
+	 * @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
+	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Integer integerBetween(Integer lower, Boolean inclusiveLower, Integer upper, Boolean inclusiveUpper)
 	{
 		return (Integer) matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches integerLessThan (not inclusive)
-	* @param toMatch The number to be compared
-	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches integerLessThan (not inclusive)
+	 * @param toMatch The number to be compared
+	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Integer integerLessThan(Integer toMatch)
 	{
 		return integerLessThan(toMatch, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches integerLessThan
-	* @param toMatch The number to be compared
-	* @param inclusive Whether or not a number equal to toMatch should be considered a match
-	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches integerLessThan
+	 * @param toMatch The number to be compared
+	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
+	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Integer integerLessThan(Integer toMatch, Boolean inclusive)
 	{
 		return (Integer) matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches integerMoreThan (not inclusive)
-	* @param toMatch The number to be compared
-	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches integerMoreThan (not inclusive)
+	 * @param toMatch The number to be compared
+	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Integer integerMoreThan(Integer toMatch)
 	{
 		return integerMoreThan(toMatch, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches integerMoreThan
-	* @param toMatch The number to be compared
-	* @param inclusive Whether or not a number equal to toMatch should be considered a match
-	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches integerMoreThan
+	 * @param toMatch The number to be compared
+	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
+	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Integer integerMoreThan(Integer toMatch, Boolean inclusive)
 	{
 		return (Integer) matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches isNotNull
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches isNotNull
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object isNotNull()
 	{
 		return matches(new fflib_MatcherDefinitions.IsNotNull());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches isNull
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches isNull
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object isNull()
 	{
 		return matches(new fflib_MatcherDefinitions.IsNull());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches listContains
-	* @param toMatch The list to be compared
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches listContains
+	 * @param toMatch The list to be compared
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object listContains(Object toMatch)
 	{
 		return matches(new fflib_MatcherDefinitions.ListContains(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches listIsEmpty
-	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches listIsEmpty
+	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	 */
 	public static Object listIsEmpty()
 	{
 		return matches(new fflib_MatcherDefinitions.ListIsEmpty());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches longBetween (not inclusive)
-	* @param lower The lower number to be compared
-	* @param upper The upper number to be compared
-	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches longBetween (not inclusive)
+	 * @param lower The lower number to be compared
+	 * @param upper The upper number to be compared
+	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Long longBetween(Long lower, Long upper)
 	{
 		return longBetween(lower, false, upper, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches longBetween
-	* @param lower The lower number to be compared
-	* @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
-	* @param upper The upper number to be compared
-	* @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
-	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches longBetween
+	 * @param lower The lower number to be compared
+	 * @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
+	 * @param upper The upper number to be compared
+	 * @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
+	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Long longBetween(Long lower, Boolean inclusiveLower, Long upper, Boolean inclusiveUpper)
 	{
 		return (Long) matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches longLessThan (not inclusive)
-	* @param toMatch The number to be compared
-	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches longLessThan (not inclusive)
+	 * @param toMatch The number to be compared
+	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Long longLessThan(Long toMatch)
 	{
 		return longLessThan(toMatch, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches longLessThan
-	* @param toMatch The number to be compared
-	* @param inclusive Whether or not a number equal to toMatch should be considered a match
-	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches longLessThan
+	 * @param toMatch The number to be compared
+	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
+	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Long longLessThan(Long toMatch, Boolean inclusive)
 	{
 		return (Long) matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches longMoreThan (not inclusive)
-	* @param toMatch The number to be compared
-	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches longMoreThan (not inclusive)
+	 * @param toMatch The number to be compared
+	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Long longMoreThan(Long toMatch)
 	{
 		return longMoreThan(toMatch, false);
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches longMoreThan
-	* @param toMatch The number to be compared
-	* @param inclusive Whether or not a number equal to toMatch should be considered a match
-	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches longMoreThan
+	 * @param toMatch The number to be compared
+	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
+	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static Long longMoreThan(Long toMatch, Boolean inclusive)
 	{
 		return (Long) matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an SObject of specified SObjectType
-	* @param objectType The SObjectType to be compared
-	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	*/
+	 * Registers a matcher which will check if the method is called with an SObject of specified SObjectType
+	 * @param objectType The SObjectType to be compared
+	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	 */
 	public static SObject sObjectOfType(Schema.SObjectType objectType)
 	{
 		return (SObject) matches(new fflib_MatcherDefinitions.SObjectOfType(objectType));
 	}
 	/**
-	* Registers a matcher which will check if the method is called with an SObject
-	* @param toMatch A Map of SObjectFields to required values, to be compared to concrete SObject records
-	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	*/
+	 * Registers a matcher which will check if the method is called with an SObject
+	 * @param toMatch A Map of SObjectFields to required values, to be compared to concrete SObject records
+	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	 */
 	public static SObject sObjectWith(Map<Schema.SObjectField, Object> toMatch)
 	{
 		return (SObject) matches(new fflib_MatcherDefinitions.SObjectWith(toMatch));
 	}
 	/**
-	* Registers a matcher which will check if the method is called with a list of SObject
-	* @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records
-	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	*/
+	 * Registers a matcher which will check if the method is called with a list of SObject
+	 * @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records
+	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	 */
 	public static SObject[] sObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch)
 	{
 		return (SObject[]) matches(new fflib_MatcherDefinitions.SObjectsWith(toMatch, true));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with a list of SObject
-	* @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records. Comparison can be order dependent
-	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	*/
+	 * Registers a matcher which will check if the method is called with a list of SObject
+	 * @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records. Comparison can be order dependent
+	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	 */
 	public static SObject[] sObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch, Boolean matchInOrder)
 	{
 		return (SObject[]) matches(new fflib_MatcherDefinitions.SObjectsWith(toMatch, matchInOrder));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an SObject
-	* @param toMatch The Id to be compared
-	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	*/
+	 * Registers a matcher which will check if the method is called with an SObject
+	 * @param toMatch The Id to be compared
+	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	 */
 	public static SObject sObjectWithId(Id toMatch)
 	{
 		return (SObject) matches(new fflib_MatcherDefinitions.SObjectWithId(toMatch));
 	}
 	/**
-	* Registers a matcher which will check if the method is called with an SObject
-	* @param toMatch The name to be compared
-	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	*/
+	 * Registers a matcher which will check if the method is called with an SObject
+	 * @param toMatch The name to be compared
+	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	 */
 	public static SObject sObjectWithName(String toMatch)
 	{
 		return (SObject) matches(new fflib_MatcherDefinitions.SObjectWithName(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches stringContains
-	* @param toMatch The substring to be compared
-	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches stringContains
+	 * @param toMatch The substring to be compared
+	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static String stringContains(String toMatch)
 	{
 		return (String) matches(new fflib_MatcherDefinitions.StringContains(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches stringEndsWith
-	* @param toMatch The substring to be compared
-	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches stringEndsWith
+	 * @param toMatch The substring to be compared
+	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static String stringEndsWith(String toMatch)
 	{
 		return (String) matches(new fflib_MatcherDefinitions.StringEndsWith(toMatch));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches stringIsBlank
-	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches stringIsBlank
+	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static String stringIsBlank()
 	{
 		return (String) matches(new fflib_MatcherDefinitions.StringIsBlank());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches stringIsNotBlank
-	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches stringIsNotBlank
+	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static String stringIsNotBlank()
 	{
 		return (String) matches(new fflib_MatcherDefinitions.StringIsNotBlank());
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches stringMatches
-	* @param regEx The regex String to be compared
-	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches stringMatches
+	 * @param regEx The regex String to be compared
+	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static String stringMatches(String regEx)
 	{
 		return (String) matches(new fflib_MatcherDefinitions.StringMatches(regEx));
 	}
 
 	/**
-	* Registers a matcher which will check if the method is called with an arg that matches stringStartsWith
-	* @param toMatch The substring to be compared
-	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	*/
+	 * Registers a matcher which will check if the method is called with an arg that matches stringStartsWith
+	 * @param toMatch The substring to be compared
+	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	 */
 	public static String stringStartsWith(String toMatch)
 	{
 		return (String) matches(new fflib_MatcherDefinitions.StringStartsWith(toMatch));

--- a/sfdx-source/apex-mocks/main/classes/fflib_Match.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_Match.cls
@@ -1,45 +1,45 @@
 /**
- * Copyright (c) 2014, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2014, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 @NamespaceAccessible
 public class fflib_Match
 {
 	private static List<fflib_IMatcher> matchers = new List<fflib_IMatcher>();
 
-	/** 
-	 * Matching
-	 * True when comparing method arg values to matchers, false when comparing absolute arg values.
-	 */
-	public static Boolean Matching = false;
-	
 	/**
-	 * Used internally by the mocking framework, you shouldn't need to call this method directly.
-	 * Copies the registered matchers, and then switches matching mode off.
-	 * @param expectedSize The expected number of matchers to be returned. If this does not match the actual value an expection is thrown.
-	 * @return List<fflib_IMatcher> The registered matchers, collected while in matching mode.
-	 */
+	* Matching
+	* True when comparing method arg values to matchers, false when comparing absolute arg values.
+	*/
+	public static Boolean Matching = false;
+
+	/**
+	* Used internally by the mocking framework, you shouldn't need to call this method directly.
+	* Copies the registered matchers, and then switches matching mode off.
+	* @param expectedSize The expected number of matchers to be returned. If this does not match the actual value an expection is thrown.
+	* @return List<fflib_IMatcher> The registered matchers, collected while in matching mode.
+	*/
 	@NamespaceAccessible
 	public static List<fflib_IMatcher> getAndClearMatchers(Integer expectedSize)
 	{
@@ -50,1113 +50,1116 @@ public class fflib_Match
 
 		if (retval.size() != expectedSize)
 		{
-			throw new fflib_ApexMocks.ApexMocksException('The number of matchers defined (' + retval.size() + ').'
-				+ ' does not match the number expected (' + expectedSize + ')\n'
+			throw new fflib_ApexMocks.ApexMocksException(
+				'The number of matchers defined ('
+				+ retval.size()
+				+ ').'
+				+ ' does not match the number expected ('
+				+ expectedSize
+				+ ')\n'
 				+ 'If you are using matchers all arguments must be passed in as matchers.\n'
-				+ 'For example myList.add(fflib_Match.anyInteger(), \'String\') should be defined as myList.add(fflib_Match.anyInteger(), fflib_Match.eq(\'String\')).');
+				+ 'For example myList.add(fflib_Match.anyInteger(), \'String\') should be defined as myList.add(fflib_Match.anyInteger(), fflib_Match.eq(\'String\')).'
+			);
 		}
-		
+
 		return retval;
 	}
-	
+
 	/**
-	 * Used internally by the mocking framework, you shouldn't need to call this method directly.
-	 * Compares all supplied method arg values to the supplied target matchers.
-	 * @param methodArg The arguments supplied when the method was called
-	 * @param targetMatchers The matchers the arguments need to be compared with
-	 * @throws fflib_ApexMocks.ApexMocksException Thrown when methodArgValues is null/empty, targetMatchers is null, or their sizes don't match
-	 * @return Boolean True if all arg values satisfy all of the supplied matchers.
-	 */
+	* Used internally by the mocking framework, you shouldn't need to call this method directly.
+	* Compares all supplied method arg values to the supplied target matchers.
+	* @param methodArg The arguments supplied when the method was called
+	* @param targetMatchers The matchers the arguments need to be compared with
+	* @throws fflib_ApexMocks.ApexMocksException Thrown when methodArgValues is null/empty, targetMatchers is null, or their sizes don't match
+	* @return Boolean True if all arg values satisfy all of the supplied matchers.
+	*/
 	@NamespaceAccessible
 	public static Boolean matchesAllArgs(fflib_MethodArgValues methodArg, List<fflib_IMatcher> targetMatchers)
 	{
 		validateArgs(methodArg, targetMatchers);
-		
+
 		Integer matchersSize = targetMatchers.size();
-		for (Integer i=0; i<matchersSize; i++)
+		for (Integer i = 0; i < matchersSize; i++)
 		{
 			Object argValue = methodArg.argValues[i];
 			fflib_IMatcher matcher = targetMatchers[i];
-			
+
 			if (!matcher.matches(argValue))
 			{
 				return false;
 			}
 		}
-		
+
 		return true;
 	}
-	
+
 	private static void validateArgs(fflib_MethodArgValues methodArg, List<fflib_IMatcher> targetMatchers)
 	{
 		if (methodArg == null)
 		{
 			throw new fflib_ApexMocks.ApexMocksException('MethodArgs cannot be null');
 		}
-		
+
 		if (methodArg.argValues == null)
 		{
 			throw new fflib_ApexMocks.ApexMocksException('MethodArgs.argValues cannot be null');
 		}
-		
+
 		if (targetMatchers == null)
 		{
 			throw new fflib_ApexMocks.ApexMocksException('Matchers cannot be null');
 		}
-		
+
 		if (targetMatchers.size() != methodArg.argValues.size())
 		{
-			throw new fflib_ApexMocks.ApexMocksException('MethodArgs and matchers must have the same count'
-				+ ', MethodArgs: (' + methodArg.argValues.size() + ') ' + methodArg.argValues
-				+ ', Matchers: (' + targetMatchers.size() + ') ' + targetMatchers);
+			throw new fflib_ApexMocks.ApexMocksException('MethodArgs and matchers must have the same count' + ', MethodArgs: (' + methodArg.argValues.size() + ') ' + methodArg.argValues + ', Matchers: (' + targetMatchers.size() + ') ' + targetMatchers);
 		}
 	}
-	
+
 	/**
-	 * Registers a matcher which will be stubbed/verified against.
-	 * @param matcher The matcher that needs to be compared
-	 * @return Object Always returns null. This can then be cast into the correct arg type
-	 * so that the right method is called on the mock objects.
-	 */
+	* Registers a matcher which will be stubbed/verified against.
+	* @param matcher The matcher that needs to be compared
+	* @return Object Always returns null. This can then be cast into the correct arg type
+	* so that the right method is called on the mock objects.
+	*/
 	@NamespaceAccessible
 	public static Object matches(fflib_IMatcher matcher)
 	{
 		Matching = true;
 		matchers.add(matcher);
-		
+
 		return null;
 	}
-	
-	/** 
-	 * COMBINED MATCHER
-	 * The allOf, anyOf and noneOf methods are overloaded to provide fluent matcher calls for up to 4 matcher conditions.
-	 * To connect 5 or more, the List<Object> version directly.
-	 */
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches allOf
-	 * @param o1 A dummy object returned by registering another matcher 
-	 * @param o2 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)public static Object allOf(Object o1, Object o2)
-	 */
-    public static Object allOf(Object o1, Object o2)
+	* COMBINED MATCHER
+	* The allOf, anyOf and noneOf methods are overloaded to provide fluent matcher calls for up to 4 matcher conditions.
+	* To connect 5 or more, the List<Object> version directly.
+	*/
+
+	/**
+	* Registers a matcher which will check if the method is called with an arg that matches allOf
+	* @param o1 A dummy object returned by registering another matcher
+	* @param o2 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)public static Object allOf(Object o1, Object o2)
+	*/
+	public static Object allOf(Object o1, Object o2)
 	{
 		return allOf(new Object[]{ o1, o2 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches allOf
-	 * @param o1 A dummy object returned by registering another matcher
-	 * @param o2 A dummy object returned by registering another matcher
-	 * @param o3 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches allOf
+	* @param o1 A dummy object returned by registering another matcher
+	* @param o2 A dummy object returned by registering another matcher
+	* @param o3 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object allOf(Object o1, Object o2, Object o3)
 	{
 		return allOf(new Object[]{ o1, o2, o3 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches allOf
-	 * @param o1 A dummy object returned by registering another matcher
-	 * @param o2 A dummy object returned by registering another matcher
-	 * @param o3 A dummy object returned by registering another matcher
-	 * @param o4 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches allOf
+	* @param o1 A dummy object returned by registering another matcher
+	* @param o2 A dummy object returned by registering another matcher
+	* @param o3 A dummy object returned by registering another matcher
+	* @param o4 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object allOf(Object o1, Object o2, Object o3, Object o4)
 	{
 		return allOf(new Object[]{ o1, o2, o3, o4 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches allOf
-	 * @param o A list of dummy objects returned by registering other matchers
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches allOf
+	* @param o A list of dummy objects returned by registering other matchers
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object allOf(List<Object> o)
 	{
 		return combined(fflib_MatcherDefinitions.Connective.ALL, o);
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyOf
-	 * @param o1 A dummy object returned by registering another matcher
-	 * @param o2 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyOf
+	* @param o1 A dummy object returned by registering another matcher
+	* @param o2 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object anyOf(Object o1, Object o2)
 	{
 		return anyOf(new Object[]{ o1, o2 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyOf
-	 * @param o1 A dummy object returned by registering another matcher
-	 * @param o2 A dummy object returned by registering another matcher
-	 * @param o3 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyOf
+	* @param o1 A dummy object returned by registering another matcher
+	* @param o2 A dummy object returned by registering another matcher
+	* @param o3 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object anyOf(Object o1, Object o2, Object o3)
 	{
 		return anyOf(new Object[]{ o1, o2, o3 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyOf
-	 * @param o1 A dummy object returned by registering another matcher
-	 * @param o2 A dummy object returned by registering another matcher
-	 * @param o3 A dummy object returned by registering another matcher
-	 * @param o4 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyOf
+	* @param o1 A dummy object returned by registering another matcher
+	* @param o2 A dummy object returned by registering another matcher
+	* @param o3 A dummy object returned by registering another matcher
+	* @param o4 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object anyOf(Object o1, Object o2, Object o3, Object o4)
 	{
 		return anyOf(new Object[]{ o1, o2, o3, o4 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyOf
-	 * @param o A list of dummy objects returned by registering other matchers
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyOf
+	* @param o A list of dummy objects returned by registering other matchers
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object anyOf(List<Object> o)
 	{
 		return combined(fflib_MatcherDefinitions.Connective.AT_LEAST_ONE, o);
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches isNot
-	 * @param o1 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches isNot
+	* @param o1 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object isNot(Object o1)
 	{
 		return noneOf(new Object[]{ o1 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches noneOf
-	 * @param o1 A dummy object returned by registering another matcher
-	 * @param o2 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches noneOf
+	* @param o1 A dummy object returned by registering another matcher
+	* @param o2 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object noneOf(Object o1, Object o2)
 	{
 		return noneOf(new Object[]{ o1, o2 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches noneOf
-	 * @param o1 A dummy object returned by registering another matcher
-	 * @param o2 A dummy object returned by registering another matcher
-	 * @param o3 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches noneOf
+	* @param o1 A dummy object returned by registering another matcher
+	* @param o2 A dummy object returned by registering another matcher
+	* @param o3 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object noneOf(Object o1, Object o2, Object o3)
 	{
 		return noneOf(new Object[]{ o1, o2, o3 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches noneOf
-	 * @param o1 A dummy object returned by registering another matcher
-	 * @param o2 A dummy object returned by registering another matcher
-	 * @param o3 A dummy object returned by registering another matcher
-	 * @param o4 A dummy object returned by registering another matcher
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches noneOf
+	* @param o1 A dummy object returned by registering another matcher
+	* @param o2 A dummy object returned by registering another matcher
+	* @param o3 A dummy object returned by registering another matcher
+	* @param o4 A dummy object returned by registering another matcher
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object noneOf(Object o1, Object o2, Object o3, Object o4)
 	{
 		return noneOf(new Object[]{ o1, o2, o3, o4 });
 	}
-	
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches noneOf
-	 * @param o A list of dummy objects returned by registering other matchers
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches noneOf
+	* @param o A list of dummy objects returned by registering other matchers
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object noneOf(List<Object> o)
 	{
 		return combined(fflib_MatcherDefinitions.Connective.NONE, o);
 	}
-	
+
 	private static Object combined(fflib_MatcherDefinitions.Connective connectiveExpression, List<Object> o)
 	{
 		return matches(new fflib_MatcherDefinitions.Combined(connectiveExpression, (gatherMatchers(o))));
 	}
-	
+
 	private static List<fflib_IMatcher> gatherMatchers(Object[] ignoredMatcherObjects)
 	{
 		if (ignoredMatcherObjects == null || ignoredMatcherObjects.isEmpty())
 		{
 			throw new fflib_ApexMocks.ApexMocksException('Must register matchers to combine');
 		}
-		
+
 		//Each ignored matcher object represents a matcher that has been registered against fflib_Match.matchers,
 		//but is actually for the connective matchers.
 		List<fflib_IMatcher> innerMatchers = new List<fflib_IMatcher>();
-		
+
 		Integer innerMatcherCount = ignoredMatcherObjects.size();
 		while (innerMatchers.size() < innerMatcherCount)
 		{
 			if (matchers.isEmpty())
 			{
-				throw new fflib_ApexMocks.ApexMocksException('Error reclaiming inner matchers for combined matcher. Wanted '
-					+ innerMatcherCount + ' matchers but only got ' + innerMatchers);
+				throw new fflib_ApexMocks.ApexMocksException('Error reclaiming inner matchers for combined matcher. Wanted ' + innerMatcherCount + ' matchers but only got ' + innerMatchers);
 			}
-			
-			fflib_IMatcher innerMatcher = matchers.remove(matchers.size()-1);
-			
+
+			fflib_IMatcher innerMatcher = matchers.remove(matchers.size() - 1);
+
 			//Add to the start of the list to preserve the order in which matchers were declared.
 			//Note. Apex throws list index out of bounds if inserting an element into an empty list at index 0S
 			if (!innerMatchers.isEmpty())
 			{
-				innerMatchers.add(0, innerMatcher);	
+				innerMatchers.add(0, innerMatcher);
 			}
 			else
 			{
 				innerMatchers.add(innerMatcher);
 			}
 		}
-		
+
 		return innerMatchers;
 	}
-	
+
 	/**
-	 * ALL OTHER MATCHER METHODS
-	 */
-	
+	* ALL OTHER MATCHER METHODS
+	*/
+
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eq
-	 * @param toMatch The Object to be compared
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eq
+	* @param toMatch The Object to be compared
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object eq(Object toMatch)
 	{
 		return matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqBoolean
-	 * @param toMatch The Boolean to be compared
-	 * @return Boolean A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqBoolean
+	* @param toMatch The Boolean to be compared
+	* @return Boolean A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Boolean eqBoolean(Boolean toMatch)
 	{
-		return (Boolean)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (Boolean) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqDate
-	 * @param toMatch The Date to be compared
-	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqDate
+	* @param toMatch The Date to be compared
+	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Date eqDate(Date toMatch)
 	{
-		return (Date)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (Date) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqDatetime
-	 * @param toMatch The Datetime to be compared
-	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqDatetime
+	* @param toMatch The Datetime to be compared
+	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Datetime eqDatetime(Datetime toMatch)
 	{
-		return (Datetime)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (Datetime) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqDecimal
-	 * @param toMatch The Decimal to be compared
-	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqDecimal
+	* @param toMatch The Decimal to be compared
+	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Decimal eqDecimal(Decimal toMatch)
 	{
-		return (Decimal)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (Decimal) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqDouble
-	 * @param toMatch The Double to be compared
-	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqDouble
+	* @param toMatch The Double to be compared
+	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Double eqDouble(Double toMatch)
 	{
-		return (Double)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (Double) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqId
-	 * @param toMatch The Id to be compared
-	 * @return Id A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqId
+	* @param toMatch The Id to be compared
+	* @return Id A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Id eqId(Id toMatch)
 	{
-		return (Id)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (Id) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqInteger
-	 * @param toMatch The Integer to be compared
-	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqInteger
+	* @param toMatch The Integer to be compared
+	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Integer eqInteger(Integer toMatch)
 	{
-		return (Integer)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (Integer) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqList
-	 * @param toMatch The List to be compared
-	 * @return List A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqList
+	* @param toMatch The List to be compared
+	* @return List A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static List<Object> eqList(List<Object> toMatch)
 	{
-		return (List<Object>)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (List<Object>) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqLong
-	 * @param toMatch The Long to be compared
-	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqLong
+	* @param toMatch The Long to be compared
+	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Long eqLong(Long toMatch)
 	{
-		return (Long)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (Long) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqSObjectField
-	 * @param toMatch The SObjectField to be compared
-	 * @return SObjectField A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqSObjectField
+	* @param toMatch The SObjectField to be compared
+	* @return SObjectField A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static SObjectField eqSObjectField(SObjectField toMatch)
 	{
-		return (SObjectField)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (SObjectField) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqSObjectType
-	 * @param toMatch The SObjectType to be compared
-	 * @return SObjectType A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqSObjectType
+	* @param toMatch The SObjectType to be compared
+	* @return SObjectType A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static SObjectType eqSObjectType(SObjectType toMatch)
 	{
-		return (SObjectType)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (SObjectType) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches eqString
-	 * @param toMatch The String to be compared
-	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches eqString
+	* @param toMatch The String to be compared
+	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static String eqString(String toMatch)
 	{
-		return (String)matches(new fflib_MatcherDefinitions.Eq(toMatch));
+		return (String) matches(new fflib_MatcherDefinitions.Eq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches refEq
-	 * @param toMatch The Object to be compared
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches refEq
+	* @param toMatch The Object to be compared
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object refEq(Object toMatch)
 	{
 		return matches(new fflib_MatcherDefinitions.RefEq(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyBoolean
-	 * @return Boolean A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyBoolean
+	* @return Boolean A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Boolean anyBoolean()
 	{
-		return (Boolean)matches(new fflib_MatcherDefinitions.AnyBoolean());
+		return (Boolean) matches(new fflib_MatcherDefinitions.AnyBoolean());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyDate
-	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyDate
+	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Date anyDate()
 	{
-		return (Date)matches(new fflib_MatcherDefinitions.AnyDate());
+		return (Date) matches(new fflib_MatcherDefinitions.AnyDate());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyDatetime
-	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyDatetime
+	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Datetime anyDatetime()
 	{
-		return (Datetime)matches(new fflib_MatcherDefinitions.AnyDatetime());
+		return (Datetime) matches(new fflib_MatcherDefinitions.AnyDatetime());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyDecimal
-	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyDecimal
+	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Decimal anyDecimal()
 	{
-		return (Decimal)matches(new fflib_MatcherDefinitions.AnyDecimal());
+		return (Decimal) matches(new fflib_MatcherDefinitions.AnyDecimal());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyDouble
-	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyDouble
+	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Double anyDouble()
 	{
-		return (Double)matches(new fflib_MatcherDefinitions.AnyDouble());
+		return (Double) matches(new fflib_MatcherDefinitions.AnyDouble());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyFieldSet
-	 * @return Schema.FieldSet A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyFieldSet
+	* @return Schema.FieldSet A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Schema.FieldSet anyFieldSet()
 	{
-		return (Schema.FieldSet)matches(new fflib_MatcherDefinitions.AnyFieldSet());
+		return (Schema.FieldSet) matches(new fflib_MatcherDefinitions.AnyFieldSet());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyId
-	 * @return Id A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyId
+	* @return Id A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Id anyId()
 	{
-		return (Id)matches(new fflib_MatcherDefinitions.AnyId());
+		return (Id) matches(new fflib_MatcherDefinitions.AnyId());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyInteger
-	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyInteger
+	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Integer anyInteger()
 	{
-		return (Integer)matches(new fflib_MatcherDefinitions.AnyInteger());
+		return (Integer) matches(new fflib_MatcherDefinitions.AnyInteger());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyList
-	 * @return List A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyList
+	* @return List A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static List<Object> anyList()
 	{
-		return (List<Object>)matches(new fflib_MatcherDefinitions.AnyList());
+		return (List<Object>) matches(new fflib_MatcherDefinitions.AnyList());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyLong
-	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyLong
+	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Long anyLong()
 	{
-		return (Long)matches(new fflib_MatcherDefinitions.AnyLong());
+		return (Long) matches(new fflib_MatcherDefinitions.AnyLong());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyObject
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyObject
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object anyObject()
 	{
 		return matches(new fflib_MatcherDefinitions.AnyObject());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anyString
-	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anyString
+	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static String anyString()
 	{
-		return (String)matches(new fflib_MatcherDefinitions.AnyString());
+		return (String) matches(new fflib_MatcherDefinitions.AnyString());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anySObject
-	 * @return SObject A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anySObject
+	* @return SObject A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static SObject anySObject()
 	{
-		return (SObject)matches(new fflib_MatcherDefinitions.AnySObject());
+		return (SObject) matches(new fflib_MatcherDefinitions.AnySObject());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anySObjectField
-	 * @return SObjectField A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anySObjectField
+	* @return SObjectField A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static SObjectField anySObjectField()
 	{
-		return (SObjectField)matches(new fflib_MatcherDefinitions.AnySObjectField());
+		return (SObjectField) matches(new fflib_MatcherDefinitions.AnySObjectField());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches anySObjectType
-	 * @return SObjectType A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches anySObjectType
+	* @return SObjectType A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static SObjectType anySObjectType()
 	{
-		return (SObjectType)matches(new fflib_MatcherDefinitions.AnySObjectType());
+		return (SObjectType) matches(new fflib_MatcherDefinitions.AnySObjectType());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches dateAfter (not inclusive)
-	 * @param fromDate The Date to be compared
-	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches dateAfter (not inclusive)
+	* @param fromDate The Date to be compared
+	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Date dateAfter(Date fromDate)
 	{
 		return dateAfter(fromDate, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches dateAfter
-	 * @param fromDate The Date to be compared
-	 * @param inclusive Whether or not a Date equal to fromDate should be considered a match
-	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches dateAfter
+	* @param fromDate The Date to be compared
+	* @param inclusive Whether or not a Date equal to fromDate should be considered a match
+	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Date dateAfter(Date fromDate, Boolean inclusive)
 	{
-		return (Date)matches(new fflib_MatcherDefinitions.DatetimeAfter(fromDate, inclusive));
+		return (Date) matches(new fflib_MatcherDefinitions.DatetimeAfter(fromDate, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches dateBefore (not inclusive)
-	 * @param toDate The Date to be compared
-	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches dateBefore (not inclusive)
+	* @param toDate The Date to be compared
+	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Date dateBefore(Date toDate)
 	{
 		return dateBefore(toDate, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches dateBefore
-	 * @param toDate The Date to be compared
-	 * @param inclusive Whether or not a Date equal to toDate should be considered a match
-	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches dateBefore
+	* @param toDate The Date to be compared
+	* @param inclusive Whether or not a Date equal to toDate should be considered a match
+	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Date dateBefore(Date toDate, Boolean inclusive)
 	{
-		return (Date)matches(new fflib_MatcherDefinitions.DatetimeBefore(toDate, inclusive));
+		return (Date) matches(new fflib_MatcherDefinitions.DatetimeBefore(toDate, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches dateBetween (not inclusive)
-	 * @param fromDate The lower bound Date to be compared
-	 * @param toDate The upper bound Date to be compared
-	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches dateBetween (not inclusive)
+	* @param fromDate The lower bound Date to be compared
+	* @param toDate The upper bound Date to be compared
+	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Date dateBetween(Date fromDate, Date toDate)
 	{
 		return dateBetween(fromDate, false, toDate, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches dateBetween
-	 * @param fromDate The lower bound Date to be compared
-	 * @param inclusiveFrom Whether or not a Date equal to fromDate should be considered a match
-	 * @param toDate The upper bound Date to be compared
-	 * @param inclusiveTo Whether or not a Date equal to toDate should be considered a match
-	 * @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches dateBetween
+	* @param fromDate The lower bound Date to be compared
+	* @param inclusiveFrom Whether or not a Date equal to fromDate should be considered a match
+	* @param toDate The upper bound Date to be compared
+	* @param inclusiveTo Whether or not a Date equal to toDate should be considered a match
+	* @return Date A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Date dateBetween(Date fromDate, Boolean inclusiveFrom, Date toDate, Boolean inclusiveTo)
 	{
-		return (Date)matches(new fflib_MatcherDefinitions.DatetimeBetween(fromDate, inclusiveFrom, toDate, inclusiveTo));
+		return (Date) matches(new fflib_MatcherDefinitions.DatetimeBetween(fromDate, inclusiveFrom, toDate, inclusiveTo));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches datetimeAfter (not inclusive)
-	 * @param fromDate The Datetime to be compared
-	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches datetimeAfter (not inclusive)
+	* @param fromDate The Datetime to be compared
+	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Datetime datetimeAfter(Datetime fromDate)
 	{
 		return datetimeAfter(fromDate, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches datetimeAfter
-	 * @param fromDate The Datetime to be compared
-	 * @param inclusive Whether or not a Datetime equal to fromDate should be considered a match
-	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches datetimeAfter
+	* @param fromDate The Datetime to be compared
+	* @param inclusive Whether or not a Datetime equal to fromDate should be considered a match
+	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Datetime datetimeAfter(Datetime fromDate, Boolean inclusive)
 	{
-		return (Datetime)matches(new fflib_MatcherDefinitions.DatetimeAfter(fromDate, inclusive));
+		return (Datetime) matches(new fflib_MatcherDefinitions.DatetimeAfter(fromDate, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches datetimeBefore (not inclusive)
-	 * @param toDate The Datetime to be compared
-	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches datetimeBefore (not inclusive)
+	* @param toDate The Datetime to be compared
+	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Datetime datetimeBefore(Datetime toDate)
 	{
 		return datetimeBefore(toDate, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches datetimeBefore
-	 * @param toDate The Datetime to be compared
-	 * @param inclusive Whether or not a Datetime equal to toDate should be considered a match
-	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches datetimeBefore
+	* @param toDate The Datetime to be compared
+	* @param inclusive Whether or not a Datetime equal to toDate should be considered a match
+	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Datetime datetimeBefore(Datetime toDate, Boolean inclusive)
 	{
-		return (Datetime)matches(new fflib_MatcherDefinitions.DatetimeBefore(toDate, inclusive));
+		return (Datetime) matches(new fflib_MatcherDefinitions.DatetimeBefore(toDate, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches datetimeBetween (not inclusive)
-	 * @param fromDate The lower bound Datetime to be compared
-	 * @param toDate The upper bound Datetime to be compared
-	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches datetimeBetween (not inclusive)
+	* @param fromDate The lower bound Datetime to be compared
+	* @param toDate The upper bound Datetime to be compared
+	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Datetime datetimeBetween(Datetime fromDate, Datetime toDate)
 	{
 		return datetimeBetween(fromDate, false, toDate, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches datetimeBetween
-	 * @param fromDate The lower bound Datetime to be compared
-	 * @param inclusiveFrom Whether or not a Datetime equal to fromDate should be considered a match
-	 * @param toDate The upper bound Datetime to be compared
-	 * @param inclusiveTo Whether or not a Datetime equal to toDate should be considered a match
-	 * @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches datetimeBetween
+	* @param fromDate The lower bound Datetime to be compared
+	* @param inclusiveFrom Whether or not a Datetime equal to fromDate should be considered a match
+	* @param toDate The upper bound Datetime to be compared
+	* @param inclusiveTo Whether or not a Datetime equal to toDate should be considered a match
+	* @return Datetime A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Datetime datetimeBetween(Datetime fromDate, Boolean inclusiveFrom, Datetime toDate, Boolean inclusiveTo)
 	{
-		return (Datetime)matches(new fflib_MatcherDefinitions.DatetimeBetween(fromDate, inclusiveFrom, toDate, inclusiveTo));
+		return (Datetime) matches(new fflib_MatcherDefinitions.DatetimeBetween(fromDate, inclusiveFrom, toDate, inclusiveTo));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches decimalBetween (not inclusive)
-	 * @param lower The lower number to be compared
-	 * @param upper The upper number to be compared
-	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches decimalBetween (not inclusive)
+	* @param lower The lower number to be compared
+	* @param upper The upper number to be compared
+	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Decimal decimalBetween(Decimal lower, Decimal upper)
 	{
 		return decimalBetween(lower, false, upper, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches decimalBetween
-	 * @param lower The lower number to be compared
-	 * @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
-	 * @param upper The upper number to be compared
-	 * @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
-	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches decimalBetween
+	* @param lower The lower number to be compared
+	* @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
+	* @param upper The upper number to be compared
+	* @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
+	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Decimal decimalBetween(Decimal lower, Boolean inclusiveLower, Decimal upper, Boolean inclusiveUpper)
 	{
-		return (Decimal)matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
+		return (Decimal) matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches decimalLessThan (not inclusive)
-	 * @param toMatch The number to be compared
-	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches decimalLessThan (not inclusive)
+	* @param toMatch The number to be compared
+	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Decimal decimalLessThan(Decimal toMatch)
 	{
 		return decimalLessThan(toMatch, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches decimalLessThan
-	 * @param toMatch The number to be compared
-	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
-	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches decimalLessThan
+	* @param toMatch The number to be compared
+	* @param inclusive Whether or not a number equal to toMatch should be considered a match
+	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Decimal decimalLessThan(Decimal toMatch, Boolean inclusive)
 	{
-		return (Decimal)matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
+		return (Decimal) matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches decimalMoreThan (not inclusive)
-	 * @param toMatch The number to be compared
-	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches decimalMoreThan (not inclusive)
+	* @param toMatch The number to be compared
+	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Decimal decimalMoreThan(Decimal toMatch)
 	{
 		return decimalMoreThan(toMatch, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches decimalMoreThan
-	 * @param toMatch The number to be compared
-	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
-	 * @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches decimalMoreThan
+	* @param toMatch The number to be compared
+	* @param inclusive Whether or not a number equal to toMatch should be considered a match
+	* @return Decimal A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Decimal decimalMoreThan(Decimal toMatch, Boolean inclusive)
 	{
-		return (Decimal)matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
+		return (Decimal) matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches doubleBetween (not inclusive)
-	 * @param lower The lower number to be compared
-	 * @param upper The upper number to be compared
-	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches doubleBetween (not inclusive)
+	* @param lower The lower number to be compared
+	* @param upper The upper number to be compared
+	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Double doubleBetween(Double lower, Double upper)
 	{
 		return doubleBetween(lower, false, upper, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches doubleBetween
-	 * @param lower The lower number to be compared
-	 * @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
-	 * @param upper The upper number to be compared
-	 * @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
-	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches doubleBetween
+	* @param lower The lower number to be compared
+	* @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
+	* @param upper The upper number to be compared
+	* @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
+	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Double doubleBetween(Double lower, Boolean inclusiveLower, Double upper, Boolean inclusiveUpper)
 	{
-		return (Double)matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
+		return (Double) matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches doubleLessThan (not inclusive)
-	 * @param toMatch The number to be compared
-	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches doubleLessThan (not inclusive)
+	* @param toMatch The number to be compared
+	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Double doubleLessThan(Double toMatch)
 	{
 		return doubleLessThan(toMatch, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches doubleLessThan
-	 * @param toMatch The number to be compared
-	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
-	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches doubleLessThan
+	* @param toMatch The number to be compared
+	* @param inclusive Whether or not a number equal to toMatch should be considered a match
+	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Double doubleLessThan(Double toMatch, Boolean inclusive)
 	{
-		return (Double)matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
+		return (Double) matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches doubleMoreThan (not inclusive)
-	 * @param toMatch The number to be compared
-	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches doubleMoreThan (not inclusive)
+	* @param toMatch The number to be compared
+	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Double doubleMoreThan(Double toMatch)
 	{
 		return doubleMoreThan(toMatch, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches doubleMoreThan
-	 * @param toMatch The number to be compared
-	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
-	 * @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches doubleMoreThan
+	* @param toMatch The number to be compared
+	* @param inclusive Whether or not a number equal to toMatch should be considered a match
+	* @return Double A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Double doubleMoreThan(Double toMatch, Boolean inclusive)
 	{
-		return (Double)matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
+		return (Double) matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches FieldSetEquivalentTo
-	 * @param toMatch The fieldSet to be compared
-	 * @return Schema.FieldSet A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches FieldSetEquivalentTo
+	* @param toMatch The fieldSet to be compared
+	* @return Schema.FieldSet A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Schema.FieldSet fieldSetEquivalentTo(Schema.FieldSet toMatch)
 	{
-		return (Schema.FieldSet)matches(new fflib_MatcherDefinitions.FieldSetEquivalentTo(toMatch));
+		return (Schema.FieldSet) matches(new fflib_MatcherDefinitions.FieldSetEquivalentTo(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches integerBetween (not inclusive)
-	 * @param lower The lower number to be compared
-	 * @param upper The upper number to be compared
-	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches integerBetween (not inclusive)
+	* @param lower The lower number to be compared
+	* @param upper The upper number to be compared
+	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Integer integerBetween(Integer lower, Integer upper)
 	{
 		return integerBetween(lower, false, upper, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches integerBetween
-	 * @param lower The lower number to be compared
-	 * @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
-	 * @param upper The upper number to be compared
-	 * @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
-	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches integerBetween
+	* @param lower The lower number to be compared
+	* @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
+	* @param upper The upper number to be compared
+	* @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
+	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Integer integerBetween(Integer lower, Boolean inclusiveLower, Integer upper, Boolean inclusiveUpper)
 	{
-		return (Integer)matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
+		return (Integer) matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches integerLessThan (not inclusive)
-	 * @param toMatch The number to be compared
-	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches integerLessThan (not inclusive)
+	* @param toMatch The number to be compared
+	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Integer integerLessThan(Integer toMatch)
 	{
 		return integerLessThan(toMatch, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches integerLessThan
-	 * @param toMatch The number to be compared
-	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
-	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches integerLessThan
+	* @param toMatch The number to be compared
+	* @param inclusive Whether or not a number equal to toMatch should be considered a match
+	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Integer integerLessThan(Integer toMatch, Boolean inclusive)
 	{
-		return (Integer)matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
+		return (Integer) matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches integerMoreThan (not inclusive)
-	 * @param toMatch The number to be compared
-	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches integerMoreThan (not inclusive)
+	* @param toMatch The number to be compared
+	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Integer integerMoreThan(Integer toMatch)
 	{
 		return integerMoreThan(toMatch, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches integerMoreThan
-	 * @param toMatch The number to be compared
-	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
-	 * @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches integerMoreThan
+	* @param toMatch The number to be compared
+	* @param inclusive Whether or not a number equal to toMatch should be considered a match
+	* @return Integer A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Integer integerMoreThan(Integer toMatch, Boolean inclusive)
 	{
-		return (Integer)matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
+		return (Integer) matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches isNotNull
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches isNotNull
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object isNotNull()
 	{
 		return matches(new fflib_MatcherDefinitions.IsNotNull());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches isNull
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches isNull
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object isNull()
 	{
 		return matches(new fflib_MatcherDefinitions.IsNull());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches listContains
-	 * @param toMatch The list to be compared
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches listContains
+	* @param toMatch The list to be compared
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object listContains(Object toMatch)
 	{
 		return matches(new fflib_MatcherDefinitions.ListContains(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches listIsEmpty
-	 * @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches listIsEmpty
+	* @return Object A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked. (You may need to cast down to your specific object type)
+	*/
 	public static Object listIsEmpty()
 	{
 		return matches(new fflib_MatcherDefinitions.ListIsEmpty());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches longBetween (not inclusive)
-	 * @param lower The lower number to be compared
-	 * @param upper The upper number to be compared
-	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches longBetween (not inclusive)
+	* @param lower The lower number to be compared
+	* @param upper The upper number to be compared
+	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Long longBetween(Long lower, Long upper)
 	{
 		return longBetween(lower, false, upper, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches longBetween
-	 * @param lower The lower number to be compared
-	 * @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
-	 * @param upper The upper number to be compared
-	 * @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
-	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches longBetween
+	* @param lower The lower number to be compared
+	* @param inclusiveLower Whether or not a number equal to the lower bound should be considered a match
+	* @param upper The upper number to be compared
+	* @param inclusiveUpper Whether or not a number equal to the upper bound should be considered a match
+	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Long longBetween(Long lower, Boolean inclusiveLower, Long upper, Boolean inclusiveUpper)
 	{
-		return (Long)matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
+		return (Long) matches(new fflib_MatcherDefinitions.DecimalBetween(lower, inclusiveLower, upper, inclusiveUpper));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches longLessThan (not inclusive)
-	 * @param toMatch The number to be compared
-	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches longLessThan (not inclusive)
+	* @param toMatch The number to be compared
+	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Long longLessThan(Long toMatch)
 	{
 		return longLessThan(toMatch, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches longLessThan
-	 * @param toMatch The number to be compared
-	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
-	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches longLessThan
+	* @param toMatch The number to be compared
+	* @param inclusive Whether or not a number equal to toMatch should be considered a match
+	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Long longLessThan(Long toMatch, Boolean inclusive)
 	{
-		return (Long)matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
+		return (Long) matches(new fflib_MatcherDefinitions.DecimalLessThan(toMatch, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches longMoreThan (not inclusive)
-	 * @param toMatch The number to be compared
-	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches longMoreThan (not inclusive)
+	* @param toMatch The number to be compared
+	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Long longMoreThan(Long toMatch)
 	{
 		return longMoreThan(toMatch, false);
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches longMoreThan
-	 * @param toMatch The number to be compared
-	 * @param inclusive Whether or not a number equal to toMatch should be considered a match
-	 * @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches longMoreThan
+	* @param toMatch The number to be compared
+	* @param inclusive Whether or not a number equal to toMatch should be considered a match
+	* @return Long A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static Long longMoreThan(Long toMatch, Boolean inclusive)
 	{
-		return (Long)matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
+		return (Long) matches(new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, inclusive));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an SObject of specified SObjectType
-	 * @param objectType The SObjectType to be compared
-	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	 */
+	* Registers a matcher which will check if the method is called with an SObject of specified SObjectType
+	* @param objectType The SObjectType to be compared
+	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	*/
 	public static SObject sObjectOfType(Schema.SObjectType objectType)
 	{
-		return (SObject)matches(new fflib_MatcherDefinitions.SObjectOfType(objectType));
+		return (SObject) matches(new fflib_MatcherDefinitions.SObjectOfType(objectType));
 	}
 	/**
-	 * Registers a matcher which will check if the method is called with an SObject
-	 * @param toMatch A Map of SObjectFields to required values, to be compared to concrete SObject records
-	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	 */
+	* Registers a matcher which will check if the method is called with an SObject
+	* @param toMatch A Map of SObjectFields to required values, to be compared to concrete SObject records
+	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	*/
 	public static SObject sObjectWith(Map<Schema.SObjectField, Object> toMatch)
 	{
-		return (SObject)matches(new fflib_MatcherDefinitions.SObjectWith(toMatch));
+		return (SObject) matches(new fflib_MatcherDefinitions.SObjectWith(toMatch));
 	}
 	/**
-	 * Registers a matcher which will check if the method is called with a list of SObject
-	 * @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records
-	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	 */
+	* Registers a matcher which will check if the method is called with a list of SObject
+	* @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records
+	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	*/
 	public static SObject[] sObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch)
 	{
-		return (SObject[])matches(new fflib_MatcherDefinitions.SObjectsWith(toMatch,true));
+		return (SObject[]) matches(new fflib_MatcherDefinitions.SObjectsWith(toMatch, true));
 	}
-    
+
 	/**
-	 * Registers a matcher which will check if the method is called with a list of SObject
-	 * @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records. Comparison can be order dependent
-	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	 */
+	* Registers a matcher which will check if the method is called with a list of SObject
+	* @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records. Comparison can be order dependent
+	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	*/
 	public static SObject[] sObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch, Boolean matchInOrder)
 	{
-		return (SObject[])matches(new fflib_MatcherDefinitions.SObjectsWith(toMatch,matchInOrder));
+		return (SObject[]) matches(new fflib_MatcherDefinitions.SObjectsWith(toMatch, matchInOrder));
 	}
-    
+
 	/**
-	 * Registers a matcher which will check if the method is called with an SObject
-	 * @param toMatch The Id to be compared
-	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	 */
+	* Registers a matcher which will check if the method is called with an SObject
+	* @param toMatch The Id to be compared
+	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	*/
 	public static SObject sObjectWithId(Id toMatch)
 	{
-		return (SObject)matches(new fflib_MatcherDefinitions.SObjectWithId(toMatch));
+		return (SObject) matches(new fflib_MatcherDefinitions.SObjectWithId(toMatch));
 	}
 	/**
-	 * Registers a matcher which will check if the method is called with an SObject
-	 * @param toMatch The name to be compared
-	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
-	 */
+	* Registers a matcher which will check if the method is called with an SObject
+	* @param toMatch The name to be compared
+	* @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	*/
 	public static SObject sObjectWithName(String toMatch)
 	{
-		return (SObject)matches(new fflib_MatcherDefinitions.SObjectWithName(toMatch));
+		return (SObject) matches(new fflib_MatcherDefinitions.SObjectWithName(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches stringContains
-	 * @param toMatch The substring to be compared
-	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches stringContains
+	* @param toMatch The substring to be compared
+	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static String stringContains(String toMatch)
 	{
-		return (String)matches(new fflib_MatcherDefinitions.StringContains(toMatch));
+		return (String) matches(new fflib_MatcherDefinitions.StringContains(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches stringEndsWith
-	 * @param toMatch The substring to be compared
-	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches stringEndsWith
+	* @param toMatch The substring to be compared
+	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static String stringEndsWith(String toMatch)
 	{
-		return (String)matches(new fflib_MatcherDefinitions.StringEndsWith(toMatch));
+		return (String) matches(new fflib_MatcherDefinitions.StringEndsWith(toMatch));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches stringIsBlank
-	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches stringIsBlank
+	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static String stringIsBlank()
 	{
-		return (String)matches(new fflib_MatcherDefinitions.StringIsBlank());
+		return (String) matches(new fflib_MatcherDefinitions.StringIsBlank());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches stringIsNotBlank
-	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches stringIsNotBlank
+	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static String stringIsNotBlank()
 	{
-		return (String)matches(new fflib_MatcherDefinitions.StringIsNotBlank());
+		return (String) matches(new fflib_MatcherDefinitions.StringIsNotBlank());
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches stringMatches
-	 * @param regEx The regex String to be compared
-	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches stringMatches
+	* @param regEx The regex String to be compared
+	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static String stringMatches(String regEx)
 	{
-		return (String)matches(new fflib_MatcherDefinitions.StringMatches(regEx));
+		return (String) matches(new fflib_MatcherDefinitions.StringMatches(regEx));
 	}
 
 	/**
-	 * Registers a matcher which will check if the method is called with an arg that matches stringStartsWith
-	 * @param toMatch The substring to be compared
-	 * @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
-	 */
+	* Registers a matcher which will check if the method is called with an arg that matches stringStartsWith
+	* @param toMatch The substring to be compared
+	* @return String A dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked.
+	*/
 	public static String stringStartsWith(String toMatch)
 	{
-		return (String)matches(new fflib_MatcherDefinitions.StringStartsWith(toMatch));
+		return (String) matches(new fflib_MatcherDefinitions.StringStartsWith(toMatch));
 	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
@@ -1,41 +1,41 @@
 /**
-* Copyright (c) 2014-2017, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014-2017, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 /**
-* Class providing Apex Mocks standard matcher implementations.
-* You shouldn't need to reference the classes directly outside of the ApexMocks framework, instead use the equivalent helper method in fflib_Match
-* to construct the matcher, register the matcher and return an object of the correct type to be called in your unit test.
-* E.g. Don't construct Eq(Object toMatch), instead call fflib_Match.eq(Object toMatch).
-*/
+ * Class providing Apex Mocks standard matcher implementations.
+ * You shouldn't need to reference the classes directly outside of the ApexMocks framework, instead use the equivalent helper method in fflib_Match
+ * to construct the matcher, register the matcher and return an object of the correct type to be called in your unit test.
+ * E.g. Don't construct Eq(Object toMatch), instead call fflib_Match.eq(Object toMatch).
+ */
 @NamespaceAccessible
 public with sharing class fflib_MatcherDefinitions
 {
 	/**
-	* Connective - Enum representing the possible operators for the Combined matcher. Possible values: ALL, AT_LEAST_ONE, NONE
-	*/
+	 * Connective - Enum representing the possible operators for the Combined matcher. Possible values: ALL, AT_LEAST_ONE, NONE
+	 */
 	public enum Connective
 	{
 		ALL,
@@ -48,8 +48,8 @@ public with sharing class fflib_MatcherDefinitions
 	*/
 
 	/**
-	* Combined matcher: compares the supplied argument matches one, all or none of the internal matchers
-	*/
+	 * Combined matcher: compares the supplied argument matches one, all or none of the internal matchers
+	 */
 	@NamespaceAccessible
 	public class Combined implements fflib_IMatcher
 	{
@@ -57,11 +57,11 @@ public with sharing class fflib_MatcherDefinitions
 		private List<fflib_IMatcher> internalMatchers;
 
 		/**
-		* Combined constructor
-		* @param connectiveExpression Controls the combination mode, i.e. if we need to match all, any or none of the inner matchers
-		* @param internalMatchers An ordered list of the internal matchers to be combined
-		* @return fflib_MatcherDefinitions.Combined A new Combined instance
-		*/
+		 * Combined constructor
+		 * @param connectiveExpression Controls the combination mode, i.e. if we need to match all, any or none of the inner matchers
+		 * @param internalMatchers An ordered list of the internal matchers to be combined
+		 * @return fflib_MatcherDefinitions.Combined A new Combined instance
+		 */
 		public Combined(Connective connectiveExpression, List<fflib_IMatcher> internalMatchers)
 		{
 			this.connectiveExpression = validate(connectiveExpression);
@@ -151,18 +151,18 @@ public with sharing class fflib_MatcherDefinitions
 	*/
 
 	/**
-	* Eq matcher: checks if the supplied argument is equal (==) to a specified object
-	*/
+	 * Eq matcher: checks if the supplied argument is equal (==) to a specified object
+	 */
 	@NamespaceAccessible
 	public class Eq implements fflib_IMatcher
 	{
 		private Object toMatch;
 
 		/**
-		* Eq constructor
-		* @param toMatch The object to be compared
-		* @return fflib_MatcherDefinitions.Eq A new Eq instance
-		*/
+		 * Eq constructor
+		 * @param toMatch The object to be compared
+		 * @return fflib_MatcherDefinitions.Eq A new Eq instance
+		 */
 		public Eq(Object toMatch)
 		{
 			this.toMatch = validateNotNull(toMatch);
@@ -180,18 +180,18 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* RefEq matcher: checks if the supplied argument is a reference to the same object (===) as a specified object
-	*/
+	 * RefEq matcher: checks if the supplied argument is a reference to the same object (===) as a specified object
+	 */
 	@NamespaceAccessible
 	public class RefEq implements fflib_IMatcher
 	{
 		private Object toMatch;
 
 		/**
-		* RefEq constructor
-		* @param toMatch The object to be compared
-		* @return fflib_MatcherDefinitions.RefEq A new RefEq instance
-		*/
+		 * RefEq constructor
+		 * @param toMatch The object to be compared
+		 * @return fflib_MatcherDefinitions.RefEq A new RefEq instance
+		 */
 		public RefEq(Object toMatch)
 		{
 			this.toMatch = validateNotNull(toMatch);
@@ -213,8 +213,8 @@ public with sharing class fflib_MatcherDefinitions
 	*/
 
 	/**
-	* AnyBoolean matcher: checks if the supplied argument is an instance of a Boolean
-	*/
+	 * AnyBoolean matcher: checks if the supplied argument is an instance of a Boolean
+	 */
 	@NamespaceAccessible
 	public class AnyBoolean implements fflib_IMatcher
 	{
@@ -230,8 +230,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnyDate matcher: checks if the supplied argument is an instance of a Date
-	*/
+	 * AnyDate matcher: checks if the supplied argument is an instance of a Date
+	 */
 	@NamespaceAccessible
 	public class AnyDate implements fflib_IMatcher
 	{
@@ -247,9 +247,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnyDatetime matcher: checks if the supplied argument is an instance of a Datetime
-	* @NamespaceAccessible
-	*/
+	 * AnyDatetime matcher: checks if the supplied argument is an instance of a Datetime
+	 * @NamespaceAccessible
+	 */
 	public class AnyDatetime implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -264,9 +264,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* @NamespaceAccessible
-	* AnyDecimal matcher: checks if the supplied argument is an instance of a Decimal
-	*/
+	 * @NamespaceAccessible
+	 * AnyDecimal matcher: checks if the supplied argument is an instance of a Decimal
+	 */
 	public class AnyDecimal implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -281,8 +281,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnyDouble matcher: checks if the supplied argument is an instance of a Double
-	*/
+	 * AnyDouble matcher: checks if the supplied argument is an instance of a Double
+	 */
 	@NamespaceAccessible
 	public class AnyDouble implements fflib_IMatcher
 	{
@@ -298,8 +298,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnyFieldSet matcher: checks if the supplied argument is an instance of a FieldSet
-	*/
+	 * AnyFieldSet matcher: checks if the supplied argument is an instance of a FieldSet
+	 */
 	@NamespaceAccessible
 	public class AnyFieldSet implements fflib_IMatcher
 	{
@@ -315,9 +315,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnyId matcher: checks if the supplied argument is an instance of an Id
-	* @NamespaceAccessible
-	*/
+	 * AnyId matcher: checks if the supplied argument is an instance of an Id
+	 * @NamespaceAccessible
+	 */
 	public class AnyId implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -332,9 +332,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* @NamespaceAccessible
-	* AnyInteger matcher: checks if the supplied argument is an instance of an Integer
-	*/
+	 * @NamespaceAccessible
+	 * AnyInteger matcher: checks if the supplied argument is an instance of an Integer
+	 */
 	public class AnyInteger implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -349,8 +349,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnyList matcher: checks if the supplied argument is an instance of a List
-	*/
+	 * AnyList matcher: checks if the supplied argument is an instance of a List
+	 */
 	@NamespaceAccessible
 	public class AnyList implements fflib_IMatcher
 	{
@@ -366,8 +366,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnyLong matcher: checks if the supplied argument is an instance of a Long
-	*/
+	 * AnyLong matcher: checks if the supplied argument is an instance of a Long
+	 */
 	@NamespaceAccessible
 	public class AnyLong implements fflib_IMatcher
 	{
@@ -383,8 +383,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnyObject matcher: checks if the supplied argument is an instance of an Object
-	*/
+	 * AnyObject matcher: checks if the supplied argument is an instance of an Object
+	 */
 	public class AnyObject implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -399,8 +399,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnyString matcher: checks if the supplied argument is an instance of a String
-	*/
+	 * AnyString matcher: checks if the supplied argument is an instance of a String
+	 */
 	@NamespaceAccessible
 	public class AnyString implements fflib_IMatcher
 	{
@@ -416,8 +416,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnySObject matcher: checks if the supplied argument is an instance of an SObject
-	*/
+	 * AnySObject matcher: checks if the supplied argument is an instance of an SObject
+	 */
 	@NamespaceAccessible
 	public class AnySObject implements fflib_IMatcher
 	{
@@ -433,8 +433,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnySObjectField matcher: checks if the supplied argument is an instance of an SObjectField
-	*/
+	 * AnySObjectField matcher: checks if the supplied argument is an instance of an SObjectField
+	 */
 	@NamespaceAccessible
 	public class AnySObjectField implements fflib_IMatcher
 	{
@@ -450,9 +450,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* AnySObjectType matcher: checks if the supplied argument is an instance of an SObjectType
-	* @NamespaceAccessible
-	*/
+	 * AnySObjectType matcher: checks if the supplied argument is an instance of an SObjectType
+	 * @NamespaceAccessible
+	 */
 	public class AnySObjectType implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -471,8 +471,8 @@ public with sharing class fflib_MatcherDefinitions
 	*/
 
 	/**
-	* DatetimeAfter matcher: checks if the supplied argument is after a specified datetime
-	*/
+	 * DatetimeAfter matcher: checks if the supplied argument is after a specified datetime
+	 */
 	@NamespaceAccessible
 	public class DatetimeAfter implements fflib_IMatcher
 	{
@@ -480,11 +480,11 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusive;
 
 		/**
-		* DatetimeAfter constructor
-		* @param fromDatetime The datetime to be compared
-		* @param inclusive Whether or not dates equal to the fromDatetime should be considered a match
-		* @return fflib_MatcherDefinitions.DatetimeAfter A new DatetimeAfter instance
-		*/
+		 * DatetimeAfter constructor
+		 * @param fromDatetime The datetime to be compared
+		 * @param inclusive Whether or not dates equal to the fromDatetime should be considered a match
+		 * @return fflib_MatcherDefinitions.DatetimeAfter A new DatetimeAfter instance
+		 */
 		public DatetimeAfter(Datetime fromDatetime, Boolean inclusive)
 		{
 			this.fromDatetime = (Datetime) validateNotNull(fromDatetime);
@@ -516,8 +516,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* DatetimeBefore matcher: checks if the supplied argument is before a specified datetime
-	*/
+	 * DatetimeBefore matcher: checks if the supplied argument is before a specified datetime
+	 */
 	@NamespaceAccessible
 	public class DatetimeBefore implements fflib_IMatcher
 	{
@@ -525,11 +525,11 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusive;
 
 		/**
-		* DatetimeBefore constructor
-		* @param toDatetime The datetime to be compared
-		* @param inclusive Whether or not dates equal to the toDatetime should be considered a match
-		* @return fflib_MatcherDefinitions.DatetimeBefore A new DatetimeBefore instance
-		*/
+		 * DatetimeBefore constructor
+		 * @param toDatetime The datetime to be compared
+		 * @param inclusive Whether or not dates equal to the toDatetime should be considered a match
+		 * @return fflib_MatcherDefinitions.DatetimeBefore A new DatetimeBefore instance
+		 */
 		public DatetimeBefore(Datetime toDatetime, Boolean inclusive)
 		{
 			this.toDatetime = (Datetime) validateNotNull(toDatetime);
@@ -561,8 +561,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* DatetimeBetween matcher: checks if the supplied argument is between two specified datetimes
-	*/
+	 * DatetimeBetween matcher: checks if the supplied argument is between two specified datetimes
+	 */
 	@NamespaceAccessible
 	public class DatetimeBetween implements fflib_IMatcher
 	{
@@ -572,13 +572,13 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusiveTo;
 
 		/**
-		* DatetimeBetween constructor
-		* @param fromDatetime The lower bound datetime to be compared
-		* @param inclusiveFrom Whether or not dates equal to the fromDatetime should be considered a match
-		* @param toDatetime The upper bound dateetime to be compared
-		* @param inclusiveTo Whether or not dates equal to the toDatetime should be considered a match
-		* @return fflib_MatcherDefinitions.DatetimeBetween A new DatetimeBetween instance
-		*/
+		 * DatetimeBetween constructor
+		 * @param fromDatetime The lower bound datetime to be compared
+		 * @param inclusiveFrom Whether or not dates equal to the fromDatetime should be considered a match
+		 * @param toDatetime The upper bound dateetime to be compared
+		 * @param inclusiveTo Whether or not dates equal to the toDatetime should be considered a match
+		 * @return fflib_MatcherDefinitions.DatetimeBetween A new DatetimeBetween instance
+		 */
 		public DatetimeBetween(Datetime fromDatetime, Boolean inclusiveFrom, Datetime toDatetime, Boolean inclusiveTo)
 		{
 			this.fromDatetime = (Datetime) validateNotNull(fromDatetime);
@@ -612,8 +612,8 @@ public with sharing class fflib_MatcherDefinitions
 	*/
 
 	/**
-	* DecimalBetween matcher: checks if the supplied argument is between two specified decimals
-	*/
+	 * DecimalBetween matcher: checks if the supplied argument is between two specified decimals
+	 */
 	@NamespaceAccessible
 	public class DecimalBetween implements fflib_IMatcher
 	{
@@ -623,13 +623,13 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusiveUpper;
 
 		/**
-		* DecimalBetween constructor
-		* @param lower The lower bound number to be compared
-		* @param inclusiveLower Whether or not numbers equal to lower should be considered a match
-		* @param upper The upper bound number to be compared
-		* @param inclusiveUpper Whether or not numbers equal to upper should be considered a match
-		* @return fflib_MatcherDefinitions.DecimalBetween A new DecimalBetween instance
-		*/
+		 * DecimalBetween constructor
+		 * @param lower The lower bound number to be compared
+		 * @param inclusiveLower Whether or not numbers equal to lower should be considered a match
+		 * @param upper The upper bound number to be compared
+		 * @param inclusiveUpper Whether or not numbers equal to upper should be considered a match
+		 * @return fflib_MatcherDefinitions.DecimalBetween A new DecimalBetween instance
+		 */
 		public DecimalBetween(Decimal lower, Boolean inclusiveLower, Decimal upper, Boolean inclusiveUpper)
 		{
 			this.lower = (Decimal) validateNotNull(lower);
@@ -660,8 +660,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* DecimalLessThan matcher: checks if the supplied argument is less than a specified decimal
-	*/
+	 * DecimalLessThan matcher: checks if the supplied argument is less than a specified decimal
+	 */
 	@NamespaceAccessible
 	public class DecimalLessThan implements fflib_IMatcher
 	{
@@ -669,11 +669,11 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusive;
 
 		/**
-		* DecimalLessThan constructor
-		* @param toMatch The number to be compared against
-		* @param inclusive Whether or not numbers equal to toMatch should be considered a match
-		* @return fflib_MatcherDefinitions.DecimalLessThan A new DecimalLessThan instance
-		*/
+		 * DecimalLessThan constructor
+		 * @param toMatch The number to be compared against
+		 * @param inclusive Whether or not numbers equal to toMatch should be considered a match
+		 * @return fflib_MatcherDefinitions.DecimalLessThan A new DecimalLessThan instance
+		 */
 		public DecimalLessThan(Decimal toMatch, Boolean inclusive)
 		{
 			this.toMatch = (Decimal) validateNotNull(toMatch);
@@ -705,8 +705,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* DecimalMoreThan matcher: checks if the supplied argument is greater than a specified decimal
-	*/
+	 * DecimalMoreThan matcher: checks if the supplied argument is greater than a specified decimal
+	 */
 	@NamespaceAccessible
 	public class DecimalMoreThan implements fflib_IMatcher
 	{
@@ -714,11 +714,11 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusive;
 
 		/**
-		* DecimalMoreThan constructor
-		* @param toMatch The number to be compared against
-		* @param inclusive Whether or not numbers equal to toMatch should be considered a match
-		* @return fflib_MatcherDefinitions.DecimalMoreThan A new DecimalMoreThan instance
-		*/
+		 * DecimalMoreThan constructor
+		 * @param toMatch The number to be compared against
+		 * @param inclusive Whether or not numbers equal to toMatch should be considered a match
+		 * @return fflib_MatcherDefinitions.DecimalMoreThan A new DecimalMoreThan instance
+		 */
 		public DecimalMoreThan(Decimal toMatch, Boolean inclusive)
 		{
 			this.toMatch = (Decimal) validateNotNull(toMatch);
@@ -750,13 +750,13 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* FIELDSET MATCHERS
-	*/
+	 * FIELDSET MATCHERS
+	 */
 
 	/**
-	* FieldSetEquivalentTo matcher: checks the supplied argument is a field set with the same field set members as a specified field set
-	* This matcher is needed because equivalent FieldSets do not pass == checks, and we can't override equals/hashcode on FieldSets.
-	*/
+	 * FieldSetEquivalentTo matcher: checks the supplied argument is a field set with the same field set members as a specified field set
+	 * This matcher is needed because equivalent FieldSets do not pass == checks, and we can't override equals/hashcode on FieldSets.
+	 */
 	@NamespaceAccessible
 	public class FieldSetEquivalentTo implements fflib_IMatcher
 	{
@@ -792,9 +792,9 @@ public with sharing class fflib_MatcherDefinitions
 	*/
 
 	/**
-	* IsNotNull matcher: checks the supplied argument is not null
-	* @NamespaceAccessible
-	*/
+	 * IsNotNull matcher: checks the supplied argument is not null
+	 * @NamespaceAccessible
+	 */
 	public class IsNotNull implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -809,8 +809,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* IsNull matcher: checks the supplied argument is null
-	*/
+	 * IsNull matcher: checks the supplied argument is null
+	 */
 	@NamespaceAccessible
 	public class IsNull implements fflib_IMatcher
 	{
@@ -830,18 +830,18 @@ public with sharing class fflib_MatcherDefinitions
 	*/
 
 	/**
-	* ListContains matcher: checks if the supplied argument is equal (==) to any of the elements in a specified list
-	*/
+	 * ListContains matcher: checks if the supplied argument is equal (==) to any of the elements in a specified list
+	 */
 	@NamespaceAccessible
 	public class ListContains implements fflib_IMatcher
 	{
 		private Object toMatch;
 
 		/**
-		* ListContains constructor
-		* @param toMatch The list of objects to be compared
-		* @return fflib_MatcherDefinitions.ListContains A new ListContains instance
-		*/
+		 * ListContains constructor
+		 * @param toMatch The list of objects to be compared
+		 * @return fflib_MatcherDefinitions.ListContains A new ListContains instance
+		 */
 		public ListContains(Object toMatch)
 		{
 			this.toMatch = toMatch;
@@ -870,9 +870,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* ListIsEmpty matcher: checks if the supplied argument is an empty list
-	* @NamespaceAccessible
-	*/
+	 * ListIsEmpty matcher: checks if the supplied argument is an empty list
+	 * @NamespaceAccessible
+	 */
 	public class ListIsEmpty implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -891,18 +891,18 @@ public with sharing class fflib_MatcherDefinitions
 	*/
 
 	/**
-	* SObjectOfType matcher: checks if the supplied argument has the specified SObjectType
-	* @NamespaceAccessible
-	*/
+	 * SObjectOfType matcher: checks if the supplied argument has the specified SObjectType
+	 * @NamespaceAccessible
+	 */
 	public class SObjectOfType implements fflib_IMatcher
 	{
 		private Schema.SObjectType objectType;
 
 		/**
-		* SObjectOfType constructor
-		* @param objectType The SObjectType to be compared
-		* @return fflib_MatcherDefinitions.SObjectOfType A new SObjectOfType instance
-		*/
+		 * SObjectOfType constructor
+		 * @param objectType The SObjectType to be compared
+		 * @return fflib_MatcherDefinitions.SObjectOfType A new SObjectOfType instance
+		 */
 		public SObjectOfType(Schema.SObjectType objectType)
 		{
 			this.objectType = (Schema.SObjectType) validateNotNull(objectType);
@@ -926,22 +926,22 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* SObjectWith matcher: compares the supplied argument against a Map<Schema.SObjectField, Object>, representing fields and their expected values.
-	* Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
-	*
-	* If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
-	* the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
-	*/
+	 * SObjectWith matcher: compares the supplied argument against a Map<Schema.SObjectField, Object>, representing fields and their expected values.
+	 * Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
+	 *
+	 * If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
+	 * the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
+	 */
 	@NamespaceAccessible
 	public class SObjectWith implements fflib_IMatcher
 	{
 		private Map<Schema.SObjectField, Object> toMatch;
 
 		/**
-		* SObjectWith constructor
-		* @param toMatch A map of fields to their values to be compared. We compare each of these fields against the supplied sobject's field values.
-		* @return fflib_MatcherDefinitions.SObjectWith A new SObjectWith instance
-		*/
+		 * SObjectWith constructor
+		 * @param toMatch A map of fields to their values to be compared. We compare each of these fields against the supplied sobject's field values.
+		 * @return fflib_MatcherDefinitions.SObjectWith A new SObjectWith instance
+		 */
 		public SObjectWith(Map<Schema.SObjectField, Object> toMatch)
 		{
 			this.toMatch = validate(toMatch);
@@ -979,30 +979,30 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* SObjectsWith matcher: compares the supplied list<Sobject> argument against a list<Map<Schema.SObjectField, Object>>, representing fields and their expected values.
-	* Each list element represents one Sobject in a list supplied to a mocked method that accepts list<SObject>.
-	* Each list element that is a map<Schema.SobjectField,Object> is compared against the equivalent argument list element position
-	*
-	* Example:
-	* You use uow.registerNew(someListofAccounts). You mock uow in the testmethod.
-	* toMatch is new list<Schema.SObjectField,Object> {
-	* new map<Schema.SobjectField,Object> {Account.Name => 'foo'},
-	* new map<Schema.SobjectField,Object> {Account.Name => 'bar'}
-	* }
-	* By default, matchers compare against argument elements in order, viz:
-	* The matcher will compare the first Account in the list passed to uow.registerNew to the first map of field values (i.e. Account[0].Name must be 'foo')
-	* The matcher then compares the second Account in the list passed to uow.registerNew to the second map of field values (i.e. Account[1].Name must be 'bar')
-	*
-	* Optional second argument matchInOrderr if false means that each argument element is compared against all matcher elements
-	* if everuy argument is matched exactly once and no matcher matches more than once, then the match is true
-	*
-	* If the arity of the list passed in the mocked method doesn't agree with the arity of the map of expected field values, false is returned
-	*
-	* Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
-	*
-	* If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
-	* the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
-	*/
+	 * SObjectsWith matcher: compares the supplied list<Sobject> argument against a list<Map<Schema.SObjectField, Object>>, representing fields and their expected values.
+	 * Each list element represents one Sobject in a list supplied to a mocked method that accepts list<SObject>.
+	 * Each list element that is a map<Schema.SobjectField,Object> is compared against the equivalent argument list element position
+	 *
+	 * Example:
+	 * You use uow.registerNew(someListofAccounts). You mock uow in the testmethod.
+	 * toMatch is new list<Schema.SObjectField,Object> {
+	 * new map<Schema.SobjectField,Object> {Account.Name => 'foo'},
+	 * new map<Schema.SobjectField,Object> {Account.Name => 'bar'}
+	 * }
+	 * By default, matchers compare against argument elements in order, viz:
+	 * The matcher will compare the first Account in the list passed to uow.registerNew to the first map of field values (i.e. Account[0].Name must be 'foo')
+	 * The matcher then compares the second Account in the list passed to uow.registerNew to the second map of field values (i.e. Account[1].Name must be 'bar')
+	 *
+	 * Optional second argument matchInOrderr if false means that each argument element is compared against all matcher elements
+	 * if everuy argument is matched exactly once and no matcher matches more than once, then the match is true
+	 *
+	 * If the arity of the list passed in the mocked method doesn't agree with the arity of the map of expected field values, false is returned
+	 *
+	 * Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
+	 *
+	 * If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
+	 * the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
+	 */
 	@NamespaceAccessible
 	public class SObjectsWith implements fflib_IMatcher
 	{
@@ -1017,10 +1017,10 @@ public with sharing class fflib_MatcherDefinitions
 		}
 
 		/**
-		* SObjectsWith constructor
-		* @param toMatch A list of maps of fields to their values to be compared. We compare each of these fields against the supplied list of sobject's field values.
-		* @return fflib_MatcherDefinitions.SObjectWith A new SObjectWith instance
-		*/
+		 * SObjectsWith constructor
+		 * @param toMatch A list of maps of fields to their values to be compared. We compare each of these fields against the supplied list of sobject's field values.
+		 * @return fflib_MatcherDefinitions.SObjectWith A new SObjectWith instance
+		 */
 		public SObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch, Boolean matchInOrder)
 		{
 			this.toMatch = validate(toMatch);
@@ -1126,10 +1126,10 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* helper for the sObjectWith, sObjectsWith matchers
-	* Compares to see if the field values in toMatch exist in the sobj
-	* *
-	*/
+	 * helper for the sObjectWith, sObjectsWith matchers
+	 * Compares to see if the field values in toMatch exist in the sobj
+	 * *
+	 */
 	private static Boolean sObjectMatches(Sobject sobj, map<Schema.SobjectField, Object> toMatch)
 	{
 		for (Schema.SObjectField f : toMatch.keySet())
@@ -1156,18 +1156,18 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* SObjectWithId matcher: checks if the supplied argument has the specified Id
-	*/
+	 * SObjectWithId matcher: checks if the supplied argument has the specified Id
+	 */
 	@NamespaceAccessible
 	public class SObjectWithId implements fflib_IMatcher
 	{
 		private Id toMatch;
 
 		/**
-		* SObjectWithId constructor
-		* @param toMatch The Id to be compared
-		* @return fflib_MatcherDefinitions.SObjectWithId A new SObjectWithId instance
-		*/
+		 * SObjectWithId constructor
+		 * @param toMatch The Id to be compared
+		 * @return fflib_MatcherDefinitions.SObjectWithId A new SObjectWithId instance
+		 */
 		public SObjectWithId(Id toMatch)
 		{
 			this.toMatch = (Id) validateNotNull(toMatch);
@@ -1191,18 +1191,18 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* SObjectWithName matcher: checks if the supplied argument has the specified Name
-	* @NamespaceAccessible
-	*/
+	 * SObjectWithName matcher: checks if the supplied argument has the specified Name
+	 * @NamespaceAccessible
+	 */
 	public class SObjectWithName implements fflib_IMatcher
 	{
 		private String toMatch;
 
 		/**
-		* SObjectWithName constructor
-		* @param toMatch The name to be compared
-		* @return fflib_MatcherDefinitions.SObjectWithName A new SObjectWithName instance
-		*/
+		 * SObjectWithName constructor
+		 * @param toMatch The name to be compared
+		 * @return fflib_MatcherDefinitions.SObjectWithName A new SObjectWithName instance
+		 */
 		public SObjectWithName(String toMatch)
 		{
 			this.toMatch = (String) validateNotNull(toMatch);
@@ -1237,18 +1237,18 @@ public with sharing class fflib_MatcherDefinitions
 	*/
 
 	/**
-	* StringContains matcher: checks if the supplied argument contains the specified substring
-	*/
+	 * StringContains matcher: checks if the supplied argument contains the specified substring
+	 */
 	@NamespaceAccessible
 	public class StringContains implements fflib_IMatcher
 	{
 		private String toMatch;
 
 		/**
-		* StringContains constructor
-		* @param toMatch The substring to be compared
-		* @return fflib_MatcherDefinitions.StringContains A new StringContains instance
-		*/
+		 * StringContains constructor
+		 * @param toMatch The substring to be compared
+		 * @return fflib_MatcherDefinitions.StringContains A new StringContains instance
+		 */
 		public StringContains(String toMatch)
 		{
 			this.toMatch = (String) validateNotNull(toMatch);
@@ -1266,18 +1266,18 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* StringEndsWith matcher: checks if the supplied argument ends with the specified substring
-	*/
+	 * StringEndsWith matcher: checks if the supplied argument ends with the specified substring
+	 */
 	@NamespaceAccessible
 	public class StringEndsWith implements fflib_IMatcher
 	{
 		private String toMatch;
 
 		/**
-		* StringEndsWith constructor
-		* @param toMatch The substring to be compared
-		* @return fflib_MatcherDefinitions.StringEndsWith A new StringEndsWith instance
-		*/
+		 * StringEndsWith constructor
+		 * @param toMatch The substring to be compared
+		 * @return fflib_MatcherDefinitions.StringEndsWith A new StringEndsWith instance
+		 */
 		public StringEndsWith(String toMatch)
 		{
 			this.toMatch = (String) validateNotNull(toMatch);
@@ -1295,9 +1295,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* StringIsBlank matcher: checks if the supplied argument is a blank String
-	* @NamespaceAccessible
-	*/
+	 * StringIsBlank matcher: checks if the supplied argument is a blank String
+	 * @NamespaceAccessible
+	 */
 	public class StringIsBlank implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -1312,9 +1312,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* @NamespaceAccessible
-	* StringIsNotBlank matcher: checks if the supplied argument is a non-blank string
-	*/
+	 * @NamespaceAccessible
+	 * StringIsNotBlank matcher: checks if the supplied argument is a non-blank string
+	 */
 	public class StringIsNotBlank implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -1329,8 +1329,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* StringMatches matcher: checks if the supplied argument matches the specified regex expression
-	*/
+	 * StringMatches matcher: checks if the supplied argument matches the specified regex expression
+	 */
 	@NamespaceAccessible
 	public class StringMatches implements fflib_IMatcher
 	{
@@ -1338,10 +1338,10 @@ public with sharing class fflib_MatcherDefinitions
 		private final String regEx;
 
 		/**
-		* StringMatches constructor
-		* @param toMatch The substring to be compared
-		* @return fflib_MatcherDefinitions.StringMatches A new StringMatches instance
-		*/
+		 * StringMatches constructor
+		 * @param toMatch The substring to be compared
+		 * @return fflib_MatcherDefinitions.StringMatches A new StringMatches instance
+		 */
 		public StringMatches(String regEx)
 		{
 			this.regEx = regEx;
@@ -1360,18 +1360,18 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	* StringStartsWith matcher: checks if the supplied argument starts with the specified substring
-	*/
+	 * StringStartsWith matcher: checks if the supplied argument starts with the specified substring
+	 */
 	@NamespaceAccessible
 	public class StringStartsWith implements fflib_IMatcher
 	{
 		private String toMatch;
 
 		/**
-		* StringStartsWith constructor
-		* @param toMatch The substring to be compared
-		* @return fflib_MatcherDefinitions.StringStartsWith A new StringStartsWith instance
-		*/
+		 * StringStartsWith constructor
+		 * @param toMatch The substring to be compared
+		 * @return fflib_MatcherDefinitions.StringStartsWith A new StringStartsWith instance
+		 */
 		public StringStartsWith(String toMatch)
 		{
 			this.toMatch = (String) validateNotNull(toMatch);

--- a/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatcherDefinitions.cls
@@ -1,73 +1,73 @@
 /**
- * Copyright (c) 2014-2017, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2014-2017, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 /**
- * Class providing Apex Mocks standard matcher implementations.
- * You shouldn't need to reference the classes directly outside of the ApexMocks framework, instead use the equivalent helper method in fflib_Match
- * to construct the matcher, register the matcher and return an object of the correct type to be called in your unit test.
- * E.g. Don't construct Eq(Object toMatch), instead call fflib_Match.eq(Object toMatch).
- */
+* Class providing Apex Mocks standard matcher implementations.
+* You shouldn't need to reference the classes directly outside of the ApexMocks framework, instead use the equivalent helper method in fflib_Match
+* to construct the matcher, register the matcher and return an object of the correct type to be called in your unit test.
+* E.g. Don't construct Eq(Object toMatch), instead call fflib_Match.eq(Object toMatch).
+*/
 @NamespaceAccessible
 public with sharing class fflib_MatcherDefinitions
 {
 	/**
-	 * Connective - Enum representing the possible operators for the Combined matcher. Possible values: ALL, AT_LEAST_ONE, NONE
-	 */
-	public Enum Connective
+	* Connective - Enum representing the possible operators for the Combined matcher. Possible values: ALL, AT_LEAST_ONE, NONE
+	*/
+	public enum Connective
 	{
 		ALL,
 		AT_LEAST_ONE,
 		NONE
 	}
-	
+
 	/*
-	 * COMBINED MATCHER
-	 */
-	
+	* COMBINED MATCHER
+	*/
+
 	/**
-	 * Combined matcher: compares the supplied argument matches one, all or none of the internal matchers
-	 */
+	* Combined matcher: compares the supplied argument matches one, all or none of the internal matchers
+	*/
 	@NamespaceAccessible
 	public class Combined implements fflib_IMatcher
 	{
 		private Connective connectiveExpression;
 		private List<fflib_IMatcher> internalMatchers;
-		
+
 		/**
-		 * Combined constructor
-		 * @param connectiveExpression Controls the combination mode, i.e. if we need to match all, any or none of the inner matchers
-		 * @param internalMatchers An ordered list of the internal matchers to be combined
-		 * @return fflib_MatcherDefinitions.Combined A new Combined instance
-		 */
+		* Combined constructor
+		* @param connectiveExpression Controls the combination mode, i.e. if we need to match all, any or none of the inner matchers
+		* @param internalMatchers An ordered list of the internal matchers to be combined
+		* @return fflib_MatcherDefinitions.Combined A new Combined instance
+		*/
 		public Combined(Connective connectiveExpression, List<fflib_IMatcher> internalMatchers)
 		{
 			this.connectiveExpression = validate(connectiveExpression);
 			this.internalMatchers = validate(internalMatchers);
 		}
-		
+
 		public Boolean matches(Object arg)
 		{
 			for (fflib_IMatcher internalMatcher : internalMatchers)
@@ -91,31 +91,31 @@ public with sharing class fflib_MatcherDefinitions
 					return false;
 				}
 			}
-			
+
 			//We didn't return early.
 			//If matching any, must have been no matches => failure!
 			//If matching all, must have been all matches => success!
 			//If matching none, must have been all mismatches => success!
 			return connectiveExpression != Connective.AT_LEAST_ONE;
 		}
-		
+
 		private Connective validate(Connective connectiveExpression)
 		{
 			if (connectiveExpression == null)
 			{
 				throw new fflib_ApexMocks.ApexMocksException('Invalid connective expression: ' + connectiveExpression);
 			}
-			
+
 			return connectiveExpression;
 		}
-		
-		private List<fflib_IMatcher>  validate(List<fflib_IMatcher> innerMatchers)
+
+		private List<fflib_IMatcher> validate(List<fflib_IMatcher> innerMatchers)
 		{
 			if (innerMatchers == null || innerMatchers.isEmpty())
 			{
 				throw new fflib_ApexMocks.ApexMocksException('Invalid inner matchers: ' + innerMatchers);
 			}
-			
+
 			return innerMatchers;
 		}
 
@@ -145,29 +145,29 @@ public with sharing class fflib_MatcherDefinitions
 			}
 		}
 	}
-	
+
 	/*
-	 * OBJECT MATCHERS
-	 */
-	
+	* OBJECT MATCHERS
+	*/
+
 	/**
-	 * Eq matcher: checks if the supplied argument is equal (==) to a specified object
-	 */
+	* Eq matcher: checks if the supplied argument is equal (==) to a specified object
+	*/
 	@NamespaceAccessible
 	public class Eq implements fflib_IMatcher
 	{
 		private Object toMatch;
-		
+
 		/**
-		 * Eq constructor
-		 * @param toMatch The object to be compared
-		 * @return fflib_MatcherDefinitions.Eq A new Eq instance
-		 */
+		* Eq constructor
+		* @param toMatch The object to be compared
+		* @return fflib_MatcherDefinitions.Eq A new Eq instance
+		*/
 		public Eq(Object toMatch)
 		{
 			this.toMatch = validateNotNull(toMatch);
 		}
-		
+
 		public Boolean matches(Object arg)
 		{
 			return toMatch == arg;
@@ -178,25 +178,25 @@ public with sharing class fflib_MatcherDefinitions
 			return '[equals ' + stringify(toMatch) + ']';
 		}
 	}
-	
+
 	/**
-	 * RefEq matcher: checks if the supplied argument is a reference to the same object (===) as a specified object
-	 */
+	* RefEq matcher: checks if the supplied argument is a reference to the same object (===) as a specified object
+	*/
 	@NamespaceAccessible
 	public class RefEq implements fflib_IMatcher
 	{
 		private Object toMatch;
-		
+
 		/**
-		 * RefEq constructor
-		 * @param toMatch The object to be compared
-		 * @return fflib_MatcherDefinitions.RefEq A new RefEq instance
-		 */
+		* RefEq constructor
+		* @param toMatch The object to be compared
+		* @return fflib_MatcherDefinitions.RefEq A new RefEq instance
+		*/
 		public RefEq(Object toMatch)
 		{
 			this.toMatch = validateNotNull(toMatch);
 		}
-		
+
 		public Boolean matches(Object arg)
 		{
 			return toMatch === arg;
@@ -207,14 +207,14 @@ public with sharing class fflib_MatcherDefinitions
 			return '[reference equals ' + fflib_MatcherDefinitions.stringify(toMatch) + ']';
 		}
 	}
-	
+
 	/*
-	 * ANY MATCHERS
-	 */
+	* ANY MATCHERS
+	*/
 
 	/**
-	 * AnyBoolean matcher: checks if the supplied argument is an instance of a Boolean
-	 */
+	* AnyBoolean matcher: checks if the supplied argument is an instance of a Boolean
+	*/
 	@NamespaceAccessible
 	public class AnyBoolean implements fflib_IMatcher
 	{
@@ -230,8 +230,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnyDate matcher: checks if the supplied argument is an instance of a Date
-	 */
+	* AnyDate matcher: checks if the supplied argument is an instance of a Date
+	*/
 	@NamespaceAccessible
 	public class AnyDate implements fflib_IMatcher
 	{
@@ -247,9 +247,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnyDatetime matcher: checks if the supplied argument is an instance of a Datetime
-	@NamespaceAccessible
-	 */
+	* AnyDatetime matcher: checks if the supplied argument is an instance of a Datetime
+	* @NamespaceAccessible
+	*/
 	public class AnyDatetime implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -264,9 +264,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	@NamespaceAccessible
-	 * AnyDecimal matcher: checks if the supplied argument is an instance of a Decimal
-	 */
+	* @NamespaceAccessible
+	* AnyDecimal matcher: checks if the supplied argument is an instance of a Decimal
+	*/
 	public class AnyDecimal implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -281,8 +281,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnyDouble matcher: checks if the supplied argument is an instance of a Double
-	 */
+	* AnyDouble matcher: checks if the supplied argument is an instance of a Double
+	*/
 	@NamespaceAccessible
 	public class AnyDouble implements fflib_IMatcher
 	{
@@ -298,8 +298,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnyFieldSet matcher: checks if the supplied argument is an instance of a FieldSet
-	 */
+	* AnyFieldSet matcher: checks if the supplied argument is an instance of a FieldSet
+	*/
 	@NamespaceAccessible
 	public class AnyFieldSet implements fflib_IMatcher
 	{
@@ -315,9 +315,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnyId matcher: checks if the supplied argument is an instance of an Id
-	@NamespaceAccessible
-	 */
+	* AnyId matcher: checks if the supplied argument is an instance of an Id
+	* @NamespaceAccessible
+	*/
 	public class AnyId implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -330,11 +330,11 @@ public with sharing class fflib_MatcherDefinitions
 			return '[any Id]';
 		}
 	}
-	
+
 	/**
-	@NamespaceAccessible
-	 * AnyInteger matcher: checks if the supplied argument is an instance of an Integer
-	 */
+	* @NamespaceAccessible
+	* AnyInteger matcher: checks if the supplied argument is an instance of an Integer
+	*/
 	public class AnyInteger implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -349,8 +349,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnyList matcher: checks if the supplied argument is an instance of a List
-	 */
+	* AnyList matcher: checks if the supplied argument is an instance of a List
+	*/
 	@NamespaceAccessible
 	public class AnyList implements fflib_IMatcher
 	{
@@ -366,8 +366,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnyLong matcher: checks if the supplied argument is an instance of a Long
-	 */
+	* AnyLong matcher: checks if the supplied argument is an instance of a Long
+	*/
 	@NamespaceAccessible
 	public class AnyLong implements fflib_IMatcher
 	{
@@ -383,8 +383,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnyObject matcher: checks if the supplied argument is an instance of an Object
-	 */
+	* AnyObject matcher: checks if the supplied argument is an instance of an Object
+	*/
 	public class AnyObject implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -397,10 +397,10 @@ public with sharing class fflib_MatcherDefinitions
 			return '[any Object]';
 		}
 	}
-	
+
 	/**
-	 * AnyString matcher: checks if the supplied argument is an instance of a String
-	 */
+	* AnyString matcher: checks if the supplied argument is an instance of a String
+	*/
 	@NamespaceAccessible
 	public class AnyString implements fflib_IMatcher
 	{
@@ -416,8 +416,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnySObject matcher: checks if the supplied argument is an instance of an SObject
-	 */
+	* AnySObject matcher: checks if the supplied argument is an instance of an SObject
+	*/
 	@NamespaceAccessible
 	public class AnySObject implements fflib_IMatcher
 	{
@@ -433,8 +433,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnySObjectField matcher: checks if the supplied argument is an instance of an SObjectField
-	 */
+	* AnySObjectField matcher: checks if the supplied argument is an instance of an SObjectField
+	*/
 	@NamespaceAccessible
 	public class AnySObjectField implements fflib_IMatcher
 	{
@@ -450,9 +450,9 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * AnySObjectType matcher: checks if the supplied argument is an instance of an SObjectType
-	@NamespaceAccessible
-	 */
+	* AnySObjectType matcher: checks if the supplied argument is an instance of an SObjectType
+	* @NamespaceAccessible
+	*/
 	public class AnySObjectType implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -465,37 +465,37 @@ public with sharing class fflib_MatcherDefinitions
 			return '[any SObjectType]';
 		}
 	}
-	
+
 	/*
-	 * DATETIME MATCHERS
-	 */
+	* DATETIME MATCHERS
+	*/
 
 	/**
-	 * DatetimeAfter matcher: checks if the supplied argument is after a specified datetime
-	 */
+	* DatetimeAfter matcher: checks if the supplied argument is after a specified datetime
+	*/
 	@NamespaceAccessible
 	public class DatetimeAfter implements fflib_IMatcher
 	{
 		private Datetime fromDatetime;
 		private Boolean inclusive;
-		
+
 		/**
-		 * DatetimeAfter constructor
-		 * @param fromDatetime The datetime to be compared
-		 * @param inclusive Whether or not dates equal to the fromDatetime should be considered a match
-		 * @return fflib_MatcherDefinitions.DatetimeAfter A new DatetimeAfter instance
-		 */
+		* DatetimeAfter constructor
+		* @param fromDatetime The datetime to be compared
+		* @param inclusive Whether or not dates equal to the fromDatetime should be considered a match
+		* @return fflib_MatcherDefinitions.DatetimeAfter A new DatetimeAfter instance
+		*/
 		public DatetimeAfter(Datetime fromDatetime, Boolean inclusive)
 		{
-			this.fromDatetime = (Datetime)validateNotNull(fromDatetime);
-			this.inclusive = (Boolean)validateNotNull(inclusive);
+			this.fromDatetime = (Datetime) validateNotNull(fromDatetime);
+			this.inclusive = (Boolean) validateNotNull(inclusive);
 		}
-		
+
 		public Boolean matches(Object arg)
 		{
 			if (arg instanceof Datetime)
 			{
-				Datetime datetimeToCompare = (Datetime)arg;
+				Datetime datetimeToCompare = (Datetime) arg;
 				return inclusive ? fromDatetime <= datetimeToCompare : fromDatetime < datetimeToCompare;
 			}
 
@@ -514,33 +514,33 @@ public with sharing class fflib_MatcherDefinitions
 			}
 		}
 	}
-	
+
 	/**
-	 * DatetimeBefore matcher: checks if the supplied argument is before a specified datetime
-	 */
+	* DatetimeBefore matcher: checks if the supplied argument is before a specified datetime
+	*/
 	@NamespaceAccessible
 	public class DatetimeBefore implements fflib_IMatcher
 	{
 		private Datetime toDatetime;
 		private Boolean inclusive;
-		
+
 		/**
-		 * DatetimeBefore constructor
-		 * @param toDatetime The datetime to be compared
-		 * @param inclusive Whether or not dates equal to the toDatetime should be considered a match
-		 * @return fflib_MatcherDefinitions.DatetimeBefore A new DatetimeBefore instance
-		 */
+		* DatetimeBefore constructor
+		* @param toDatetime The datetime to be compared
+		* @param inclusive Whether or not dates equal to the toDatetime should be considered a match
+		* @return fflib_MatcherDefinitions.DatetimeBefore A new DatetimeBefore instance
+		*/
 		public DatetimeBefore(Datetime toDatetime, Boolean inclusive)
 		{
-			this.toDatetime = (Datetime)validateNotNull(toDatetime);
-			this.inclusive = (Boolean)validateNotNull(inclusive);
+			this.toDatetime = (Datetime) validateNotNull(toDatetime);
+			this.inclusive = (Boolean) validateNotNull(inclusive);
 		}
-		
+
 		public Boolean matches(Object arg)
 		{
 			if (arg instanceof Datetime)
 			{
-				Datetime datetimeToCompare = (Datetime)arg;
+				Datetime datetimeToCompare = (Datetime) arg;
 				return inclusive ? datetimeToCompare <= toDatetime : datetimeToCompare < toDatetime;
 			}
 
@@ -561,8 +561,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * DatetimeBetween matcher: checks if the supplied argument is between two specified datetimes
-	 */
+	* DatetimeBetween matcher: checks if the supplied argument is between two specified datetimes
+	*/
 	@NamespaceAccessible
 	public class DatetimeBetween implements fflib_IMatcher
 	{
@@ -570,30 +570,29 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusiveFrom;
 		private Datetime toDatetime;
 		private Boolean inclusiveTo;
-		
+
 		/**
-		 * DatetimeBetween constructor
-		 * @param fromDatetime The lower bound datetime to be compared
-		 * @param inclusiveFrom Whether or not dates equal to the fromDatetime should be considered a match
-		 * @param toDatetime The upper bound dateetime to be compared
-		 * @param inclusiveTo Whether or not dates equal to the toDatetime should be considered a match
-		 * @return fflib_MatcherDefinitions.DatetimeBetween A new DatetimeBetween instance
-		 */
+		* DatetimeBetween constructor
+		* @param fromDatetime The lower bound datetime to be compared
+		* @param inclusiveFrom Whether or not dates equal to the fromDatetime should be considered a match
+		* @param toDatetime The upper bound dateetime to be compared
+		* @param inclusiveTo Whether or not dates equal to the toDatetime should be considered a match
+		* @return fflib_MatcherDefinitions.DatetimeBetween A new DatetimeBetween instance
+		*/
 		public DatetimeBetween(Datetime fromDatetime, Boolean inclusiveFrom, Datetime toDatetime, Boolean inclusiveTo)
 		{
-			this.fromDatetime = (Datetime)validateNotNull(fromDatetime);
-			this.inclusiveFrom = (Boolean)validateNotNull(inclusiveFrom);
-			this.toDatetime = (Datetime)validateNotNull(toDatetime);
-			this.inclusiveTo = (Boolean)validateNotNull(inclusiveTo);
+			this.fromDatetime = (Datetime) validateNotNull(fromDatetime);
+			this.inclusiveFrom = (Boolean) validateNotNull(inclusiveFrom);
+			this.toDatetime = (Datetime) validateNotNull(toDatetime);
+			this.inclusiveTo = (Boolean) validateNotNull(inclusiveTo);
 		}
-		
+
 		public Boolean matches(Object arg)
 		{
 			if (arg instanceof Datetime)
 			{
-				Datetime datetimeToCompare = (Datetime)arg;
-				if ((inclusiveFrom ? datetimeToCompare >= fromDatetime : datetimeToCompare > fromDatetime)
-					&& (inclusiveTo ? datetimeToCompare <= toDatetime : datetimeToCompare < toDatetime))
+				Datetime datetimeToCompare = (Datetime) arg;
+				if ((inclusiveFrom ? datetimeToCompare >= fromDatetime : datetimeToCompare > fromDatetime) && (inclusiveTo ? datetimeToCompare <= toDatetime : datetimeToCompare < toDatetime))
 				{
 					return true;
 				}
@@ -604,22 +603,17 @@ public with sharing class fflib_MatcherDefinitions
 
 		public override String toString()
 		{
-			return String.format('[{0} {1} and {2} {3}]', new List<String>{
-				inclusiveFrom ? 'on or after' : 'after',
-				JSON.serialize(fromDateTime),
-				inclusiveTo ? 'on or before' : 'before',
-				JSON.serialize(toDateTime)
-			});
+			return String.format('[{0} {1} and {2} {3}]', new List<String>{ inclusiveFrom ? 'on or after' : 'after', JSON.serialize(fromDateTime), inclusiveTo ? 'on or before' : 'before', JSON.serialize(toDateTime) });
 		}
 	}
 
 	/*
-	 * DECIMAL (AND OTHER NUMBER) MATCHERS
-	 */
-	
+	* DECIMAL (AND OTHER NUMBER) MATCHERS
+	*/
+
 	/**
-	 * DecimalBetween matcher: checks if the supplied argument is between two specified decimals
-	 */
+	* DecimalBetween matcher: checks if the supplied argument is between two specified decimals
+	*/
 	@NamespaceAccessible
 	public class DecimalBetween implements fflib_IMatcher
 	{
@@ -629,29 +623,28 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusiveUpper;
 
 		/**
-		 * DecimalBetween constructor
-		 * @param lower The lower bound number to be compared
-		 * @param inclusiveLower Whether or not numbers equal to lower should be considered a match
-		 * @param upper The upper bound number to be compared
-		 * @param inclusiveUpper Whether or not numbers equal to upper should be considered a match
-		 * @return fflib_MatcherDefinitions.DecimalBetween A new DecimalBetween instance
-		 */
+		* DecimalBetween constructor
+		* @param lower The lower bound number to be compared
+		* @param inclusiveLower Whether or not numbers equal to lower should be considered a match
+		* @param upper The upper bound number to be compared
+		* @param inclusiveUpper Whether or not numbers equal to upper should be considered a match
+		* @return fflib_MatcherDefinitions.DecimalBetween A new DecimalBetween instance
+		*/
 		public DecimalBetween(Decimal lower, Boolean inclusiveLower, Decimal upper, Boolean inclusiveUpper)
 		{
-			this.lower = (Decimal)validateNotNull(lower);
-			this.inclusiveLower = (Boolean)validateNotNull(inclusiveLower);
-			this.upper = (Decimal)validateNotNull(upper);
-			this.inclusiveUpper = (Boolean)validateNotNull(inclusiveUpper);
+			this.lower = (Decimal) validateNotNull(lower);
+			this.inclusiveLower = (Boolean) validateNotNull(inclusiveLower);
+			this.upper = (Decimal) validateNotNull(upper);
+			this.inclusiveUpper = (Boolean) validateNotNull(inclusiveUpper);
 		}
 
 		public Boolean matches(Object arg)
 		{
 			if (arg != null && arg instanceof Decimal)
 			{
-				Decimal longArg = (Decimal)arg;
+				Decimal longArg = (Decimal) arg;
 
-				if ((inclusiveLower ? longArg >= lower : longArg > lower)
-					&& (inclusiveUpper ? longArg <= upper : longArg < upper))
+				if ((inclusiveLower ? longArg >= lower : longArg > lower) && (inclusiveUpper ? longArg <= upper : longArg < upper))
 				{
 					return true;
 				}
@@ -662,18 +655,13 @@ public with sharing class fflib_MatcherDefinitions
 
 		public override String toString()
 		{
-			return String.format('{0} {1} and {2} {3}', new List<String>{
-				inclusiveLower ? 'greater than or equal to' : 'greater than',
-				'' + lower,
-				inclusiveUpper ? 'less than or equal to' : 'less than',
-				'' + upper
-			});
+			return String.format('{0} {1} and {2} {3}', new List<String>{ inclusiveLower ? 'greater than or equal to' : 'greater than', '' + lower, inclusiveUpper ? 'less than or equal to' : 'less than', '' + upper });
 		}
 	}
 
 	/**
-	 * DecimalLessThan matcher: checks if the supplied argument is less than a specified decimal
-	 */
+	* DecimalLessThan matcher: checks if the supplied argument is less than a specified decimal
+	*/
 	@NamespaceAccessible
 	public class DecimalLessThan implements fflib_IMatcher
 	{
@@ -681,22 +669,22 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusive;
 
 		/**
-		 * DecimalLessThan constructor
-		 * @param toMatch The number to be compared against
-		 * @param inclusive Whether or not numbers equal to toMatch should be considered a match
-		 * @return fflib_MatcherDefinitions.DecimalLessThan A new DecimalLessThan instance
-		 */
+		* DecimalLessThan constructor
+		* @param toMatch The number to be compared against
+		* @param inclusive Whether or not numbers equal to toMatch should be considered a match
+		* @return fflib_MatcherDefinitions.DecimalLessThan A new DecimalLessThan instance
+		*/
 		public DecimalLessThan(Decimal toMatch, Boolean inclusive)
 		{
-			this.toMatch = (Decimal)validateNotNull(toMatch);
-			this.inclusive = (Boolean)validateNotNull(inclusive);
+			this.toMatch = (Decimal) validateNotNull(toMatch);
+			this.inclusive = (Boolean) validateNotNull(inclusive);
 		}
 
 		public Boolean matches(Object arg)
 		{
 			if (arg != null && arg instanceof Decimal)
 			{
-				Decimal longArg = (Decimal)arg;
+				Decimal longArg = (Decimal) arg;
 				return inclusive ? longArg <= toMatch : longArg < toMatch;
 			}
 
@@ -717,8 +705,8 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * DecimalMoreThan matcher: checks if the supplied argument is greater than a specified decimal
-	 */
+	* DecimalMoreThan matcher: checks if the supplied argument is greater than a specified decimal
+	*/
 	@NamespaceAccessible
 	public class DecimalMoreThan implements fflib_IMatcher
 	{
@@ -726,22 +714,22 @@ public with sharing class fflib_MatcherDefinitions
 		private Boolean inclusive;
 
 		/**
-		 * DecimalMoreThan constructor
-		 * @param toMatch The number to be compared against
-		 * @param inclusive Whether or not numbers equal to toMatch should be considered a match
-		 * @return fflib_MatcherDefinitions.DecimalMoreThan A new DecimalMoreThan instance
-		 */
+		* DecimalMoreThan constructor
+		* @param toMatch The number to be compared against
+		* @param inclusive Whether or not numbers equal to toMatch should be considered a match
+		* @return fflib_MatcherDefinitions.DecimalMoreThan A new DecimalMoreThan instance
+		*/
 		public DecimalMoreThan(Decimal toMatch, Boolean inclusive)
 		{
-			this.toMatch = (Decimal)validateNotNull(toMatch);
-			this.inclusive = (Boolean)validateNotNull(inclusive);
+			this.toMatch = (Decimal) validateNotNull(toMatch);
+			this.inclusive = (Boolean) validateNotNull(inclusive);
 		}
 
 		public Boolean matches(Object arg)
 		{
 			if (arg != null && arg instanceof Decimal)
 			{
-				Decimal longArg = (Decimal)arg;
+				Decimal longArg = (Decimal) arg;
 				return inclusive ? longArg >= toMatch : longArg > toMatch;
 			}
 
@@ -761,22 +749,22 @@ public with sharing class fflib_MatcherDefinitions
 		}
 	}
 
-	/** 
-	 * FIELDSET MATCHERS
-	 */
-	
 	/**
-	 * FieldSetEquivalentTo matcher: checks the supplied argument is a field set with the same field set members as a specified field set
-	 * This matcher is needed because equivalent FieldSets do not pass == checks, and we can't override equals/hashcode on FieldSets.
-	 */
+	* FIELDSET MATCHERS
+	*/
+
+	/**
+	* FieldSetEquivalentTo matcher: checks the supplied argument is a field set with the same field set members as a specified field set
+	* This matcher is needed because equivalent FieldSets do not pass == checks, and we can't override equals/hashcode on FieldSets.
+	*/
 	@NamespaceAccessible
 	public class FieldSetEquivalentTo implements fflib_IMatcher
 	{
 		private final Set<Schema.FieldSetMember> toMatch;
 
 		/*
-		 * Dirty test-only constructor, allowing us to test this class even if there are no field sets defined in the current org.
-		 */
+		* Dirty test-only constructor, allowing us to test this class even if there are no field sets defined in the current org.
+		*/
 		@TestVisible
 		public FieldSetEquivalentTo()
 		{
@@ -785,12 +773,12 @@ public with sharing class fflib_MatcherDefinitions
 
 		public FieldSetEquivalentTo(Schema.FieldSet toMatch)
 		{
-			this.toMatch = new Set<Schema.FieldSetMember>(((Schema.FieldSet)validateNotNull(toMatch)).getFields());
+			this.toMatch = new Set<Schema.FieldSetMember>(((Schema.FieldSet) validateNotNull(toMatch)).getFields());
 		}
 
 		public Boolean matches(Object arg)
 		{
-			return (toMatch != null && arg != null && arg instanceof Schema.FieldSet) ? toMatch == new Set<Schema.FieldSetMember>(((FieldSet)arg).getFields()) : false;
+			return (toMatch != null && arg != null && arg instanceof Schema.FieldSet) ? toMatch == new Set<Schema.FieldSetMember>(((FieldSet) arg).getFields()) : false;
 		}
 
 		public override String toString()
@@ -800,13 +788,13 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/*
-	 * IS MATCHERS
-	 */
-	
+	* IS MATCHERS
+	*/
+
 	/**
-	 * IsNotNull matcher: checks the supplied argument is not null
-	@NamespaceAccessible
-	 */
+	* IsNotNull matcher: checks the supplied argument is not null
+	* @NamespaceAccessible
+	*/
 	public class IsNotNull implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
@@ -819,10 +807,10 @@ public with sharing class fflib_MatcherDefinitions
 			return '[is not null]';
 		}
 	}
-	
+
 	/**
-	 * IsNull matcher: checks the supplied argument is null
-	 */
+	* IsNull matcher: checks the supplied argument is null
+	*/
 	@NamespaceAccessible
 	public class IsNull implements fflib_IMatcher
 	{
@@ -838,22 +826,22 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/*
-	 * LIST MATCHERS
-	 */
-	
+	* LIST MATCHERS
+	*/
+
 	/**
-	 * ListContains matcher: checks if the supplied argument is equal (==) to any of the elements in a specified list
-	 */
+	* ListContains matcher: checks if the supplied argument is equal (==) to any of the elements in a specified list
+	*/
 	@NamespaceAccessible
 	public class ListContains implements fflib_IMatcher
 	{
 		private Object toMatch;
-		
+
 		/**
-		 * ListContains constructor
-		 * @param toMatch The list of objects to be compared
-		 * @return fflib_MatcherDefinitions.ListContains A new ListContains instance
-		 */
+		* ListContains constructor
+		* @param toMatch The list of objects to be compared
+		* @return fflib_MatcherDefinitions.ListContains A new ListContains instance
+		*/
 		public ListContains(Object toMatch)
 		{
 			this.toMatch = toMatch;
@@ -863,7 +851,7 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			if (arg != null && arg instanceof List<Object>)
 			{
-				for (Object o : (List<Object>)arg)
+				for (Object o : (List<Object>) arg)
 				{
 					if (o == toMatch)
 					{
@@ -882,16 +870,14 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * ListIsEmpty matcher: checks if the supplied argument is an empty list
-	@NamespaceAccessible
-	 */
+	* ListIsEmpty matcher: checks if the supplied argument is an empty list
+	* @NamespaceAccessible
+	*/
 	public class ListIsEmpty implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
 		{
-			return arg != null
-				&& arg instanceof List<Object>
-				&& ((List<Object>)arg).isEmpty();
+			return arg != null && arg instanceof List<Object> && ((List<Object>) arg).isEmpty();
 		}
 
 		public override String toString()
@@ -901,32 +887,32 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/*
-	 * SOBJECT MATCHERS
-	 */
-	
+	* SOBJECT MATCHERS
+	*/
+
 	/**
-	 * SObjectOfType matcher: checks if the supplied argument has the specified SObjectType
-	@NamespaceAccessible
-	 */
+	* SObjectOfType matcher: checks if the supplied argument has the specified SObjectType
+	* @NamespaceAccessible
+	*/
 	public class SObjectOfType implements fflib_IMatcher
 	{
 		private Schema.SObjectType objectType;
 
 		/**
-		 * SObjectOfType constructor
-		 * @param objectType The SObjectType to be compared
-		 * @return fflib_MatcherDefinitions.SObjectOfType A new SObjectOfType instance
-		 */
+		* SObjectOfType constructor
+		* @param objectType The SObjectType to be compared
+		* @return fflib_MatcherDefinitions.SObjectOfType A new SObjectOfType instance
+		*/
 		public SObjectOfType(Schema.SObjectType objectType)
 		{
-			this.objectType = (Schema.SObjectType)validateNotNull(objectType);
+			this.objectType = (Schema.SObjectType) validateNotNull(objectType);
 		}
 
 		public Boolean matches(Object arg)
 		{
 			if (arg != null && arg instanceof SObject)
 			{
-				SObject soArg = (SObject)arg;
+				SObject soArg = (SObject) arg;
 				return soArg.getSObjectType() == objectType;
 			}
 
@@ -940,22 +926,22 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * SObjectWith matcher: compares the supplied argument against a Map<Schema.SObjectField, Object>, representing fields and their expected values.
-	 * Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
-	 * 
-	 * If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
-	 * the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
-	 */
+	* SObjectWith matcher: compares the supplied argument against a Map<Schema.SObjectField, Object>, representing fields and their expected values.
+	* Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
+	*
+	* If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
+	* the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
+	*/
 	@NamespaceAccessible
 	public class SObjectWith implements fflib_IMatcher
 	{
 		private Map<Schema.SObjectField, Object> toMatch;
 
 		/**
-		 * SObjectWith constructor
-		 * @param toMatch A map of fields to their values to be compared. We compare each of these fields against the supplied sobject's field values.
-		 * @return fflib_MatcherDefinitions.SObjectWith A new SObjectWith instance
-		 */
+		* SObjectWith constructor
+		* @param toMatch A map of fields to their values to be compared. We compare each of these fields against the supplied sobject's field values.
+		* @return fflib_MatcherDefinitions.SObjectWith A new SObjectWith instance
+		*/
 		public SObjectWith(Map<Schema.SObjectField, Object> toMatch)
 		{
 			this.toMatch = validate(toMatch);
@@ -965,8 +951,8 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			if (arg != null && arg instanceof SObject)
 			{
-				SObject soArg = (SObject)arg;
-				if (!sobjectMatches(soArg,this.toMatch))
+				SObject soArg = (SObject) arg;
+				if (!sobjectMatches(soArg, this.toMatch))
 				{
 					return false;
 				}
@@ -994,26 +980,26 @@ public with sharing class fflib_MatcherDefinitions
 
 	/**
 	* SObjectsWith matcher: compares the supplied list<Sobject> argument against a list<Map<Schema.SObjectField, Object>>, representing fields and their expected values.
-	* Each list element represents one Sobject in a list supplied to a mocked method that accepts list<SObject>. 
+	* Each list element represents one Sobject in a list supplied to a mocked method that accepts list<SObject>.
 	* Each list element that is a map<Schema.SobjectField,Object> is compared against the equivalent argument list element position
-	* 
+	*
 	* Example:
-	*   You use uow.registerNew(someListofAccounts). You mock uow in the testmethod.
-	*   toMatch is new list<Schema.SObjectField,Object> {
-	*      new map<Schema.SobjectField,Object> {Account.Name => 'foo'},
-	*      new map<Schema.SobjectField,Object> {Account.Name => 'bar'}
-	*    } 
-	*   By default, matchers compare against argument elements in order, viz:
-	* 		The matcher will compare the first Account in the list passed to uow.registerNew to the first map of field values (i.e. Account[0].Name must be 'foo')
-	*   	The matcher then compares the second Account in the list passed to uow.registerNew to the second map of field values (i.e. Account[1].Name must be 'bar')
-	* 	
-	*   Optional second argument matchInOrderr if false means that each argument element is compared against all matcher elements
-	*   if everuy argument is matched exactly once and no matcher matches more than once, then the match is true
-	* 
+	* You use uow.registerNew(someListofAccounts). You mock uow in the testmethod.
+	* toMatch is new list<Schema.SObjectField,Object> {
+	* new map<Schema.SobjectField,Object> {Account.Name => 'foo'},
+	* new map<Schema.SobjectField,Object> {Account.Name => 'bar'}
+	* }
+	* By default, matchers compare against argument elements in order, viz:
+	* The matcher will compare the first Account in the list passed to uow.registerNew to the first map of field values (i.e. Account[0].Name must be 'foo')
+	* The matcher then compares the second Account in the list passed to uow.registerNew to the second map of field values (i.e. Account[1].Name must be 'bar')
+	*
+	* Optional second argument matchInOrderr if false means that each argument element is compared against all matcher elements
+	* if everuy argument is matched exactly once and no matcher matches more than once, then the match is true
+	*
 	* If the arity of the list passed in the mocked method doesn't agree with the arity of the map of expected field values, false is returned
-	* 
+	*
 	* Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
-	* 
+	*
 	* If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
 	* the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
 	*/
@@ -1021,8 +1007,9 @@ public with sharing class fflib_MatcherDefinitions
 	public class SObjectsWith implements fflib_IMatcher
 	{
 		private list<Map<Schema.SObjectField, Object>> toMatch;
-		private Boolean matchInOrder {
-			get 
+		private Boolean matchInOrder
+		{
+			get
 			{
 				return matchInOrder == null ? false : matchInOrder;
 			}
@@ -1030,10 +1017,10 @@ public with sharing class fflib_MatcherDefinitions
 		}
 
 		/**
-		 * SObjectsWith constructor
-		 * @param toMatch A list of maps of fields to their values to be compared. We compare each of these fields against the supplied list of sobject's field values.
-		 * @return fflib_MatcherDefinitions.SObjectWith A new SObjectWith instance
-		 */
+		* SObjectsWith constructor
+		* @param toMatch A list of maps of fields to their values to be compared. We compare each of these fields against the supplied list of sobject's field values.
+		* @return fflib_MatcherDefinitions.SObjectWith A new SObjectWith instance
+		*/
 		public SObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch, Boolean matchInOrder)
 		{
 			this.toMatch = validate(toMatch);
@@ -1048,31 +1035,31 @@ public with sharing class fflib_MatcherDefinitions
 		{
 			if (arg != null && arg instanceof list<SObject>)
 			{
-				SObject[] sobjsArg = (SObject[])arg;
-				list<map<Schema.SObjectField,Object>> toMatches = new list<map<Schema.SObjectField,Object>>();
-                
+				SObject[] sobjsArg = (SObject[]) arg;
+				list<map<Schema.SObjectField, Object>> toMatches = new list<map<Schema.SObjectField, Object>>();
+
 				//	Counters for matchInOrder = false; not relevant for matchInOrder = true
-				list<Integer> argMatchedCounts = new list<Integer>();		// # times matched by a matcher. anything other than 1 is match error
-				list<Integer> matcherMatchedCounts = new list<Integer>(); 	// for each map<Schema.SObjectField,Object>
-        																	// # args that match it. Anything other than 1 is match error
-                
-                
-				for (map<Schema.SObjectField,Object> mtchElm : toMatch)
+				list<Integer> argMatchedCounts = new list<Integer>(); // # times matched by a matcher. anything other than 1 is match error
+				list<Integer> matcherMatchedCounts = new list<Integer>(); // for each map<Schema.SObjectField,Object>
+				// # args that match it. Anything other than 1 is match error
+
+				for (map<Schema.SObjectField, Object> mtchElm : toMatch)
 				{
 					toMatches.add(mtchElm);
 					matcherMatchedCounts.add(0);
-				}   
-                
-				if (sobjsArg.size() != toMatches.size())	// arity of arguments to mocked method doesn't agree with arity of expected matches
+				}
+
+				if (sobjsArg.size() != toMatches.size()) // arity of arguments to mocked method doesn't agree with arity of expected matches
 				{
 					return false;
 				}
-                
+
 				if (matchInOrder)
 				{
-					for (Integer i = 0; i < sobjsArg.size(); i++) 
-					{	// match in order (toMatch[i] must match arg[i])
-						if (!sobjectMatches(sobjsArg[i],toMatches[i]))
+					for (Integer i = 0; i < sobjsArg.size(); i++)
+					{
+						// match in order (toMatch[i] must match arg[i])
+						if (!sobjectMatches(sobjsArg[i], toMatches[i]))
 						{
 							return false;
 						}
@@ -1080,44 +1067,44 @@ public with sharing class fflib_MatcherDefinitions
 					return true;
 				}
 				else
-				{	
+				{
 					// match in any order (but every arg must be matched only once)
-					for (Integer i = 0; i < sobjsArg.size(); i++) 
+					for (Integer i = 0; i < sobjsArg.size(); i++)
 					{
 						argMatchedCounts.add(0);
-						// For each arg passed to mocked method, see if any match in the list of match field maps. 
+						// For each arg passed to mocked method, see if any match in the list of match field maps.
 						// Loop within loop so not hugely efficient but there are no IDs to rely on.
 						// Avoid unit test methods that build huge lists of expected results
-                         
+
 						for (Integer m = 0; m < toMatches.size(); m++)
 						{
-							if (sobjectMatches(sobjsArg[i],toMatches[m]))
+							if (sobjectMatches(sobjsArg[i], toMatches[m]))
 							{
-								argMatchedCounts[i] ++;
-								matcherMatchedCounts[m] ++;
+								argMatchedCounts[i]++;
+								matcherMatchedCounts[m]++;
 							}
 						}
 					}
 					// Check to see that every arg was matched only once
 					// Check to see that every matcher matched only once
 					// Anything else is a match fail
-                    
-					for (Integer i=0; i < argMatchedCounts.size(); i++)
+
+					for (Integer i = 0; i < argMatchedCounts.size(); i++)
 					{
-						if (argMatchedCounts[i] != 1 || matcherMatchedCounts[i] != 1) 
+						if (argMatchedCounts[i] != 1 || matcherMatchedCounts[i] != 1)
 						{
 							return false;
-						}      
+						}
 					}
-					return true;    
-				}    
+					return true;
+				}
 			}
 			return false;
 		}
 
 		private list<Map<Schema.SObjectField, Object>> validate(list<Map<Schema.SObjectField, Object>> arg)
 		{
-			if (arg == null || arg.isEmpty() )
+			if (arg == null || arg.isEmpty())
 			{
 				throw new fflib_ApexMocks.ApexMocksException('Arg cannot be null/empty/other than list of map<Schema.SobjectField,Object>: ' + arg);
 			}
@@ -1136,62 +1123,61 @@ public with sharing class fflib_MatcherDefinitions
 				return '[unordered SObjects with ' + fflib_MatcherDefinitions.stringify(toMatch) + ']';
 			}
 		}
-        
+	}
 
-	}    
-  
-    /**
-     * helper for the sObjectWith, sObjectsWith matchers
-     * Compares to see if the field values in toMatch exist in the sobj
-    **/
-    private static Boolean sObjectMatches(Sobject sobj, map<Schema.SobjectField,Object> toMatch)
-    {
-        for (Schema.SObjectField f : toMatch.keySet())
-        {
-            Object valueToMatch = toMatch.get(f);
-            
-            try
-            {
-                if (sobj.get(f) != valueToMatch)
-                {
-                    return false;
-                }
-            }
-            catch (Exception e)
-            {
-                //If we fail to get the value for a field it's either:
-                // - 'SObject row was retrieved via SOQL without querying the requested field' as a mismatch
-                // - System.SObjectException - Account.Id does not belong to SObject type Opportunity
-                //Don't care too much, just treat this as a mismatch.
-                return false;
-            }
-        }
-		return true;  // map of expected fieldvals found in sobj arg
-    }
-    
 	/**
-	 * SObjectWithId matcher: checks if the supplied argument has the specified Id
-	 */
+	* helper for the sObjectWith, sObjectsWith matchers
+	* Compares to see if the field values in toMatch exist in the sobj
+	* *
+	*/
+	private static Boolean sObjectMatches(Sobject sobj, map<Schema.SobjectField, Object> toMatch)
+	{
+		for (Schema.SObjectField f : toMatch.keySet())
+		{
+			Object valueToMatch = toMatch.get(f);
+
+			try
+			{
+				if (sobj.get(f) != valueToMatch)
+				{
+					return false;
+				}
+			}
+			catch (Exception e)
+			{
+				//If we fail to get the value for a field it's either:
+				// - 'SObject row was retrieved via SOQL without querying the requested field' as a mismatch
+				// - System.SObjectException - Account.Id does not belong to SObject type Opportunity
+				//Don't care too much, just treat this as a mismatch.
+				return false;
+			}
+		}
+		return true; // map of expected fieldvals found in sobj arg
+	}
+
+	/**
+	* SObjectWithId matcher: checks if the supplied argument has the specified Id
+	*/
 	@NamespaceAccessible
 	public class SObjectWithId implements fflib_IMatcher
 	{
 		private Id toMatch;
 
 		/**
-		 * SObjectWithId constructor
-		 * @param toMatch The Id to be compared
-		 * @return fflib_MatcherDefinitions.SObjectWithId A new SObjectWithId instance
-		 */
+		* SObjectWithId constructor
+		* @param toMatch The Id to be compared
+		* @return fflib_MatcherDefinitions.SObjectWithId A new SObjectWithId instance
+		*/
 		public SObjectWithId(Id toMatch)
 		{
-			this.toMatch = (Id)validateNotNull(toMatch);
+			this.toMatch = (Id) validateNotNull(toMatch);
 		}
 
 		public Boolean matches(Object arg)
 		{
 			if (arg != null && arg instanceof SObject)
 			{
-				SObject soArg = (SObject)arg;
+				SObject soArg = (SObject) arg;
 				return soArg.Id == toMatch;
 			}
 
@@ -1205,28 +1191,28 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * SObjectWithName matcher: checks if the supplied argument has the specified Name
-	@NamespaceAccessible
-	 */
+	* SObjectWithName matcher: checks if the supplied argument has the specified Name
+	* @NamespaceAccessible
+	*/
 	public class SObjectWithName implements fflib_IMatcher
 	{
 		private String toMatch;
 
 		/**
-		 * SObjectWithName constructor
-		 * @param toMatch The name to be compared
-		 * @return fflib_MatcherDefinitions.SObjectWithName A new SObjectWithName instance
-		 */
+		* SObjectWithName constructor
+		* @param toMatch The name to be compared
+		* @return fflib_MatcherDefinitions.SObjectWithName A new SObjectWithName instance
+		*/
 		public SObjectWithName(String toMatch)
 		{
-			this.toMatch = (String)validateNotNull(toMatch);
+			this.toMatch = (String) validateNotNull(toMatch);
 		}
 
 		public Boolean matches(Object arg)
 		{
 			if (arg != null && arg instanceof SObject)
 			{
-				SObject soArg = (SObject)arg;	
+				SObject soArg = (SObject) arg;
 				Schema.DescribeSObjectResult describe = soArg.getSObjectType().getDescribe();
 				for (Schema.SObjectField f : describe.fields.getMap().values())
 				{
@@ -1247,30 +1233,30 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/*
-	 * STRING MATCHERS
-	 */
-	
+	* STRING MATCHERS
+	*/
+
 	/**
-	 * StringContains matcher: checks if the supplied argument contains the specified substring
-	 */
+	* StringContains matcher: checks if the supplied argument contains the specified substring
+	*/
 	@NamespaceAccessible
 	public class StringContains implements fflib_IMatcher
 	{
 		private String toMatch;
-		
+
 		/**
-		 * StringContains constructor
-		 * @param toMatch The substring to be compared
-		 * @return fflib_MatcherDefinitions.StringContains A new StringContains instance
-		 */
+		* StringContains constructor
+		* @param toMatch The substring to be compared
+		* @return fflib_MatcherDefinitions.StringContains A new StringContains instance
+		*/
 		public StringContains(String toMatch)
 		{
-			this.toMatch = (String)validateNotNull(toMatch);
-		}	
-		
+			this.toMatch = (String) validateNotNull(toMatch);
+		}
+
 		public Boolean matches(Object arg)
 		{
-			return arg != null && arg instanceof String ? ((String)arg).contains(toMatch) : false;
+			return arg != null && arg instanceof String ? ((String) arg).contains(toMatch) : false;
 		}
 
 		public override String toString()
@@ -1280,26 +1266,26 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * StringEndsWith matcher: checks if the supplied argument ends with the specified substring
-	 */
+	* StringEndsWith matcher: checks if the supplied argument ends with the specified substring
+	*/
 	@NamespaceAccessible
 	public class StringEndsWith implements fflib_IMatcher
 	{
 		private String toMatch;
-		
+
 		/**
-		 * StringEndsWith constructor
-		 * @param toMatch The substring to be compared
-		 * @return fflib_MatcherDefinitions.StringEndsWith A new StringEndsWith instance
-		 */
+		* StringEndsWith constructor
+		* @param toMatch The substring to be compared
+		* @return fflib_MatcherDefinitions.StringEndsWith A new StringEndsWith instance
+		*/
 		public StringEndsWith(String toMatch)
 		{
-			this.toMatch = (String)validateNotNull(toMatch);
-		}	
-		
+			this.toMatch = (String) validateNotNull(toMatch);
+		}
+
 		public Boolean matches(Object arg)
 		{
-			return arg != null && arg instanceof String ? ((String)arg).endsWith(toMatch) : false;
+			return arg != null && arg instanceof String ? ((String) arg).endsWith(toMatch) : false;
 		}
 
 		public override String toString()
@@ -1309,14 +1295,14 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * StringIsBlank matcher: checks if the supplied argument is a blank String
-	@NamespaceAccessible
-	 */
+	* StringIsBlank matcher: checks if the supplied argument is a blank String
+	* @NamespaceAccessible
+	*/
 	public class StringIsBlank implements fflib_IMatcher
-	{		
+	{
 		public Boolean matches(Object arg)
 		{
-			return arg == null || (arg instanceof String ? String.isBlank((String)arg) : false);
+			return arg == null || (arg instanceof String ? String.isBlank((String) arg) : false);
 		}
 
 		public override String toString()
@@ -1326,14 +1312,14 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	@NamespaceAccessible
-	 * StringIsNotBlank matcher: checks if the supplied argument is a non-blank string
-	 */
+	* @NamespaceAccessible
+	* StringIsNotBlank matcher: checks if the supplied argument is a non-blank string
+	*/
 	public class StringIsNotBlank implements fflib_IMatcher
-	{		
+	{
 		public Boolean matches(Object arg)
 		{
-			return (arg != NULL && arg instanceof String) ? String.isNotBlank((String)arg) : false;
+			return (arg != null && arg instanceof String) ? String.isNotBlank((String) arg) : false;
 		}
 
 		public override String toString()
@@ -1343,28 +1329,28 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * StringMatches matcher: checks if the supplied argument matches the specified regex expression
-	 */
+	* StringMatches matcher: checks if the supplied argument matches the specified regex expression
+	*/
 	@NamespaceAccessible
 	public class StringMatches implements fflib_IMatcher
 	{
 		private Pattern pat;
 		private final String regEx;
-		
+
 		/**
-		 * StringMatches constructor
-		 * @param toMatch The substring to be compared
-		 * @return fflib_MatcherDefinitions.StringMatches A new StringMatches instance
-		 */
+		* StringMatches constructor
+		* @param toMatch The substring to be compared
+		* @return fflib_MatcherDefinitions.StringMatches A new StringMatches instance
+		*/
 		public StringMatches(String regEx)
 		{
 			this.regEx = regEx;
-			this.pat = Pattern.compile((String)validateNotNull(regEx));
-		}	
-		
+			this.pat = Pattern.compile((String) validateNotNull(regEx));
+		}
+
 		public Boolean matches(Object arg)
 		{
-			return arg != null && arg instanceof String ? pat.matcher((String)arg).matches() : false;
+			return arg != null && arg instanceof String ? pat.matcher((String) arg).matches() : false;
 		}
 
 		public override String toString()
@@ -1374,26 +1360,26 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * StringStartsWith matcher: checks if the supplied argument starts with the specified substring
-	 */
+	* StringStartsWith matcher: checks if the supplied argument starts with the specified substring
+	*/
 	@NamespaceAccessible
 	public class StringStartsWith implements fflib_IMatcher
 	{
 		private String toMatch;
-		
+
 		/**
-		 * StringStartsWith constructor
-		 * @param toMatch The substring to be compared
-		 * @return fflib_MatcherDefinitions.StringStartsWith A new StringStartsWith instance
-		 */
+		* StringStartsWith constructor
+		* @param toMatch The substring to be compared
+		* @return fflib_MatcherDefinitions.StringStartsWith A new StringStartsWith instance
+		*/
 		public StringStartsWith(String toMatch)
 		{
-			this.toMatch = (String)validateNotNull(toMatch);
-		}	
-		
+			this.toMatch = (String) validateNotNull(toMatch);
+		}
+
 		public Boolean matches(Object arg)
 		{
-			return arg != null && arg instanceof String ? ((String)arg).startsWith(toMatch) : false;
+			return arg != null && arg instanceof String ? ((String) arg).startsWith(toMatch) : false;
 		}
 
 		public override String toString()
@@ -1403,16 +1389,16 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/*
-	 * Helpers
-	 */
+	* Helpers
+	*/
 
 	private static Object validateNotNull(Object arg)
 	{
 		if (arg == null)
 		{
-			throw new fflib_ApexMocks.ApexMocksException('Arg cannot be null: ' + arg);	
+			throw new fflib_ApexMocks.ApexMocksException('Arg cannot be null: ' + arg);
 		}
-		
+
 		return arg;
 	}
 

--- a/sfdx-source/apex-mocks/main/classes/fflib_MatchersReturnValue.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatchersReturnValue.cls
@@ -1,28 +1,28 @@
 /**
-* Copyright (c) 2014-2016, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014-2016, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @NamespaceAccessible
 public with sharing class fflib_MatchersReturnValue
 {

--- a/sfdx-source/apex-mocks/main/classes/fflib_MatchersReturnValue.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MatchersReturnValue.cls
@@ -1,34 +1,34 @@
 /**
- * Copyright (c) 2014-2016, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2014-2016, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 @NamespaceAccessible
 public with sharing class fflib_MatchersReturnValue
 {
 	public List<fflib_IMatcher> matchers;
 	public fflib_MethodReturnValue returnValue;
-	
+
 	public fflib_MatchersReturnValue(List<fflib_IMatcher> matchers, fflib_MethodReturnValue returnValue)
 	{
 		this.matchers = matchers;

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodArgValues.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodArgValues.cls
@@ -1,72 +1,72 @@
 /**
- * Copyright (c) 2014-2016, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2014-2016, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 @NamespaceAccessible
 public with sharing class fflib_MethodArgValues
 {
 	public List<Object> argValues;
-	
+
 	/**
-	 * Wrapper object which encapsulates the argument values
-	 * supplied during a given method call.
-	 * @param argValues The
-	 * @return fflib_MethodArgValues The method argument wrapper object
-	 */
+	* Wrapper object which encapsulates the argument values
+	* supplied during a given method call.
+	* @param argValues The
+	* @return fflib_MethodArgValues The method argument wrapper object
+	*/
 	@NamespaceAccessible
 	public fflib_MethodArgValues(List<Object> argValues)
 	{
 		this.argValues = argValues;
 	}
-	
+
 	/**
-	 * Standard equals override.
-	 * @param other The object whose equality we are verifying
-	 * @return Boolean True if meaningfully equivalent, false otherwise.
-	 */
+	* Standard equals override.
+	* @param other The object whose equality we are verifying
+	* @return Boolean True if meaningfully equivalent, false otherwise.
+	*/
 	public Boolean equals(Object other)
 	{
 		if (this === other)
 		{
 			return true;
 		}
-		
-		fflib_MethodArgValues that = other instanceof fflib_MethodArgValues ? (fflib_MethodArgValues)other : null;
+
+		fflib_MethodArgValues that = other instanceof fflib_MethodArgValues ? (fflib_MethodArgValues) other : null;
 		return that != null && this.argValues == that.argValues;
 	}
-	
+
 	/**
-	 * Standard hashCode override.
-	 * @return Integer The generated hashCode
-	 */
+	* Standard hashCode override.
+	* @return Integer The generated hashCode
+	*/
 	public Integer hashCode()
 	{
 		Integer prime = 31;
 		Integer result = 1;
-		
+
 		result = prime * result + ((argValues == null) ? 0 : argValues.hashCode());
-		
+
 		return result;
 	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodArgValues.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodArgValues.cls
@@ -1,39 +1,39 @@
 /**
-* Copyright (c) 2014-2016, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014-2016, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @NamespaceAccessible
 public with sharing class fflib_MethodArgValues
 {
 	public List<Object> argValues;
 
 	/**
-	* Wrapper object which encapsulates the argument values
-	* supplied during a given method call.
-	* @param argValues The
-	* @return fflib_MethodArgValues The method argument wrapper object
-	*/
+	 * Wrapper object which encapsulates the argument values
+	 * supplied during a given method call.
+	 * @param argValues The
+	 * @return fflib_MethodArgValues The method argument wrapper object
+	 */
 	@NamespaceAccessible
 	public fflib_MethodArgValues(List<Object> argValues)
 	{
@@ -41,10 +41,10 @@ public with sharing class fflib_MethodArgValues
 	}
 
 	/**
-	* Standard equals override.
-	* @param other The object whose equality we are verifying
-	* @return Boolean True if meaningfully equivalent, false otherwise.
-	*/
+	 * Standard equals override.
+	 * @param other The object whose equality we are verifying
+	 * @return Boolean True if meaningfully equivalent, false otherwise.
+	 */
 	public Boolean equals(Object other)
 	{
 		if (this === other)
@@ -57,9 +57,9 @@ public with sharing class fflib_MethodArgValues
 	}
 
 	/**
-	* Standard hashCode override.
-	* @return Integer The generated hashCode
-	*/
+	 * Standard hashCode override.
+	 * @return Integer The generated hashCode
+	 */
 	public Integer hashCode()
 	{
 		Integer prime = 31;

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
@@ -3,8 +3,8 @@ Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* @group Core
-*/
+ * @group Core
+ */
 @NamespaceAccessible
 public with sharing class fflib_MethodCountRecorder
 {
@@ -23,47 +23,47 @@ public with sharing class fflib_MethodCountRecorder
 	private static final fflib_MethodCountRecorder STATIC_RECORDER = new fflib_MethodCountRecorder();
 
 	/**
-	* Getter for the list of the methods ordered calls.
-	* @return The list of methods called in order.
-	*/
+	 * Getter for the list of the methods ordered calls.
+	 * @return The list of methods called in order.
+	 */
 	public List<fflib_InvocationOnMock> getInstanceOrderedMethodCalls()
 	{
 		return orderedMethodCalls;
 	}
 
 	/**
-	* Getter for the map of the method's calls with the related arguments.
-	* @return The map of methods called with the arguments.
-	*/
+	 * Getter for the map of the method's calls with the related arguments.
+	 * @return The map of methods called with the arguments.
+	 */
 	public Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getInstanceMethodArgumentsByTypeName()
 	{
 		return methodArgumentsByTypeName;
 	}
 
 	/**
-	* Getter for the list of the methods ordered calls.
-	* @return The list of methods called in order.
-	* @deprecated Use {@link #getInstanceOrderedMethodCalls()} instead.
-	*/
+	 * Getter for the list of the methods ordered calls.
+	 * @return The list of methods called in order.
+	 * @deprecated Use {@link #getInstanceOrderedMethodCalls()} instead.
+	 */
 	public static List<fflib_InvocationOnMock> getOrderedMethodCalls()
 	{
 		return STATIC_RECORDER.getInstanceOrderedMethodCalls();
 	}
 
 	/**
-	* Getter for the map of the method's calls with the related arguments.
-	* @return The map of methods called with the arguments.
-	* @deprecated Use {@link #getInstanceMethodArgumentsByTypeName()} instead.
-	*/
+	 * Getter for the map of the method's calls with the related arguments.
+	 * @return The map of methods called with the arguments.
+	 * @deprecated Use {@link #getInstanceMethodArgumentsByTypeName()} instead.
+	 */
 	public static Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getMethodArgumentsByTypeName()
 	{
 		return STATIC_RECORDER.getInstanceMethodArgumentsByTypeName();
 	}
 
 	/**
-	* Record a method was called on a mock object.
-	* @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
-	*/
+	 * Record a method was called on a mock object.
+	 * @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
+	 */
 	public void recordMethod(fflib_InvocationOnMock invocation)
 	{
 		// Primary, async-safe recording lives on this instance (held by the owning

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodCountRecorder.cls
@@ -1,71 +1,69 @@
 /*
- Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- * @group Core
- */
+* @group Core
+*/
 @NamespaceAccessible
 public with sharing class fflib_MethodCountRecorder
 {
 	/*
-	 * Map of method arguments by type name.
-	 *
-	 * Key: qualifiedMethod
-	 * Object: list of method arguments.
-	 *
-	 * Object: map of count by method call argument.
-	 */
-	private final Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> methodArgumentsByTypeName =
-		new Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>>();
+	* Map of method arguments by type name.
+	*
+	* Key: qualifiedMethod
+	* Object: list of method arguments.
+	*
+	* Object: map of count by method call argument.
+	*/
+	private final Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> methodArgumentsByTypeName = new Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>>();
 
-	private final List<fflib_InvocationOnMock> orderedMethodCalls =
-		new List<fflib_InvocationOnMock>();
+	private final List<fflib_InvocationOnMock> orderedMethodCalls = new List<fflib_InvocationOnMock>();
 
 	private static final fflib_MethodCountRecorder STATIC_RECORDER = new fflib_MethodCountRecorder();
 
 	/**
-	 * Getter for the list of the methods ordered calls.
-	 * @return The list of methods called in order.
-	 */
+	* Getter for the list of the methods ordered calls.
+	* @return The list of methods called in order.
+	*/
 	public List<fflib_InvocationOnMock> getInstanceOrderedMethodCalls()
 	{
 		return orderedMethodCalls;
 	}
 
 	/**
-	 * Getter for the map of the method's calls with the related arguments.
-	 * @return The map of methods called with the arguments.
-	 */
+	* Getter for the map of the method's calls with the related arguments.
+	* @return The map of methods called with the arguments.
+	*/
 	public Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getInstanceMethodArgumentsByTypeName()
 	{
 		return methodArgumentsByTypeName;
 	}
 
 	/**
-	 * Getter for the list of the methods ordered calls.
-	 * @return The list of methods called in order.
-	 * @deprecated Use {@link #getInstanceOrderedMethodCalls()} instead.
-	 */
+	* Getter for the list of the methods ordered calls.
+	* @return The list of methods called in order.
+	* @deprecated Use {@link #getInstanceOrderedMethodCalls()} instead.
+	*/
 	public static List<fflib_InvocationOnMock> getOrderedMethodCalls()
 	{
 		return STATIC_RECORDER.getInstanceOrderedMethodCalls();
 	}
 
 	/**
-	 * Getter for the map of the method's calls with the related arguments.
-	 * @return The map of methods called with the arguments.
-	 * @deprecated Use {@link #getInstanceMethodArgumentsByTypeName()} instead.
-	 */
+	* Getter for the map of the method's calls with the related arguments.
+	* @return The map of methods called with the arguments.
+	* @deprecated Use {@link #getInstanceMethodArgumentsByTypeName()} instead.
+	*/
 	public static Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getMethodArgumentsByTypeName()
 	{
 		return STATIC_RECORDER.getInstanceMethodArgumentsByTypeName();
 	}
 
 	/**
-	 * Record a method was called on a mock object.
-	 * @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
-	 */
+	* Record a method was called on a mock object.
+	* @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
+	*/
 	public void recordMethod(fflib_InvocationOnMock invocation)
 	{
 		// Primary, async-safe recording lives on this instance (held by the owning
@@ -83,8 +81,7 @@ public with sharing class fflib_MethodCountRecorder
 
 	private void record(fflib_InvocationOnMock invocation)
 	{
-		List<fflib_MethodArgValues> methodArgs =
-			methodArgumentsByTypeName.get(invocation.getMethod());
+		List<fflib_MethodArgValues> methodArgs = methodArgumentsByTypeName.get(invocation.getMethod());
 
 		if (methodArgs == null)
 		{

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValue.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValue.cls
@@ -1,50 +1,51 @@
 /*
- * Copyright (c) 2014-2017, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2014-2017, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+*      this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+*      this list of conditions and the following disclaimer in the documentation
+*      and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+*      may be used to endorse or promote products derived from this software without
+*      specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 /**
- * @group Core
- * Class defining a method return value.
- */
-@isTest
+* @group Core
+* Class defining a method return value.
+*/
+@IsTest
 @NamespaceAccessible
 public with sharing class fflib_MethodReturnValue
 {
 	private StandardAnswer basicAnswer = new StandardAnswer();
 
 	/**
-	 * Instance of the implementation of the Answer interface that implements the answer,
-	 * if an answer isn't explicitly set the standard answer will be used, which just returns the stubbed return value.
-	 */
-	public fflib_Answer Answer { get; set; }
+	* Instance of the implementation of the Answer interface that implements the answer,
+	* if an answer isn't explicitly set the standard answer will be used, which just returns the stubbed return value.
+	*/
+	public fflib_Answer Answer
+	{ get; set; }
 
 	/**
-	 * Setup a stubbed return value.
-	 * @param value The value to return from the stubbed method call.
-	 * @return The fflib_MethodReturnValue instance to allow you to chain the methods.
-	 */
+	* Setup a stubbed return value.
+	* @param value The value to return from the stubbed method call.
+	* @return The fflib_MethodReturnValue instance to allow you to chain the methods.
+	*/
 	@NamespaceAccessible
 	public fflib_MethodReturnValue thenReturn(Object value)
 	{
@@ -53,10 +54,10 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	 * Setup a stubbed exception.
-	 * @param e The exception to throw from the stubbed method call.
-	 * @return The fflib_MethodReturnValue instance to allow you to chain the methods.
-	 */
+	* Setup a stubbed exception.
+	* @param e The exception to throw from the stubbed method call.
+	* @return The fflib_MethodReturnValue instance to allow you to chain the methods.
+	*/
 	@NamespaceAccessible
 	public fflib_MethodReturnValue thenThrow(Exception e)
 	{
@@ -65,9 +66,9 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	 * Setup a stubbed answer.
-	 * @param answer The answer to run from the stubbed method call.
-	 */
+	* Setup a stubbed answer.
+	* @param answer The answer to run from the stubbed method call.
+	*/
 	@NamespaceAccessible
 	public void thenAnswer(fflib_Answer answer)
 	{
@@ -75,10 +76,10 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	 * Setup a list of stubbed return values.
-	 * @param values The values to return from the stubbed method call in consecutive calls.
-	 * @return The fflib_MethodReturnValue instance to allow you to chain the methods.
-	 */
+	* Setup a list of stubbed return values.
+	* @param values The values to return from the stubbed method call in consecutive calls.
+	* @return The fflib_MethodReturnValue instance to allow you to chain the methods.
+	*/
 	@NamespaceAccessible
 	public fflib_MethodReturnValue thenReturnMulti(List<Object> values)
 	{
@@ -87,10 +88,10 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	 * Setup a list stubbed exceptions.
-	 * @param es The exceptions to throw from the stubbed method call in consecutive calls.
-	 * @return The fflib_MethodReturnValue instance to allow you to chain the methods.
-	 */
+	* Setup a list stubbed exceptions.
+	* @param es The exceptions to throw from the stubbed method call in consecutive calls.
+	* @return The fflib_MethodReturnValue instance to allow you to chain the methods.
+	*/
 	@NamespaceAccessible
 	public fflib_MethodReturnValue thenThrowMulti(List<Exception> es)
 	{
@@ -99,25 +100,25 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	 * @group Core
-	 * Inner class to handle all the stubs that do not use the thenAnswer method directly.
-	 * For internal use only.
-	 */
+	* @group Core
+	* Inner class to handle all the stubs that do not use the thenAnswer method directly.
+	* For internal use only.
+	*/
 	@NamespaceAccessible
 	public class StandardAnswer implements fflib_Answer
 	{
 		private Integer whichStubReturnIndex = 0;
 		/*
-		 * It stores the return values for the method stubbed.
-		 * The values would be stored and then returned as part of the standard answer invocation.
-		 */
+		* It stores the return values for the method stubbed.
+		* The values would be stored and then returned as part of the standard answer invocation.
+		*/
 		private List<Object> ReturnValues = new List<Object>();
 
 		/**
-		 * Setter of a single return value.
-		 * @param value The value to be set as return value for the StandardAnswer object.
-		 * @return The StandardAnswer instance.
-		 */
+		* Setter of a single return value.
+		* @param value The value to be set as return value for the StandardAnswer object.
+		* @return The StandardAnswer instance.
+		*/
 		public StandardAnswer setValue(Object value)
 		{
 			ReturnValues.add(value);
@@ -125,16 +126,15 @@ public with sharing class fflib_MethodReturnValue
 		}
 
 		/**
-		 * Setter of the list of return values.
-		 * @param value The value to be set as return value for the StandardAnswer object.
-		 * @return the StandardAnswer instance.
-		 */
+		* Setter of the list of return values.
+		* @param value The value to be set as return value for the StandardAnswer object.
+		* @return the StandardAnswer instance.
+		*/
 		public StandardAnswer setValues(List<Object> values)
 		{
-			if(values == null || values.size() == 0)
+			if (values == null || values.size() == 0)
 			{
-				throw new fflib_ApexMocks.ApexMocksException(
-  					'The stubbing is not correct, no return values have been set.');
+				throw new fflib_ApexMocks.ApexMocksException('The stubbing is not correct, no return values have been set.');
 			}
 
 			ReturnValues.addAll(values);
@@ -142,21 +142,20 @@ public with sharing class fflib_MethodReturnValue
 		}
 
 		/**
-		 * Standard basic implementation for the fflib_Answer answer method, to be used as default answering.
-		 * @param invocation The invocation to answer for.
-		 * @return The ReturnValue for the method stubbed.
-		 */
+		* Standard basic implementation for the fflib_Answer answer method, to be used as default answering.
+		* @param invocation The invocation to answer for.
+		* @return The ReturnValue for the method stubbed.
+		*/
 		public Object answer(fflib_InvocationOnMock invocation)
 		{
-			if(ReturnValues == null || ReturnValues.size() == 0)
+			if (ReturnValues == null || ReturnValues.size() == 0)
 			{
-				throw new fflib_ApexMocks.ApexMocksException(
-  					'The stubbing is not correct, no return values have been set.');
+				throw new fflib_ApexMocks.ApexMocksException('The stubbing is not correct, no return values have been set.');
 			}
 
-			Integer returnValuesSize = ReturnValues.size()-1;
+			Integer returnValuesSize = ReturnValues.size() - 1;
 
-			if(whichStubReturnIndex < returnValuesSize)
+			if (whichStubReturnIndex < returnValuesSize)
 			{
 				return ReturnValues[whichStubReturnIndex++];
 			}

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValue.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValue.cls
@@ -25,9 +25,9 @@
 */
 
 /**
-* @group Core
-* Class defining a method return value.
-*/
+ * @group Core
+ * Class defining a method return value.
+ */
 @IsTest
 @NamespaceAccessible
 public with sharing class fflib_MethodReturnValue
@@ -35,17 +35,17 @@ public with sharing class fflib_MethodReturnValue
 	private StandardAnswer basicAnswer = new StandardAnswer();
 
 	/**
-	* Instance of the implementation of the Answer interface that implements the answer,
-	* if an answer isn't explicitly set the standard answer will be used, which just returns the stubbed return value.
-	*/
+	 * Instance of the implementation of the Answer interface that implements the answer,
+	 * if an answer isn't explicitly set the standard answer will be used, which just returns the stubbed return value.
+	 */
 	public fflib_Answer Answer
 	{ get; set; }
 
 	/**
-	* Setup a stubbed return value.
-	* @param value The value to return from the stubbed method call.
-	* @return The fflib_MethodReturnValue instance to allow you to chain the methods.
-	*/
+	 * Setup a stubbed return value.
+	 * @param value The value to return from the stubbed method call.
+	 * @return The fflib_MethodReturnValue instance to allow you to chain the methods.
+	 */
 	@NamespaceAccessible
 	public fflib_MethodReturnValue thenReturn(Object value)
 	{
@@ -54,10 +54,10 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	* Setup a stubbed exception.
-	* @param e The exception to throw from the stubbed method call.
-	* @return The fflib_MethodReturnValue instance to allow you to chain the methods.
-	*/
+	 * Setup a stubbed exception.
+	 * @param e The exception to throw from the stubbed method call.
+	 * @return The fflib_MethodReturnValue instance to allow you to chain the methods.
+	 */
 	@NamespaceAccessible
 	public fflib_MethodReturnValue thenThrow(Exception e)
 	{
@@ -66,9 +66,9 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	* Setup a stubbed answer.
-	* @param answer The answer to run from the stubbed method call.
-	*/
+	 * Setup a stubbed answer.
+	 * @param answer The answer to run from the stubbed method call.
+	 */
 	@NamespaceAccessible
 	public void thenAnswer(fflib_Answer answer)
 	{
@@ -76,10 +76,10 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	* Setup a list of stubbed return values.
-	* @param values The values to return from the stubbed method call in consecutive calls.
-	* @return The fflib_MethodReturnValue instance to allow you to chain the methods.
-	*/
+	 * Setup a list of stubbed return values.
+	 * @param values The values to return from the stubbed method call in consecutive calls.
+	 * @return The fflib_MethodReturnValue instance to allow you to chain the methods.
+	 */
 	@NamespaceAccessible
 	public fflib_MethodReturnValue thenReturnMulti(List<Object> values)
 	{
@@ -88,10 +88,10 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	* Setup a list stubbed exceptions.
-	* @param es The exceptions to throw from the stubbed method call in consecutive calls.
-	* @return The fflib_MethodReturnValue instance to allow you to chain the methods.
-	*/
+	 * Setup a list stubbed exceptions.
+	 * @param es The exceptions to throw from the stubbed method call in consecutive calls.
+	 * @return The fflib_MethodReturnValue instance to allow you to chain the methods.
+	 */
 	@NamespaceAccessible
 	public fflib_MethodReturnValue thenThrowMulti(List<Exception> es)
 	{
@@ -100,10 +100,10 @@ public with sharing class fflib_MethodReturnValue
 	}
 
 	/**
-	* @group Core
-	* Inner class to handle all the stubs that do not use the thenAnswer method directly.
-	* For internal use only.
-	*/
+	 * @group Core
+	 * Inner class to handle all the stubs that do not use the thenAnswer method directly.
+	 * For internal use only.
+	 */
 	@NamespaceAccessible
 	public class StandardAnswer implements fflib_Answer
 	{
@@ -115,10 +115,10 @@ public with sharing class fflib_MethodReturnValue
 		private List<Object> ReturnValues = new List<Object>();
 
 		/**
-		* Setter of a single return value.
-		* @param value The value to be set as return value for the StandardAnswer object.
-		* @return The StandardAnswer instance.
-		*/
+		 * Setter of a single return value.
+		 * @param value The value to be set as return value for the StandardAnswer object.
+		 * @return The StandardAnswer instance.
+		 */
 		public StandardAnswer setValue(Object value)
 		{
 			ReturnValues.add(value);
@@ -126,10 +126,10 @@ public with sharing class fflib_MethodReturnValue
 		}
 
 		/**
-		* Setter of the list of return values.
-		* @param value The value to be set as return value for the StandardAnswer object.
-		* @return the StandardAnswer instance.
-		*/
+		 * Setter of the list of return values.
+		 * @param value The value to be set as return value for the StandardAnswer object.
+		 * @return the StandardAnswer instance.
+		 */
 		public StandardAnswer setValues(List<Object> values)
 		{
 			if (values == null || values.size() == 0)
@@ -142,10 +142,10 @@ public with sharing class fflib_MethodReturnValue
 		}
 
 		/**
-		* Standard basic implementation for the fflib_Answer answer method, to be used as default answering.
-		* @param invocation The invocation to answer for.
-		* @return The ReturnValue for the method stubbed.
-		*/
+		 * Standard basic implementation for the fflib_Answer answer method, to be used as default answering.
+		 * @param invocation The invocation to answer for.
+		 * @return The ReturnValue for the method stubbed.
+		 */
 		public Object answer(fflib_InvocationOnMock invocation)
 		{
 			if (ReturnValues == null || ReturnValues.size() == 0)

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValueRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValueRecorder.cls
@@ -1,49 +1,52 @@
 /*
- * Copyright (c) 2014, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (c) 2014, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+*      this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+*      this list of conditions and the following disclaimer in the documentation
+*      and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+*      may be used to endorse or promote products derived from this software without
+*      specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 /**
- * @group Core
- */
+* @group Core
+*/
 @NamespaceAccessible
 public with sharing class fflib_MethodReturnValueRecorder
 {
-	public Boolean Stubbing { get; set; }
+	public Boolean Stubbing
+	{ get; set; }
 
-	public List<Exception> DoThrowWhenExceptions { get; set; }
+	public List<Exception> DoThrowWhenExceptions
+	{ get; set; }
 
 	/**
-	 * Map of matchers by method.
-	 *
-	 * Key: qualifiedMethod
-	 * Object: map of method return values by method.
-	 */
+	* Map of matchers by method.
+	*
+	* Key: qualifiedMethod
+	* Object: map of method return values by method.
+	*/
 
 	private Map<fflib_QualifiedMethod, List<fflib_MatchersReturnValue>> matcherReturnValuesByMethod;
 
-	public fflib_MethodReturnValue MethodReturnValue { get; private set; }
+	public fflib_MethodReturnValue MethodReturnValue
+	{ get; private set; }
 
 	public fflib_MethodReturnValueRecorder()
 	{
@@ -53,10 +56,10 @@ public with sharing class fflib_MethodReturnValueRecorder
 	}
 
 	/**
-	 * Prepare a stubbed method return value.
-	 * @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
-	 * @return The MethodReturnValue instance.
-	 */
+	* Prepare a stubbed method return value.
+	* @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
+	* @return The MethodReturnValue instance.
+	*/
 	public fflib_MethodReturnValue prepareMethodReturnValue(fflib_InvocationOnMock invocation)
 	{
 		MethodReturnValue = new fflib_MethodReturnValue();
@@ -76,9 +79,13 @@ public with sharing class fflib_MethodReturnValueRecorder
 			for (Object arg : argValues)
 			{
 				if (arg == null)
+				{
 					fflib_Match.isNull();
+				}
 				else
+				{
 					fflib_Match.eq(arg);
+				}
 			}
 		}
 
@@ -89,10 +96,10 @@ public with sharing class fflib_MethodReturnValueRecorder
 	}
 
 	/**
-	 * Get the method return value for the given method call.
-	 * @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
-	 * @return The MethodReturnValue instance.
-	 */
+	* Get the method return value for the given method call.
+	* @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
+	* @return The MethodReturnValue instance.
+	*/
 	public fflib_MethodReturnValue getMethodReturnValue(fflib_InvocationOnMock invocation)
 	{
 		List<fflib_MatchersReturnValue> matchersForMethods = matcherReturnValuesByMethod.get(invocation.getMethod());
@@ -100,7 +107,7 @@ public with sharing class fflib_MethodReturnValueRecorder
 		{
 			for (Integer i = matchersForMethods.size() - 1; i >= 0; i--)
 			{
-				fflib_MatchersReturnValue matchersReturnValue = (fflib_MatchersReturnValue)matchersForMethods.get(i);
+				fflib_MatchersReturnValue matchersReturnValue = (fflib_MatchersReturnValue) matchersForMethods.get(i);
 				if (fflib_Match.matchesAllArgs(invocation.getMethodArgValues(), matchersReturnValue.matchers))
 				{
 					return matchersReturnValue.ReturnValue;
@@ -112,9 +119,9 @@ public with sharing class fflib_MethodReturnValueRecorder
 	}
 
 	/**
-	 * Prepare a stubbed exceptions for a void method.
-	 * @param exps The list of exception to throw.
-	 */
+	* Prepare a stubbed exceptions for a void method.
+	* @param exps The list of exception to throw.
+	*/
 	public void prepareDoThrowWhenExceptions(List<Exception> exps)
 	{
 		DoThrowWhenExceptions = exps;

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValueRecorder.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodReturnValueRecorder.cls
@@ -25,8 +25,8 @@
 */
 
 /**
-* @group Core
-*/
+ * @group Core
+ */
 @NamespaceAccessible
 public with sharing class fflib_MethodReturnValueRecorder
 {
@@ -37,11 +37,11 @@ public with sharing class fflib_MethodReturnValueRecorder
 	{ get; set; }
 
 	/**
-	* Map of matchers by method.
-	*
-	* Key: qualifiedMethod
-	* Object: map of method return values by method.
-	*/
+	 * Map of matchers by method.
+	 *
+	 * Key: qualifiedMethod
+	 * Object: map of method return values by method.
+	 */
 
 	private Map<fflib_QualifiedMethod, List<fflib_MatchersReturnValue>> matcherReturnValuesByMethod;
 
@@ -56,10 +56,10 @@ public with sharing class fflib_MethodReturnValueRecorder
 	}
 
 	/**
-	* Prepare a stubbed method return value.
-	* @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
-	* @return The MethodReturnValue instance.
-	*/
+	 * Prepare a stubbed method return value.
+	 * @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
+	 * @return The MethodReturnValue instance.
+	 */
 	public fflib_MethodReturnValue prepareMethodReturnValue(fflib_InvocationOnMock invocation)
 	{
 		MethodReturnValue = new fflib_MethodReturnValue();
@@ -96,10 +96,10 @@ public with sharing class fflib_MethodReturnValueRecorder
 	}
 
 	/**
-	* Get the method return value for the given method call.
-	* @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
-	* @return The MethodReturnValue instance.
-	*/
+	 * Get the method return value for the given method call.
+	 * @param invocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
+	 * @return The MethodReturnValue instance.
+	 */
 	public fflib_MethodReturnValue getMethodReturnValue(fflib_InvocationOnMock invocation)
 	{
 		List<fflib_MatchersReturnValue> matchersForMethods = matcherReturnValuesByMethod.get(invocation.getMethod());
@@ -119,9 +119,9 @@ public with sharing class fflib_MethodReturnValueRecorder
 	}
 
 	/**
-	* Prepare a stubbed exceptions for a void method.
-	* @param exps The list of exception to throw.
-	*/
+	 * Prepare a stubbed exceptions for a void method.
+	 * @param exps The list of exception to throw.
+	 */
 	public void prepareDoThrowWhenExceptions(List<Exception> exps)
 	{
 		DoThrowWhenExceptions = exps;

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodVerifier.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodVerifier.cls
@@ -1,19 +1,19 @@
 /*
- Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- *	This class implements the actual verification.
- *	@group Core
- */
+* This class implements the actual verification.
+* @group Core
+*/
 @NamespaceAccessible
 public abstract class fflib_MethodVerifier
 {
 	/**
-	 * Verify a method was called on a mock object.
-	 * @param mockInvocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
-	 * @param verificationMode The verification mode that holds the setting about how the verification should be performed.
-	 */
+	* Verify a method was called on a mock object.
+	* @param mockInvocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
+	* @param verificationMode The verification mode that holds the setting about how the verification should be performed.
+	*/
 	public void verifyMethodCall(fflib_InvocationOnMock mockInvocation, fflib_VerificationMode verificationMode)
 	{
 		validateMode(verificationMode);
@@ -22,37 +22,34 @@ public abstract class fflib_MethodVerifier
 	}
 
 	/*
-	 * Method that actually performs the verify
-	 * @param qm The method to be verified.
-	 * @param methodArg The arguments of the method that needs to be verified.
-	 * @param verificationMode The verification mode that holds the setting about how the verification should be performed.
-	 */
-	protected abstract void verify(
-		fflib_QualifiedMethod qm,
-		fflib_MethodArgValues methodArg,
-		fflib_VerificationMode verificationMode);
+	* Method that actually performs the verify
+	* @param qm The method to be verified.
+	* @param methodArg The arguments of the method that needs to be verified.
+	* @param verificationMode The verification mode that holds the setting about how the verification should be performed.
+	*/
+	protected abstract void verify(fflib_QualifiedMethod qm, fflib_MethodArgValues methodArg, fflib_VerificationMode verificationMode);
 
 	/*
-	 * Method that validates the verification mode used in the verify.
-	 * Not all the methods from the fflib_VerificationMode are implemented for the different classes that extends the fflib_MethodVerifier.
-	 * The error is thrown at run time, so this method is called in the method that actually performs the verify.
-	 * @param verificationMode The verification mode that has to have been verified.
-	 * @throws Exception with message for the fflib_VerificationMode not implemented.
-	 */
+	* Method that validates the verification mode used in the verify.
+	* Not all the methods from the fflib_VerificationMode are implemented for the different classes that extends the fflib_MethodVerifier.
+	* The error is thrown at run time, so this method is called in the method that actually performs the verify.
+	* @param verificationMode The verification mode that has to have been verified.
+	* @throws Exception with message for the fflib_VerificationMode not implemented.
+	*/
 	protected abstract void validateMode(fflib_VerificationMode verificationMode);
 
 	/*
-	 * Method that performs the argument capturing.
-	 * Captures argument values during verification.
-	 * @param matchers The list of matcher with which a method is verified.
-	 */
+	* Method that performs the argument capturing.
+	* Captures argument values during verification.
+	* @param matchers The list of matcher with which a method is verified.
+	*/
 	protected void capture(List<fflib_IMatcher> matchers)
 	{
-		for(fflib_IMatcher matcher : matchers)
+		for (fflib_IMatcher matcher : matchers)
 		{
-			if( matcher instanceof fflib_ArgumentCaptor.AnyObject )
+			if (matcher instanceof fflib_ArgumentCaptor.AnyObject)
 			{
-				((fflib_ArgumentCaptor.AnyObject)matcher).storeArgument();
+				((fflib_ArgumentCaptor.AnyObject) matcher).storeArgument();
 			}
 		}
 	}
@@ -66,11 +63,12 @@ public abstract class fflib_MethodVerifier
 		String customAssertMessage,
 		fflib_MethodArgValues expectedArguments,
 		List<fflib_IMatcher> expectedMatchers,
-		List<fflib_MethodArgValues> actualArguments)
+		List<fflib_MethodArgValues> actualArguments
+	)
 	{
-		String template = 'EXPECTED COUNT: {0}{1}{2}' // qualified expected count (e.g. "3 or fewer times in order")
-			+ '\nACTUAL COUNT: {3}' // actual count
-			+ '\nMETHOD: {4}' // method signature
+		String template = 'EXPECTED COUNT: {0}{1}{2}' // qualified expected count (e.g. "3 or fewer times in order") 
+			+ '\nACTUAL COUNT: {3}' // actual count 
+			+ '\nMETHOD: {4}' // method signature 
 			+ '{5}'; // custom assert message
 
 		String expectedDescription = '';
@@ -78,10 +76,10 @@ public abstract class fflib_MethodVerifier
 
 		if (qm.hasArguments())
 		{
-			template += '\n---' // separator
-				+ '\nACTUAL ARGS: {6}' // actual args
-				+ '\n---' // separator
-				+ '\nEXPECTED ARGS: {7}'; // matcher descriptions 
+			template += '\n---' // separator 
+				+ '\nACTUAL ARGS: {6}' // actual args 
+				+ '\n---' // separator 
+				+ '\nEXPECTED ARGS: {7}'; // matcher descriptions
 
 			if (expectedMatchers == null)
 			{
@@ -94,16 +92,11 @@ public abstract class fflib_MethodVerifier
 			actualDescription = describe(actualArguments);
 		}
 
-		String message = String.format(template, new List<String>{
-			'' + expectedCount,
-			String.isBlank(qualifier) ? '' : ('' + qualifier),
-			inOrder,
-			'' + methodCount,
-			'' + qm,
-			String.isBlank(customAssertMessage) ? '' : ('\n' + customAssertMessage),
-			actualDescription,
-			expectedDescription
-		});
+		String message =
+			String.format(
+				template,
+				new List<String>{ '' + expectedCount, String.isBlank(qualifier) ? '' : ('' + qualifier), inOrder, '' + methodCount, '' + qm, String.isBlank(customAssertMessage) ? '' : ('\n' + customAssertMessage), actualDescription, expectedDescription }
+			);
 
 		throw new fflib_ApexMocks.ApexMocksException(message);
 	}

--- a/sfdx-source/apex-mocks/main/classes/fflib_MethodVerifier.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_MethodVerifier.cls
@@ -3,17 +3,17 @@ Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* This class implements the actual verification.
-* @group Core
-*/
+ * This class implements the actual verification.
+ * @group Core
+ */
 @NamespaceAccessible
 public abstract class fflib_MethodVerifier
 {
 	/**
-	* Verify a method was called on a mock object.
-	* @param mockInvocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
-	* @param verificationMode The verification mode that holds the setting about how the verification should be performed.
-	*/
+	 * Verify a method was called on a mock object.
+	 * @param mockInvocation The object holding all the data of the invocation, like the method and arguments and the mock instance.
+	 * @param verificationMode The verification mode that holds the setting about how the verification should be performed.
+	 */
 	public void verifyMethodCall(fflib_InvocationOnMock mockInvocation, fflib_VerificationMode verificationMode)
 	{
 		validateMode(verificationMode);

--- a/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
@@ -25,10 +25,10 @@ public with sharing class fflib_QualifiedMethod
 	}
 
 	/**
-	* Standard equals override.
-	* @param other The object whose equality we are verifying
-	* @return Boolean True if meaningfully equivalent, false otherwise.
-	*/
+	 * Standard equals override.
+	 * @param other The object whose equality we are verifying
+	 * @return Boolean True if meaningfully equivalent, false otherwise.
+	 */
 	public Boolean equals(Object other)
 	{
 		if (this === other)
@@ -42,9 +42,9 @@ public with sharing class fflib_QualifiedMethod
 	}
 
 	/**
-	* Standard hashCode override.
-	* @return Integer The generated hashCode
-	*/
+	 * Standard hashCode override.
+	 * @return Integer The generated hashCode
+	 */
 	public Integer hashCode()
 	{
 		Integer prime = 31;
@@ -62,18 +62,18 @@ public with sharing class fflib_QualifiedMethod
 	}
 
 	/**
-	* Standard toString override.
-	* @return String The human friendly description of the method.
-	*/
+	 * Standard toString override.
+	 * @return String The human friendly description of the method.
+	 */
 	public override String toString()
 	{
 		return typeName + '.' + methodName + methodArgTypes;
 	}
 
 	/**
-	* Predicate describing whether the qualified method accepts arguments or not.
-	* @return True if the method accepts arguments.
-	*/
+	 * Predicate describing whether the qualified method accepts arguments or not.
+	 * @return True if the method accepts arguments.
+	 */
 	public Boolean hasArguments()
 	{
 		return this.methodArgTypes != null && !this.methodArgTypes.isEmpty();

--- a/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethod.cls
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
- */
+* Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
+*/
 @NamespaceAccessible
 public with sharing class fflib_QualifiedMethod
 {
@@ -8,7 +8,7 @@ public with sharing class fflib_QualifiedMethod
 	public final String typeName;
 	public final String methodName;
 	public final List<Type> methodArgTypes;
-	
+
 	@NamespaceAccessible
 	public fflib_QualifiedMethod(String typeName, String methodName, List<Type> methodArgTypes)
 	{
@@ -21,39 +21,35 @@ public with sharing class fflib_QualifiedMethod
 		this.mockInstance = mockInstance;
 		this.typeName = typeName;
 		this.methodName = methodName;
-		this.methodArgTypes = methodArgTypes;	
+		this.methodArgTypes = methodArgTypes;
 	}
-	
+
 	/**
-	 * Standard equals override.
-	 * @param other The object whose equality we are verifying
-	 * @return Boolean True if meaningfully equivalent, false otherwise.
-	 */
+	* Standard equals override.
+	* @param other The object whose equality we are verifying
+	* @return Boolean True if meaningfully equivalent, false otherwise.
+	*/
 	public Boolean equals(Object other)
 	{
 		if (this === other)
 		{
 			return true;
 		}
-		
-		fflib_QualifiedMethod that = other instanceof fflib_QualifiedMethod ? (fflib_QualifiedMethod)other : null;
-		
-		return that != null
-			&& (this.mockInstance === that.mockInstance || !fflib_ApexMocksConfig.HasIndependentMocks)
-			&& this.typeName == that.typeName
-			&& this.methodName == that.methodName
-			&& this.methodArgTypes == that.methodArgTypes;
+
+		fflib_QualifiedMethod that = other instanceof fflib_QualifiedMethod ? (fflib_QualifiedMethod) other : null;
+
+		return that != null && (this.mockInstance === that.mockInstance || !fflib_ApexMocksConfig.HasIndependentMocks) && this.typeName == that.typeName && this.methodName == that.methodName && this.methodArgTypes == that.methodArgTypes;
 	}
-	
+
 	/**
-	 * Standard hashCode override.
-	 * @return Integer The generated hashCode
-	 */
+	* Standard hashCode override.
+	* @return Integer The generated hashCode
+	*/
 	public Integer hashCode()
 	{
 		Integer prime = 31;
 		Integer result = 1;
-		
+
 		if (fflib_ApexMocksConfig.HasIndependentMocks)
 		{
 			result = prime * result + ((mockInstance == null) ? 0 : mockInstance.hashCode());
@@ -61,23 +57,23 @@ public with sharing class fflib_QualifiedMethod
 		result = prime * result + ((methodArgTypes == null) ? 0 : methodArgTypes.hashCode());
 		result = prime * result + ((methodName == null) ? 0 : methodName.hashCode());
 		result = prime * result + ((typeName == null) ? 0 : typeName.hashCode());
-		
+
 		return result;
 	}
-	
+
 	/**
-	 * Standard toString override.
-	 * @return String The human friendly description of the method.
-	 */
+	* Standard toString override.
+	* @return String The human friendly description of the method.
+	*/
 	public override String toString()
 	{
 		return typeName + '.' + methodName + methodArgTypes;
 	}
 
 	/**
-	 * Predicate describing whether the qualified method accepts arguments or not.
-	 * @return True if the method accepts arguments.
-	 */
+	* Predicate describing whether the qualified method accepts arguments or not.
+	* @return True if the method accepts arguments.
+	*/
 	public Boolean hasArguments()
 	{
 		return this.methodArgTypes != null && !this.methodArgTypes.isEmpty();

--- a/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethodAndArgValues.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethodAndArgValues.cls
@@ -3,8 +3,8 @@ Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* @group Core
-*/
+ * @group Core
+ */
 @NamespaceAccessible
 public with sharing class fflib_QualifiedMethodAndArgValues
 {

--- a/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethodAndArgValues.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_QualifiedMethodAndArgValues.cls
@@ -1,10 +1,10 @@
 /*
- Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- * @group Core
- */
+* @group Core
+*/
 @NamespaceAccessible
 public with sharing class fflib_QualifiedMethodAndArgValues
 {

--- a/sfdx-source/apex-mocks/main/classes/fflib_System.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_System.cls
@@ -1,21 +1,21 @@
 /*
- * Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+* Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- * @group Core
- * Contains counterparts for helper methods in the native System class.
- */
+* @group Core
+* Contains counterparts for helper methods in the native System class.
+*/
 
 @NamespaceAccessible
 public class fflib_System
 {
 	/**
-	 * Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
-	 * See fflib_SystemTest for examples of usage.
-	 * @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
-	 * @param value         The object instance upon which we are checking equality.
-	 */
+	* Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
+	* See fflib_SystemTest for examples of usage.
+	* @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
+	* @param value         The object instance upon which we are checking equality.
+	*/
 	@NamespaceAccessible
 	public static void assertEquals(Object ignoredRetval, Object value)
 	{
@@ -23,12 +23,12 @@ public class fflib_System
 	}
 
 	/**
-	 * Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
-	 * See fflib_SystemTest for examples of usage.
-	 * @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
-	 * @param value         The object instance upon which we are checking equality.
-	 * @param customAssertMessage Provides context or additional information for the assertion.
-	 */
+	* Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
+	* See fflib_SystemTest for examples of usage.
+	* @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
+	* @param value         The object instance upon which we are checking equality.
+	* @param customAssertMessage Provides context or additional information for the assertion.
+	*/
 	@NamespaceAccessible
 	public static void assertEquals(Object ignoredRetval, Object value, String customAssertMessage)
 	{
@@ -42,14 +42,10 @@ public class fflib_System
 		{
 			throw new fflib_ApexMocks.ApexMocksException('fflib_System.assertEquals expects you to register exactly 1 fflib_IMatcher (typically through the helpers in fflib_Match).');
 		}
-		
+
 		if (!matcher.matches(value))
 		{
-			throw new fflib_ApexMocks.ApexMocksException(String.format('Expected : {0}, Actual: {1}{2}', new String[]{
-				String.valueOf(matcher),
-				String.valueOf(value),
-				String.isBlank(customAssertMessage) ? '' : (' -- ' + customAssertMessage)
-			}));
+			throw new fflib_ApexMocks.ApexMocksException(String.format('Expected : {0}, Actual: {1}{2}', new String[]{ String.valueOf(matcher), String.valueOf(value), String.isBlank(customAssertMessage) ? '' : (' -- ' + customAssertMessage) }));
 		}
 	}
 }

--- a/sfdx-source/apex-mocks/main/classes/fflib_System.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_System.cls
@@ -3,19 +3,19 @@
 */
 
 /**
-* @group Core
-* Contains counterparts for helper methods in the native System class.
-*/
+ * @group Core
+ * Contains counterparts for helper methods in the native System class.
+ */
 
 @NamespaceAccessible
 public class fflib_System
 {
 	/**
-	* Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
-	* See fflib_SystemTest for examples of usage.
-	* @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
-	* @param value         The object instance upon which we are checking equality.
-	*/
+	 * Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
+	 * See fflib_SystemTest for examples of usage.
+	 * @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
+	 * @param value         The object instance upon which we are checking equality.
+	 */
 	@NamespaceAccessible
 	public static void assertEquals(Object ignoredRetval, Object value)
 	{
@@ -23,12 +23,12 @@ public class fflib_System
 	}
 
 	/**
-	* Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
-	* See fflib_SystemTest for examples of usage.
-	* @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
-	* @param value         The object instance upon which we are checking equality.
-	* @param customAssertMessage Provides context or additional information for the assertion.
-	*/
+	 * Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
+	 * See fflib_SystemTest for examples of usage.
+	 * @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
+	 * @param value         The object instance upon which we are checking equality.
+	 * @param customAssertMessage Provides context or additional information for the assertion.
+	 */
 	@NamespaceAccessible
 	public static void assertEquals(Object ignoredRetval, Object value, String customAssertMessage)
 	{

--- a/sfdx-source/apex-mocks/main/classes/fflib_VerificationMode.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_VerificationMode.cls
@@ -1,20 +1,31 @@
 /*
- Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- *	This class implements the verification modes with Mockito syntax style.
- *	It can be used in the classic verify and in the ordered verify.
- *	@group Core
- */
+* This class implements the verification modes with Mockito syntax style.
+* It can be used in the classic verify and in the ordered verify.
+* @group Core
+*/
 @NamespaceAccessible
 public with sharing class fflib_VerificationMode
 {
-	public Integer VerifyMin {get; set;}
-	public Integer VerifyMax {get; set;}
-	public String CustomAssertMessage { get; set; }
+	public Integer VerifyMin
+	{ get; set; }
+	public Integer VerifyMax
+	{ get; set; }
+	public String CustomAssertMessage
+	{ get; set; }
 
-	public enum ModeName {times, atLeast, atMost, between, atLeastOnce, calls}
+	public enum ModeName
+	{
+		times,
+		atLeast,
+		atMost,
+		between,
+		atLeastOnce,
+		calls
+	}
 
 	public ModeName Method;
 
@@ -29,16 +40,16 @@ public with sharing class fflib_VerificationMode
 
 	/**
 	* Sets how many times the method is expected to be called.
-	  * For InOrder verification we copy Mockito behavior which is as follows;
-	 * <ul>
-	 * <li>Consume the specified number of matching invocations, ignoring non-matching invocations in between</li>
-	 * <li>Fail an assert if the very next invocation matches, but additional matches can still exist so long as at least one non-matching invocation exists before them</li>
-	 * </ul>
-	 * For example if you had a(); a(); b(); a();
-	 * then inOrder.verify(myMock, 2)).a(); or inOrder.verify(myMock, 3)).a(); would pass but not inOrder.verify(myMock, 1)).a();
-	 * @param times The number of times you expect the method to have been called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* For InOrder verification we copy Mockito behavior which is as follows;
+	* <ul>
+	* <li>Consume the specified number of matching invocations, ignoring non-matching invocations in between</li>
+	* <li>Fail an assert if the very next invocation matches, but additional matches can still exist so long as at least one non-matching invocation exists before them</li>
+	* </ul>
+	* For example if you had a(); a(); b(); a();
+	* then inOrder.verify(myMock, 2)).a(); or inOrder.verify(myMock, 3)).a(); would pass but not inOrder.verify(myMock, 1)).a();
+	* @param times The number of times you expect the method to have been called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode times(Integer times)
 	{
@@ -48,10 +59,10 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	 * Sets a custom assert message for the verify.
-	 * @param customAssertMessage The custom message for the assert in case the assert is false. The custom message is queued to the default message.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets a custom assert message for the verify.
+	* @param customAssertMessage The custom message for the assert in case the assert is false. The custom message is queued to the default message.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode description(String customAssertMessage)
 	{
@@ -60,11 +71,11 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	 * Sets the minimum number of times the method is expected to be called.
-	 * With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
-	 * @param atLeastTimes The minimum number of times you expect the method to have been called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets the minimum number of times the method is expected to be called.
+	* With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
+	* @param atLeastTimes The minimum number of times you expect the method to have been called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode atLeast(Integer atLeastTimes)
 	{
@@ -75,10 +86,10 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	 * Sets the maximum number of times the method is expected to be called. Not available in the InOrder verification.
-	 * @param atMostTimes The maximum number of times the method is expected to be called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets the maximum number of times the method is expected to be called. Not available in the InOrder verification.
+	* @param atMostTimes The maximum number of times the method is expected to be called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode atMost(Integer atMostTimes)
 	{
@@ -89,10 +100,10 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	 * Sets that the method is called at least once.
-	 * With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets that the method is called at least once.
+	* With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode atLeastOnce()
 	{
@@ -103,11 +114,11 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	 * Sets the range of how many times the method is expected to be called. Not available in the InOrder verification.
-	 * @param atLeastTimes The minimum number of times you expect the method to have been called.
-	 * @param atMostTimes The maximum number of times the method is expected to be called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets the range of how many times the method is expected to be called. Not available in the InOrder verification.
+	* @param atLeastTimes The minimum number of times you expect the method to have been called.
+	* @param atMostTimes The maximum number of times the method is expected to be called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode between(Integer atLeastTimes, Integer atMostTimes)
 	{
@@ -119,9 +130,9 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	 * Sets that the method is not expected to be called.
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets that the method is not expected to be called.
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode never()
 	{
@@ -132,11 +143,11 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	 * Sets how many times the method is expected to be called for an InOrder verifier. Available Only with the InOrder verification.
-	 * A verification mode using calls will not fail if the method is called more times than expected.
-	 * @param callingTimes The number of times you expect the method to have been called in the InOrder verifying (no greedy verify).
-	 * @return The fflib_VerificationMode object instance with the proper settings.
-	 */
+	* Sets how many times the method is expected to be called for an InOrder verifier. Available Only with the InOrder verification.
+	* A verification mode using calls will not fail if the method is called more times than expected.
+	* @param callingTimes The number of times you expect the method to have been called in the InOrder verifying (no greedy verify).
+	* @return The fflib_VerificationMode object instance with the proper settings.
+	*/
 	@NamespaceAccessible
 	public fflib_VerificationMode calls(Integer callingTimes)
 	{

--- a/sfdx-source/apex-mocks/main/classes/fflib_VerificationMode.cls
+++ b/sfdx-source/apex-mocks/main/classes/fflib_VerificationMode.cls
@@ -3,10 +3,10 @@ Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* This class implements the verification modes with Mockito syntax style.
-* It can be used in the classic verify and in the ordered verify.
-* @group Core
-*/
+ * This class implements the verification modes with Mockito syntax style.
+ * It can be used in the classic verify and in the ordered verify.
+ * @group Core
+ */
 @NamespaceAccessible
 public with sharing class fflib_VerificationMode
 {
@@ -39,17 +39,17 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	* Sets how many times the method is expected to be called.
-	* For InOrder verification we copy Mockito behavior which is as follows;
-	* <ul>
-	* <li>Consume the specified number of matching invocations, ignoring non-matching invocations in between</li>
-	* <li>Fail an assert if the very next invocation matches, but additional matches can still exist so long as at least one non-matching invocation exists before them</li>
-	* </ul>
-	* For example if you had a(); a(); b(); a();
-	* then inOrder.verify(myMock, 2)).a(); or inOrder.verify(myMock, 3)).a(); would pass but not inOrder.verify(myMock, 1)).a();
-	* @param times The number of times you expect the method to have been called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets how many times the method is expected to be called.
+	 * For InOrder verification we copy Mockito behavior which is as follows;
+	 * <ul>
+	 * <li>Consume the specified number of matching invocations, ignoring non-matching invocations in between</li>
+	 * <li>Fail an assert if the very next invocation matches, but additional matches can still exist so long as at least one non-matching invocation exists before them</li>
+	 * </ul>
+	 * For example if you had a(); a(); b(); a();
+	 * then inOrder.verify(myMock, 2)).a(); or inOrder.verify(myMock, 3)).a(); would pass but not inOrder.verify(myMock, 1)).a();
+	 * @param times The number of times you expect the method to have been called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode times(Integer times)
 	{
@@ -59,10 +59,10 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	* Sets a custom assert message for the verify.
-	* @param customAssertMessage The custom message for the assert in case the assert is false. The custom message is queued to the default message.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets a custom assert message for the verify.
+	 * @param customAssertMessage The custom message for the assert in case the assert is false. The custom message is queued to the default message.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode description(String customAssertMessage)
 	{
@@ -71,11 +71,11 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	* Sets the minimum number of times the method is expected to be called.
-	* With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
-	* @param atLeastTimes The minimum number of times you expect the method to have been called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets the minimum number of times the method is expected to be called.
+	 * With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
+	 * @param atLeastTimes The minimum number of times you expect the method to have been called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode atLeast(Integer atLeastTimes)
 	{
@@ -86,10 +86,10 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	* Sets the maximum number of times the method is expected to be called. Not available in the InOrder verification.
-	* @param atMostTimes The maximum number of times the method is expected to be called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets the maximum number of times the method is expected to be called. Not available in the InOrder verification.
+	 * @param atMostTimes The maximum number of times the method is expected to be called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode atMost(Integer atMostTimes)
 	{
@@ -100,10 +100,10 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	* Sets that the method is called at least once.
-	* With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets that the method is called at least once.
+	 * With the InOrder verification it performs a greedy verification, which means it would consume all the instances of the method verified.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode atLeastOnce()
 	{
@@ -114,11 +114,11 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	* Sets the range of how many times the method is expected to be called. Not available in the InOrder verification.
-	* @param atLeastTimes The minimum number of times you expect the method to have been called.
-	* @param atMostTimes The maximum number of times the method is expected to be called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets the range of how many times the method is expected to be called. Not available in the InOrder verification.
+	 * @param atLeastTimes The minimum number of times you expect the method to have been called.
+	 * @param atMostTimes The maximum number of times the method is expected to be called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode between(Integer atLeastTimes, Integer atMostTimes)
 	{
@@ -130,9 +130,9 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	* Sets that the method is not expected to be called.
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets that the method is not expected to be called.
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode never()
 	{
@@ -143,11 +143,11 @@ public with sharing class fflib_VerificationMode
 	}
 
 	/**
-	* Sets how many times the method is expected to be called for an InOrder verifier. Available Only with the InOrder verification.
-	* A verification mode using calls will not fail if the method is called more times than expected.
-	* @param callingTimes The number of times you expect the method to have been called in the InOrder verifying (no greedy verify).
-	* @return The fflib_VerificationMode object instance with the proper settings.
-	*/
+	 * Sets how many times the method is expected to be called for an InOrder verifier. Available Only with the InOrder verification.
+	 * A verification mode using calls will not fail if the method is called more times than expected.
+	 * @param callingTimes The number of times you expect the method to have been called in the InOrder verifying (no greedy verify).
+	 * @return The fflib_VerificationMode object instance with the proper settings.
+	 */
 	@NamespaceAccessible
 	public fflib_VerificationMode calls(Integer callingTimes)
 	{

--- a/sfdx-source/apex-mocks/test/classes/fflib_AnswerTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_AnswerTest.cls
@@ -3,8 +3,8 @@ Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* @nodoc
-*/
+ * @nodoc
+ */
 @IsTest
 private class fflib_AnswerTest
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_AnswerTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_AnswerTest.cls
@@ -1,22 +1,21 @@
 /*
- Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- * @nodoc
- */
-@isTest
+* @nodoc
+*/
+@IsTest
 private class fflib_AnswerTest
 {
-
 	private static fflib_InvocationOnMock actualInvocation = null;
 
-	@isTest
+	@IsTest
 	static void thatAnswersWithException()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(0, 'Hi hi Hello Hi hi')).thenAnswer(new fflib_AnswerTest.ExceptionForAnswer());
@@ -28,7 +27,7 @@ private class fflib_AnswerTest
 			mockList.get2(0, 'Hi hi Hello Hi hi');
 			System.Assert.fail('an exception is expected to be thrown on the answer execution');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ansExpt)
+		catch (fflib_ApexMocks.ApexMocksException ansExpt)
 		{
 			String expectedMessage = 'an error occurs on the execution of the answer';
 			// Then
@@ -36,12 +35,12 @@ private class fflib_AnswerTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatStoresMethodIntoInvocationOnMock()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(0, 'Hi hi Hello Hi hi')).thenAnswer(new fflib_AnswerTest.BasicAnswer());
@@ -56,15 +55,15 @@ private class fflib_AnswerTest
 		System.Assert.isInstanceOfType(methodCalled, fflib_QualifiedMethod.class, 'the object returned is not a method as expected');
 
 		String expectedMethodSignature = fflib_MyList.getStubClassName() + '.get2(Integer, String)';
-		System.Assert.areEqual(expectedMethodSignature, ((fflib_QualifiedMethod)methodCalled).toString(), ' the method is no the one expected');
+		System.Assert.areEqual(expectedMethodSignature, ((fflib_QualifiedMethod) methodCalled).toString(), ' the method is no the one expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatAnswerOnlyForTheMethodStubbedWithAnswer()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get(3)).thenReturn('ted');
@@ -81,17 +80,17 @@ private class fflib_AnswerTest
 		System.Assert.isInstanceOfType(methodCalled, fflib_QualifiedMethod.class, 'the object returned is not a method as expected');
 
 		String expectedMethodSignature = fflib_MyList.getStubClassName() + '.get2(Integer, String)';
-		System.Assert.areEqual(expectedMethodSignature, ((fflib_QualifiedMethod)methodCalled).toString(), ' the method is no the one expected');
+		System.Assert.areEqual(expectedMethodSignature, ((fflib_QualifiedMethod) methodCalled).toString(), ' the method is no the one expected');
 
 		System.Assert.areEqual('ted', noAnswered, 'the get method should have returned the stubbed string');
 	}
 
-	@isTest
+	@IsTest
 	static void thatMultipleAnswersAreHandled()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get(3)).thenAnswer(new fflib_AnswerTest.FirstAnswer());
@@ -107,12 +106,12 @@ private class fflib_AnswerTest
 		System.Assert.areEqual('and this is the second one', answer2, 'the answer wasnt the one expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStoresMockInstanceIntoInvocationOnMock()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(0, 'Hi hi Hello Hi hi')).thenAnswer(new fflib_AnswerTest.BasicAnswer());
@@ -126,12 +125,12 @@ private class fflib_AnswerTest
 		System.Assert.areEqual(mockList, actualInvocation.getMock(), 'the mock returned should be the mockList used in the stubbing');
 	}
 
-	@isTest
+	@IsTest
 	static void thatMethodsParametersAreAccessible()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(0, 'Hi hi Hello Hi hi')).thenAnswer(new fflib_AnswerTest.ProcessArgumentAnswer());
@@ -144,12 +143,12 @@ private class fflib_AnswerTest
 		System.Assert.areEqual('Bye hi Hello Bye hi', actualValue, 'the answer is not correct');
 	}
 
-	@isTest
+	@IsTest
 	static void thatAnswerOnlyForTheStubbedParameter()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(0, 'Hi hi Hello Hi hi')).thenAnswer(new fflib_AnswerTest.ProcessArgumentAnswer());
@@ -166,12 +165,12 @@ private class fflib_AnswerTest
 		System.Assert.areEqual(null, actualValue3, 'the answer is not correct');
 	}
 
-	@isTest
+	@IsTest
 	static void thatMethodsParametersAreAccessibleWhenCalledWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(fflib_Match.anyInteger(), fflib_Match.anyString())).thenAnswer(new fflib_AnswerTest.ProcessArgumentAnswer());
@@ -184,12 +183,12 @@ private class fflib_AnswerTest
 		System.Assert.areEqual('Bye hi Hello Bye hi', actualValue, 'the answer is not correct');
 	}
 
-	@isTest
+	@IsTest
 	static void thatExceptionIsThrownWhenAccessOutOfIndexArgument()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(0, 'Hi hi Hello Hi hi')).thenAnswer(new fflib_AnswerTest.ExceptionForArgumentsOutOfBound());
@@ -199,12 +198,12 @@ private class fflib_AnswerTest
 		String actualValue = mockList.get2(0, 'Hi hi Hello Hi hi');
 	}
 
-	@isTest
+	@IsTest
 	static void thatExceptionIsThrownWhenAccessNegativeIndexArgument()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(0, 'Hi hi Hello Hi hi')).thenAnswer(new fflib_AnswerTest.ExceptionForNegativeArgumentIndex());
@@ -214,12 +213,12 @@ private class fflib_AnswerTest
 		String actualValue = mockList.get2(0, 'Hi hi Hello Hi hi');
 	}
 
-	@isTest
+	@IsTest
 	static void thatArgumentListEmptyForMethodWithNoArgument()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.isEmpty()).thenAnswer(new fflib_AnswerTest.ArgumentListEmptyForMethodWithNoArgument());
@@ -229,12 +228,12 @@ private class fflib_AnswerTest
 		Boolean actualValue = mockList.isEmpty();
 	}
 
-	@isTest
+	@IsTest
 	static void thatAnswerToVoidMethod()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		((fflib_MyList) mocks.doAnswer(new fflib_AnswerTest.BasicAnswer(), mockList)).addMore('Hi hi Hello Hi hi');
@@ -248,15 +247,15 @@ private class fflib_AnswerTest
 		System.Assert.isInstanceOfType(methodCalled, fflib_QualifiedMethod.class, 'the object returned is not a method as expected');
 
 		String expectedMethodSignature = fflib_MyList.getStubClassName() + '.addMore(String)';
-		System.Assert.areEqual(expectedMethodSignature, ((fflib_QualifiedMethod)methodCalled).toString(), 'Unexpected method name: ' + methodCalled);
+		System.Assert.areEqual(expectedMethodSignature, ((fflib_QualifiedMethod) methodCalled).toString(), 'Unexpected method name: ' + methodCalled);
 	}
 
-	@isTest
+	@IsTest
 	static void thatAnswerToVoidAndNotVoidMethods()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		((fflib_MyList) mocks.doAnswer(new fflib_AnswerTest.FirstAnswer(), mockList)).get(3);
@@ -274,19 +273,18 @@ private class fflib_AnswerTest
 		System.Assert.isInstanceOfType(methodCalled, fflib_QualifiedMethod.class, 'the object returned is not a method as expected');
 
 		String expectedMethodSignature = fflib_MyList.getStubClassName() + '.addMore(String)';
-		System.Assert.areEqual(expectedMethodSignature, ((fflib_QualifiedMethod)methodCalled).toString(),
-			'the last method called should be the addMore, so should be the last to set the actualInvocation variable.');
+		System.Assert.areEqual(expectedMethodSignature, ((fflib_QualifiedMethod) methodCalled).toString(), 'the last method called should be the addMore, so should be the last to set the actualInvocation variable.');
 
 		System.Assert.areEqual('this is the first answer', answer1, 'the answer was not the one expected');
 		System.Assert.areEqual('and this is the second one', answer2, 'the answer was not the one expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatAnswerToDifferentVoidMethods()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		fflib_AnswerTest.FirstAnswer answer1 = new fflib_AnswerTest.FirstAnswer();
 		fflib_AnswerTest.SecondAnswer answer2 = new fflib_AnswerTest.SecondAnswer();
@@ -340,7 +338,7 @@ private class fflib_AnswerTest
 				Object noExistingObj = invocation.getArgument(2);
 				System.Assert.fail('an exception was expected because the argument in the method are only 2');
 			}
-			catch(fflib_ApexMocks.ApexMocksException exp)
+			catch (fflib_ApexMocks.ApexMocksException exp)
 			{
 				String expectedMessage = 'Invalid index, must be greater or equal to zero and less of 2.';
 				String actualMessage = exp.getMessage();
@@ -361,7 +359,7 @@ private class fflib_AnswerTest
 				Object noExistingObj = invocation.getArgument(-1);
 				System.Assert.fail('an exception was expected because the argument index cannot be negative');
 			}
-			catch(fflib_ApexMocks.ApexMocksException exp)
+			catch (fflib_ApexMocks.ApexMocksException exp)
 			{
 				String expectedMessage = 'Invalid index, must be greater or equal to zero and less of 2.';
 				String actualMessage = exp.getMessage();

--- a/sfdx-source/apex-mocks/test/classes/fflib_AnyOrderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_AnyOrderTest.cls
@@ -1,23 +1,23 @@
 /*
- Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- * @nodoc
- */
-@isTest
+* @nodoc
+*/
+@IsTest
 private class fflib_AnyOrderTest
 {
 	/*
-	 *	replicating the apex mocks tests with the new syntax
-	 */
+	*	replicating the apex mocks tests with the new syntax
+	*/
 
-	@isTest
+	@IsTest
 	private static void whenVerifyMultipleCallsWithMatchersShouldReturnCorrectMethodCallCounts()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -29,56 +29,39 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList)).add(fflib_Match.stringContains('fred'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenVerifyWithCombinedMatchersShouldReturnCorrectMethodCallCounts()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
 		mockList.add('fred');
 
 		// Then
-		((fflib_MyList.IList) mocks.verify(mockList, mocks.never())).add(
-			(String)fflib_Match.allOf(fflib_Match.eq('bob'), fflib_Match.stringContains('re'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, mocks.never())).add((String) fflib_Match.allOf(fflib_Match.eq('bob'), fflib_Match.stringContains('re')));
 
-		((fflib_MyList.IList) mocks.verify(mockList)).add(
-			(String)fflib_Match.allOf(fflib_Match.eq('fred'), fflib_Match.stringContains('re'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList)).add((String) fflib_Match.allOf(fflib_Match.eq('fred'), fflib_Match.stringContains('re')));
 
-		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).add(
-			(String)fflib_Match.anyOf(fflib_Match.eq('bob'), fflib_Match.eq('fred'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).add((String) fflib_Match.anyOf(fflib_Match.eq('bob'), fflib_Match.eq('fred')));
 
-		((fflib_MyList.IList) mocks.verify(mockList)).add(
-			(String)fflib_Match.anyOf(fflib_Match.eq('bob'), fflib_Match.eq('jack'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList)).add((String) fflib_Match.anyOf(fflib_Match.eq('bob'), fflib_Match.eq('jack')));
 
-		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).add(
-			(String)fflib_Match.noneOf(fflib_Match.eq('jack'), fflib_Match.eq('tim'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).add((String) fflib_Match.noneOf(fflib_Match.eq('jack'), fflib_Match.eq('tim')));
 
-		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).add(
-			(String)fflib_Match.noneOf(
-				fflib_Match.anyOf(fflib_Match.eq('jack'), fflib_Match.eq('jill')),
-				fflib_Match.allOf(fflib_Match.eq('tim'), fflib_Match.stringContains('i'))
-			)
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).add((String) fflib_Match.noneOf(fflib_Match.anyOf(fflib_Match.eq('jack'), fflib_Match.eq('jill')), fflib_Match.allOf(fflib_Match.eq('tim'), fflib_Match.stringContains('i'))));
 
-		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).add(
-			(String)fflib_Match.isNot(fflib_Match.eq('jack'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).add((String) fflib_Match.isNot(fflib_Match.eq('jack')));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenVerifyCustomMatchersCanBeUsed()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.get(1);
@@ -88,16 +71,16 @@ private class fflib_AnyOrderTest
 		mockList.get(5);
 
 		// Then
-		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(3))).get((Integer)fflib_Match.matches(new isOdd()));
-		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).get((Integer)fflib_Match.matches(new isEven()));
+		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(3))).get((Integer) fflib_Match.matches(new isOdd()));
+		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).get((Integer) fflib_Match.matches(new isEven()));
 	}
 
-	@isTest
+	@IsTest
 	private static void verifyMultipleMethodCallsWithSameSingleArgument()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -107,12 +90,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(2))).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void verifyMethodNotCalled()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.get(0);
@@ -122,12 +105,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList)).get(0);
 	}
 
-	@isTest
+	@IsTest
 	private static void verifySingleMethodCallWithMultipleArguments()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.set(0, 'bob');
@@ -137,23 +120,23 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.never())).set(0, 'fred');
 	}
 
-	@isTest
+	@IsTest
 	private static void verifyMethodCallWhenNoCallsBeenMadeForType()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// Then
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.never())).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void whenVerifyMethodNeverCalledMatchersAreReset()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -164,15 +147,15 @@ private class fflib_AnyOrderTest
 	}
 
 	/*
-	 *	times
-	 */
+	*	times
+	*/
 
-	@isTest
+	@IsTest
 	private static void verifyTimesMethodHasBeenCalled()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -183,12 +166,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(3))).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void verifyTimesMethodHasBeenCalledWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob1');
@@ -199,12 +182,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.times(3))).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifyTimesMethodFailsWhenCalledLessTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -218,18 +201,18 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected');
 		}
-		catch(Exception exc)
+		catch (Exception exc)
 		{
 			assertFailMessage(exc.getMessage(), 4, 3);
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifyTimesMethodFailsWhenCalledMoreTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -243,18 +226,18 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected');
 		}
-		catch(Exception exc)
+		catch (Exception exc)
 		{
 			assertFailMessage(exc.getMessage(), 2, 3);
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifyTimesMethodFailsWhenCalledLessTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -268,18 +251,18 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected');
 		}
-		catch(Exception exc)
+		catch (Exception exc)
 		{
 			assertFailMessage(exc.getMessage(), 4, 3);
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifyTimesMethodFailsWhenCalledMoreTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -293,22 +276,22 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected');
 		}
-		catch(Exception exc)
+		catch (Exception exc)
 		{
 			assertFailMessage(exc.getMessage(), 2, 3);
 		}
 	}
 
 	/*
-	 *	description
-	 */
+	*	description
+	*/
 
-	@isTest
+	@IsTest
 	private static void thatCustomMessageIsAdded()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -324,31 +307,35 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected');
 		}
-		catch(Exception exc)
+		catch (Exception exc)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 2'
-				+ '\nACTUAL COUNT: 3'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\nCustom message to explain the reason of the verification'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("bob"), ("bob")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: [any String]',
-				exc.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 2'
+					+ '\nACTUAL COUNT: 3'
+					+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+					+ '\nCustom message to explain the reason of the verification'
+					+ '\n---'
+					+ '\nACTUAL ARGS: ("bob"), ("bob"), ("bob")'
+					+ '\n---'
+					+ '\nEXPECTED ARGS: [any String]',
+					exc.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
 	/*
-	 *	atLeast
-	 */
+	*	atLeast
+	*/
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -360,12 +347,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeast(2))).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastNumberOfTimesWhenIsCalledMoreTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -379,12 +366,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeast(2))).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void thatThrownExceptionIfCalledLessThanAtLeastNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -398,26 +385,24 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called 3 times when instead is called only twice');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 3 or more times'
-				+ '\nACTUAL COUNT: 2'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("bob")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "bob"',
-				ex.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 3 or more times' + '\nACTUAL COUNT: 2' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("bob"), ("fred"), ("bob")' + '\n---' + '\nEXPECTED ARGS: "bob"',
+					ex.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -427,12 +412,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeast(2))).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastNumberOfTimesWhenIsCalledMoreTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -444,12 +429,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeast(2))).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatThrownExceptionIfCalledLessThanAtLeastNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -462,30 +447,28 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called 3 times when instead is called only twice');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 3 or more times'
-				+ '\nACTUAL COUNT: 2'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: [any String]',
-				ex.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 3 or more times' + '\nACTUAL COUNT: 2' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("bob"), ("fred")' + '\n---' + '\nEXPECTED ARGS: [any String]',
+					ex.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
 	/*
-	 *	atMost
-	 */
+	*	atMost
+	*/
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtMostNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -498,12 +481,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atMost(5))).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtMostSameNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -516,12 +499,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atMost(3))).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void thatThrownExceptionIfCalledMoreThanAtMostNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -539,26 +522,24 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called 3 times when instead is called four times');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 3 or fewer times'
-				+ '\nACTUAL COUNT: 4'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("fred"), ("bob"), ("bob"), ("bob"), ("fred")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "bob"',
-				ex.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 3 or fewer times' + '\nACTUAL COUNT: 4' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("bob"), ("fred"), ("fred"), ("bob"), ("bob"), ("bob"), ("fred")' + '\n---' + '\nEXPECTED ARGS: "bob"',
+					ex.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtMostNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -569,12 +550,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atMost(5))).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtMostSameNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -585,12 +566,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atMost(3))).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatThrownExceptionIfCalledMoreThanAtMostNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -605,30 +586,28 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called 3 times when instead is called four times');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 3 or fewer times'
-				+ '\nACTUAL COUNT: 4'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("fred"), ("fred")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: [any String]'
-				, ex.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 3 or fewer times' + '\nACTUAL COUNT: 4' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("bob"), ("fred"), ("fred"), ("fred")' + '\n---' + '\nEXPECTED ARGS: [any String]',
+					ex.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
 	/*
-	 *	atLeastOnce
-	 */
+	*	atLeastOnce
+	*/
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastOnceNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -639,12 +618,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeastOnce())).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastOnceNumberOfTimesWhenIsCalledMoreTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -656,12 +635,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeastOnce())).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void thatThrownExceptionIfCalledLessThanAtLeastOnceNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('rob');
@@ -674,26 +653,24 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called at least once when instead is never called');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 or more times'
-				+ '\nACTUAL COUNT: 0'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("rob"), ("fred")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "bob"',
-				ex.getmessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 or more times' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("rob"), ("fred")' + '\n---' + '\nEXPECTED ARGS: "bob"',
+					ex.getmessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastOnceNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -703,12 +680,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeastOnce())).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastOnceNumberOfTimesWhenIsCalledMoreTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -722,12 +699,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeastOnce())).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatThrownExceptionIfCalledLessThanAtLeastOnceNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('fred', 'fred', 'fred', 'fred');
@@ -741,30 +718,28 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called at lest once when instead is never called');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 or more times'
-				+ '\nACTUAL COUNT: 0'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ()'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: [any String]',
-				ex.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 or more times' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ()' + '\n---' + '\nEXPECTED ARGS: [any String]',
+					ex.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
 	/*
-	 *	between
-	 */
+	*	between
+	*/
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesBetweenNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -780,12 +755,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.between(3, 5))).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void thatBetweenThrownExceptionIfCalledLessThanAtLeastNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -799,26 +774,18 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called at least 3 times when instead is called only twice');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 3 or more times'
-				+ '\nACTUAL COUNT: 2'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("bob")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "bob"',
-				ex.getMessage()
-			);
+			System.Assert.areEqual('EXPECTED COUNT: 3 or more times' + '\nACTUAL COUNT: 2' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("bob"), ("fred"), ("bob")' + '\n---' + '\nEXPECTED ARGS: "bob"', ex.getMessage());
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesBetweenNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -830,12 +797,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.between(3, 5))).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatBetweenThrownExceptionIfCalledLessThanAtLeastNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -848,26 +815,18 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called 3 times when instead is called only twice');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 3 or more times'
-				+ '\nACTUAL COUNT: 2'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: [any String]',
-				ex.getMessage()
-			);
+			System.Assert.areEqual('EXPECTED COUNT: 3 or more times' + '\nACTUAL COUNT: 2' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("bob"), ("fred")' + '\n---' + '\nEXPECTED ARGS: [any String]', ex.getMessage());
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatBetweenThrownExceptionIfCalledMoreThanAtMostNumberOfTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -887,26 +846,29 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called at most 5 times when instead is called six times');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 5 or fewer times'
-				+ '\nACTUAL COUNT: 6'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("fred"), ("bob"), ("bob"), ("bob"), ("bob"), ("bob"), ("fred")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "bob"',
-				ex.getMessage()
-			);
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 5 or fewer times'
+					+ '\nACTUAL COUNT: 6'
+					+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+					+ '\n---'
+					+ '\nACTUAL ARGS: ("bob"), ("fred"), ("fred"), ("bob"), ("bob"), ("bob"), ("bob"), ("bob"), ("fred")'
+					+ '\n---'
+					+ '\nEXPECTED ARGS: "bob"',
+					ex.getMessage()
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatBetweenThrownExceptionIfCalledMoreThanAtMostNumberOfTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -923,30 +885,28 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called 5 times when instead is called six times');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 5 or fewer times'
-				+ '\nACTUAL COUNT: 6'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("bob"), ("fred"), ("fred"), ("fred")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: [any String]',
-				ex.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 5 or fewer times' + '\nACTUAL COUNT: 6' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("bob"), ("fred"), ("bob"), ("fred"), ("fred"), ("fred")' + '\n---' + '\nEXPECTED ARGS: [any String]',
+					ex.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
 	/*
-	 *	never
-	 */
+	*	never
+	*/
 
-	@isTest
+	@IsTest
 	private static void verifyNeverMethodHasNotBeenCalled()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob1');
@@ -957,12 +917,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.never())).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void verifyNeverMethodHasBeenNotCalledWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('fred', 'fred', 'fred', 'fred');
@@ -973,12 +933,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.never())).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifyNeverFailsWhenCalledMoreTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -991,18 +951,18 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected');
 		}
-		catch(Exception exc)
+		catch (Exception exc)
 		{
 			assertFailMessage(exc.getMessage(), 0, 2);
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifyNeverFailsWhenCalledMoreTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -1016,24 +976,22 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected');
 		}
-		catch(Exception exc)
+		catch (Exception exc)
 		{
 			assertFailMessage(exc.getMessage(), 0, 3);
 		}
 	}
 
-
-
 	/*
-	 *	atLeastOnce
-	 */
+	*	atLeastOnce
+	*/
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastOnce()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -1045,12 +1003,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeastOnce())).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastOnceWhenIsCalledMoreTimes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -1064,12 +1022,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeastOnce())).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	private static void thatThrownExceptionIfCalledLessThanAtLeastOnce()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -1083,26 +1041,24 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called one times when instead is not called');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 or more times'
-				+ '\nACTUAL COUNT: 0'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred"), ("bob")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "rob"',
-				ex.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 or more times' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("bob"), ("fred"), ("bob")' + '\n---' + '\nEXPECTED ARGS: "rob"',
+					ex.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastOnceWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -1112,12 +1068,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeastOnce())).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatVerifiesAtLeastOnceWhenIsCalledMoreTimesWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -1129,12 +1085,12 @@ private class fflib_AnyOrderTest
 		((fflib_MyList.IList) mocks.verify(mockList, mocks.atLeastOnce())).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void thatThrownExceptionIfCalledLessThanAtLeastOnceWithMatchers()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -1147,41 +1103,36 @@ private class fflib_AnyOrderTest
 
 			System.Assert.fail('an exception was expected because we are asserting that the method is called once when instead is not called');
 		}
-		catch(fflib_ApexMocks.ApexMocksException ex)
+		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 or more times'
-				+ '\nACTUAL COUNT: 0'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("bob"), ("fred")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: [starts with "rob"]',
-				ex.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 or more times' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("bob"), ("fred")' + '\n---' + '\nEXPECTED ARGS: [starts with "rob"]',
+					ex.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
 	/*
-	 *	HELPER METHODS
-	 */
+	*	HELPER METHODS
+	*/
 
 	private static void assertFailMessage(String exceptionMessage, Integer expectedInvocations, Integer actualsInvocations)
 	{
-		System.Assert.isTrue(
-			exceptionMessage.startsWith('EXPECTED COUNT: ' + expectedInvocations + '\nACTUAL COUNT: ' + actualsInvocations),
-			'Unexpected verify fail message: ' + exceptionMessage
-		);
+		System.Assert.isTrue(exceptionMessage.startsWith('EXPECTED COUNT: ' + expectedInvocations + '\nACTUAL COUNT: ' + actualsInvocations), 'Unexpected verify fail message: ' + exceptionMessage);
 	}
 
 	/*
-	 *	HELPER CLASSES
-	 */
+	*	HELPER CLASSES
+	*/
 
 	private class isOdd implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)
 		{
-			return arg instanceof Integer ? Math.mod((Integer)arg, 2) == 1: false;
+			return arg instanceof Integer ? Math.mod((Integer) arg, 2) == 1 : false;
 		}
 	}
 
@@ -1189,7 +1140,7 @@ private class fflib_AnyOrderTest
 	{
 		public Boolean matches(Object arg)
 		{
-			return arg instanceof Integer ? Math.mod((Integer)arg, 2) == 0: false;
+			return arg instanceof Integer ? Math.mod((Integer) arg, 2) == 0 : false;
 		}
 	}
 }

--- a/sfdx-source/apex-mocks/test/classes/fflib_AnyOrderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_AnyOrderTest.cls
@@ -3,8 +3,8 @@ Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* @nodoc
-*/
+ * @nodoc
+ */
 @IsTest
 private class fflib_AnyOrderTest
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksTest.cls
@@ -1,18 +1,18 @@
 /*
- * Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
- */
-@isTest
+* Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
+*/
+@IsTest
 private class fflib_ApexMocksTest
 {
 	private static final fflib_ApexMocks MY_MOCKS = new fflib_ApexMocks();
-	private static final fflib_MyList MY_MOCK_LIST = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+	private static final fflib_MyList MY_MOCK_LIST = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 
-	@isTest
+	@IsTest
 	static void whenStubMultipleCallsWithMatchersShouldReturnExpectedValues()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(fflib_Match.anyInteger(), fflib_Match.anyString())).thenReturn('any');
@@ -26,12 +26,12 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual('hello', actualValue);
 	}
 
-	@isTest
+	@IsTest
 	static void whenVerifyMultipleCallsWithMatchersShouldReturnCorrectMethodCallCounts()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -43,15 +43,15 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList)).add(fflib_Match.stringContains('fred'));
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubExceptionWithMatchersShouldThrowException()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
-		((fflib_MyList.IList) mocks.doThrowWhen(new MyException('Matcher Exception'),  mockList)).add(fflib_Match.stringContains('Hello'));
+		((fflib_MyList.IList) mocks.doThrowWhen(new MyException('Matcher Exception'), mockList)).add(fflib_Match.stringContains('Hello'));
 		mocks.stopStubbing();
 
 		// When
@@ -69,60 +69,43 @@ private class fflib_ApexMocksTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void whenVerifyWithCombinedMatchersShouldReturnCorrectMethodCallCounts()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
 		mockList.add('fred');
 
 		// Then
-		((fflib_MyList.IList) mocks.verify(mockList, 0)).add(
-			(String)fflib_Match.allOf(fflib_Match.eq('bob'), fflib_Match.stringContains('re'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, 0)).add((String) fflib_Match.allOf(fflib_Match.eq('bob'), fflib_Match.stringContains('re')));
 
-		((fflib_MyList.IList) mocks.verify(mockList)).add(
-			(String)fflib_Match.allOf(fflib_Match.eq('fred'), fflib_Match.stringContains('re'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList)).add((String) fflib_Match.allOf(fflib_Match.eq('fred'), fflib_Match.stringContains('re')));
 
-		((fflib_MyList.IList) mocks.verify(mockList, 2)).add(
-			(String)fflib_Match.anyOf(fflib_Match.eq('bob'), fflib_Match.eq('fred'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, 2)).add((String) fflib_Match.anyOf(fflib_Match.eq('bob'), fflib_Match.eq('fred')));
 
-		((fflib_MyList.IList) mocks.verify(mockList, 1)).add(
-			(String)fflib_Match.anyOf(fflib_Match.eq('bob'), fflib_Match.eq('jack'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, 1)).add((String) fflib_Match.anyOf(fflib_Match.eq('bob'), fflib_Match.eq('jack')));
 
-		((fflib_MyList.IList) mocks.verify(mockList, 2)).add(
-			(String)fflib_Match.noneOf(fflib_Match.eq('jack'), fflib_Match.eq('tim'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, 2)).add((String) fflib_Match.noneOf(fflib_Match.eq('jack'), fflib_Match.eq('tim')));
 
-		((fflib_MyList.IList) mocks.verify(mockList, 2)).add(
-			(String)fflib_Match.noneOf(
-				fflib_Match.anyOf(fflib_Match.eq('jack'), fflib_Match.eq('jill')),
-				fflib_Match.allOf(fflib_Match.eq('tim'), fflib_Match.stringContains('i'))
-			)
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, 2)).add((String) fflib_Match.noneOf(fflib_Match.anyOf(fflib_Match.eq('jack'), fflib_Match.eq('jill')), fflib_Match.allOf(fflib_Match.eq('tim'), fflib_Match.stringContains('i'))));
 
-		((fflib_MyList.IList) mocks.verify(mockList, 2)).add(
-			(String)fflib_Match.isNot(fflib_Match.eq('jack'))
-		);
+		((fflib_MyList.IList) mocks.verify(mockList, 2)).add((String) fflib_Match.isNot(fflib_Match.eq('jack')));
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubCustomMatchersCanBeUsed()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
-		mocks.when(mockList.get((Integer)fflib_Match.matches(new isOdd()))).thenReturn('Odd');
-		mocks.when(mockList.get((Integer)fflib_Match.matches(new isEven()))).thenReturn('Even');
+		mocks.when(mockList.get((Integer) fflib_Match.matches(new isOdd()))).thenReturn('Odd');
+		mocks.when(mockList.get((Integer) fflib_Match.matches(new isEven()))).thenReturn('Even');
 		mocks.stopStubbing();
 
 		// When
@@ -140,12 +123,12 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual('Odd', s5);
 	}
 
-	@isTest
+	@IsTest
 	static void whenVerifyCustomMatchersCanBeUsed()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.get(1);
@@ -155,21 +138,22 @@ private class fflib_ApexMocksTest
 		mockList.get(5);
 
 		// Then
-		((fflib_MyList.IList) mocks.verify(mockList, 3)).get((Integer)fflib_Match.matches(new isOdd()));
-		((fflib_MyList.IList) mocks.verify(mockList, 2)).get((Integer)fflib_Match.matches(new isEven()));
+		((fflib_MyList.IList) mocks.verify(mockList, 3)).get((Integer) fflib_Match.matches(new isOdd()));
+		((fflib_MyList.IList) mocks.verify(mockList, 2)).get((Integer) fflib_Match.matches(new isEven()));
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubWithMatcherAndNonMatcherArgumentsShouldThrowException()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
-		String expectedError = 'The number of matchers defined (1).'
-				+ ' does not match the number expected (2)\n'
-				+ 'If you are using matchers all arguments must be passed in as matchers.\n'
-				+ 'For example myList.add(fflib_Match.anyInteger(), \'String\') should be defined as myList.add(fflib_Match.anyInteger(), fflib_Match.eq(\'String\')).';
+		String expectedError =
+			'The number of matchers defined (1).'
+			+ ' does not match the number expected (2)\n'
+			+ 'If you are using matchers all arguments must be passed in as matchers.\n'
+			+ 'For example myList.add(fflib_Match.anyInteger(), \'String\') should be defined as myList.add(fflib_Match.anyInteger(), fflib_Match.eq(\'String\')).';
 
 		// Then
 		try
@@ -184,17 +168,18 @@ private class fflib_ApexMocksTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void whenVerifyWithMatcherAndNonMatcherArgumentsShouldThrowException()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
-		String expectedError = 'The number of matchers defined (1).'
-				+ ' does not match the number expected (2)\n'
-				+ 'If you are using matchers all arguments must be passed in as matchers.\n'
-				+ 'For example myList.add(fflib_Match.anyInteger(), \'String\') should be defined as myList.add(fflib_Match.anyInteger(), fflib_Match.eq(\'String\')).';
+		String expectedError =
+			'The number of matchers defined (1).'
+			+ ' does not match the number expected (2)\n'
+			+ 'If you are using matchers all arguments must be passed in as matchers.\n'
+			+ 'For example myList.add(fflib_Match.anyInteger(), \'String\') should be defined as myList.add(fflib_Match.anyInteger(), fflib_Match.eq(\'String\')).';
 
 		mockList.get2(1, 'String literal');
 
@@ -210,12 +195,12 @@ private class fflib_ApexMocksTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubSameMethodWithMatchersAndNonMatchersShouldStubInOrder()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 
@@ -232,20 +217,20 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual('Good', mockList.get2(1, 'Matcher first'));
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubExceptionSameMethodWithMatchersAndNonMatchersShouldStubInOrder()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 
-		((fflib_MyList.IList)mocks.doThrowWhen(new fflib_ApexMocks.ApexMocksException('Bad'), mockList)).add('Non-matcher first'); //Set the exception value using the non-matcher arguments
-		((fflib_MyList.IList)mocks.doThrowWhen(new fflib_ApexMocks.ApexMocksException('Good'), mockList)).add(fflib_Match.stringContains('Non-matcher first')); //Override the exception value using matcher arguments
+		((fflib_MyList.IList) mocks.doThrowWhen(new fflib_ApexMocks.ApexMocksException('Bad'), mockList)).add('Non-matcher first'); //Set the exception value using the non-matcher arguments
+		((fflib_MyList.IList) mocks.doThrowWhen(new fflib_ApexMocks.ApexMocksException('Good'), mockList)).add(fflib_Match.stringContains('Non-matcher first')); //Override the exception value using matcher arguments
 
-		((fflib_MyList.IList)mocks.doThrowWhen(new fflib_ApexMocks.ApexMocksException('Bad'), mockList)).add(fflib_Match.stringContains('Matcher first')); //Set the exception value using the matcher arguments
-		((fflib_MyList.IList)mocks.doThrowWhen(new fflib_ApexMocks.ApexMocksException('Good'), mockList)).add('Matcher first'); //Override the exception value using non-matcher arguments
+		((fflib_MyList.IList) mocks.doThrowWhen(new fflib_ApexMocks.ApexMocksException('Bad'), mockList)).add(fflib_Match.stringContains('Matcher first')); //Set the exception value using the matcher arguments
+		((fflib_MyList.IList) mocks.doThrowWhen(new fflib_ApexMocks.ApexMocksException('Good'), mockList)).add('Matcher first'); //Override the exception value using non-matcher arguments
 
 		mocks.stopStubbing();
 
@@ -271,12 +256,12 @@ private class fflib_ApexMocksTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubSingleCallWithSingleArgumentShouldReturnStubbedValue()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get(0)).thenReturn('bob');
@@ -289,12 +274,12 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual('bob', actualValue);
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubSingleCallWithNullReturnValueItShouldReturnNull()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get(0)).thenReturn(null);
@@ -307,12 +292,12 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual(null, actualValue);
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubMultipleCallsWithSingleArgumentShouldReturnStubbedValues()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get(0)).thenReturn('bob');
@@ -330,12 +315,12 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual(null, actualValueArg2);
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubSameCallWithDifferentArgumentValueShouldReturnLastStubbedValue()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get(0)).thenReturn('bob1');
@@ -349,12 +334,12 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual('bob2', actualValue);
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubCallWithNoArgumentsShouldReturnStubbedValue()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.isEmpty()).thenReturn(false);
@@ -367,12 +352,12 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual(false, actualValue);
 	}
 
-	@isTest
+	@IsTest
 	static void verifySingleMethodCallWithNoArguments()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.isEmpty();
@@ -381,12 +366,12 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList)).isEmpty();
 	}
 
-	@isTest
+	@IsTest
 	static void verifySingleMethodCallWithSingleArgument()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -395,12 +380,12 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList)).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	static void verifyMultipleMethodCallsWithSameSingleArgument()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -410,12 +395,12 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList, 2)).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	static void verifyMultipleMethodCallsWithDifferentSingleArgument()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -426,32 +411,32 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList)).add('fred');
 	}
 
-	@isTest
+	@IsTest
 	static void verifyMethodCallsWithSameNameButDifferentArgumentTypes()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
-		mockList.add(new String[] {'bob'});
-		mockList.add((String)null);
-		mockList.add((String[])null);
+		mockList.add(new String[]{ 'bob' });
+		mockList.add((String) null);
+		mockList.add((String[]) null);
 
 		// Then
 		((fflib_MyList.IList) mocks.verify(mockList)).add('bob');
-		((fflib_MyList.IList) mocks.verify(mockList)).add(new String[] {'bob'});
-		((fflib_MyList.IList) mocks.verify(mockList)).add((String)null);
-		((fflib_MyList.IList) mocks.verify(mockList)).add((String[])null);
+		((fflib_MyList.IList) mocks.verify(mockList)).add(new String[]{ 'bob' });
+		((fflib_MyList.IList) mocks.verify(mockList)).add((String) null);
+		((fflib_MyList.IList) mocks.verify(mockList)).add((String[]) null);
 	}
 
-	@isTest
+	@IsTest
 	static void verifyMethodNotCalled()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.get(0);
@@ -461,12 +446,12 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList)).get(0);
 	}
 
-	@isTest
+	@IsTest
 	static void stubAndVerifyMethodCallsWithNoArguments()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.isEmpty()).thenReturn(false);
@@ -482,12 +467,12 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList)).clear();
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubExceptionTheExceptionShouldBeThrown()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get(0)).thenThrow(new MyException('Stubbed exception.'));
@@ -499,7 +484,7 @@ private class fflib_ApexMocksTest
 			mockList.get(0);
 			System.Assert.fail('Stubbed exception should have been thrown.');
 		}
-		catch(Exception e)
+		catch (Exception e)
 		{
 			// Then
 			System.Assert.isInstanceOfType(e, MyException.class);
@@ -507,12 +492,12 @@ private class fflib_ApexMocksTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubVoidMethodWithExceptionThenExceptionShouldBeThrown()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		((fflib_MyList.IList) mocks.doThrowWhen(new MyException('Stubbed exception.'), mockList)).clear();
@@ -524,7 +509,7 @@ private class fflib_ApexMocksTest
 			mockList.clear();
 			System.Assert.fail('Stubbed exception should have been thrown.');
 		}
-		catch(Exception e)
+		catch (Exception e)
 		{
 			// Then
 			System.Assert.isInstanceOfType(e, MyException.class);
@@ -532,12 +517,12 @@ private class fflib_ApexMocksTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubMultipleVoidMethodsWithExceptionsThenExceptionsShouldBeThrown()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		((fflib_MyList.IList) mocks.doThrowWhen(new MyException('clear stubbed exception.'), mockList)).clear();
@@ -550,7 +535,7 @@ private class fflib_ApexMocksTest
 			mockList.clear();
 			System.Assert.fail('Stubbed exception should have been thrown.');
 		}
-		catch(Exception e)
+		catch (Exception e)
 		{
 			// Then
 			System.Assert.isInstanceOfType(e, MyException.class);
@@ -563,7 +548,7 @@ private class fflib_ApexMocksTest
 			mockList.add('bob');
 			System.Assert.fail('Stubbed exception should have been thrown.');
 		}
-		catch(Exception e)
+		catch (Exception e)
 		{
 			// Then
 			System.Assert.isInstanceOfType(e, MyException.class);
@@ -571,12 +556,12 @@ private class fflib_ApexMocksTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubVoidMethodWithExceptionAndCallMethodTwiceThenExceptionShouldBeThrownTwice()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		((fflib_MyList.IList) mocks.doThrowWhen(new MyException('clear stubbed exception.'), mockList)).clear();
@@ -588,7 +573,7 @@ private class fflib_ApexMocksTest
 			mockList.clear();
 			System.Assert.fail('Stubbed exception should have been thrown.');
 		}
-		catch(Exception e)
+		catch (Exception e)
 		{
 			// Then
 			System.Assert.isInstanceOfType(e, MyException.class);
@@ -601,7 +586,7 @@ private class fflib_ApexMocksTest
 			mockList.clear();
 			System.Assert.fail('Stubbed exception should have been thrown.');
 		}
-		catch(Exception e)
+		catch (Exception e)
 		{
 			// Then
 			System.Assert.isInstanceOfType(e, MyException.class);
@@ -609,23 +594,23 @@ private class fflib_ApexMocksTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void verifyMethodCallWhenNoCallsBeenMadeForType()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// Then
 		((fflib_MyList.IList) mocks.verify(mockList, fflib_ApexMocks.NEVER)).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	static void verifySingleMethodCallWithMultipleArguments()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.set(0, 'bob');
@@ -635,12 +620,12 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList, fflib_ApexMocks.NEVER)).set(0, 'fred');
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubMultipleCallsWithMultipleArgumentShouldReturnStubbedValues()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		mocks.startStubbing();
 		mocks.when(mockList.get2(0, 'zero')).thenReturn('bob');
@@ -664,12 +649,12 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual(null, actualValueArg4);
 	}
 
-	@isTest
+	@IsTest
 	static void whenStubNullConcreteArgValueCorrectValueIsReturned()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		String expected = 'hello';
 
@@ -684,14 +669,14 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual(expected, actual);
 	}
 
-	@isTest
+	@IsTest
 	static void whenSetDoThrowWhenExceptionsValuesAreSet()
 	{
 		//Given
 		MyException e = new MyException('Test');
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
 
-		List<Exception> expsList = new List<Exception>{e};
+		List<Exception> expsList = new List<Exception>{ e };
 
 		//When
 		mocks.DoThrowWhenExceptions = expsList;
@@ -700,12 +685,12 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual(expsList, mocks.DoThrowWhenExceptions);
 	}
 
-	@isTest
+	@IsTest
 	static void whenVerifyMethodNeverCalledMatchersAreReset()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -715,12 +700,12 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList)).add(fflib_Match.anyString());
 	}
 
-	@isTest
+	@IsTest
 	static void whenMockIsGeneratedCanVerify()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('bob');
@@ -730,12 +715,12 @@ private class fflib_ApexMocksTest
 		((fflib_MyList.IList) mocks.verify(mockList)).add('bob');
 	}
 
-	@isTest
+	@IsTest
 	static void whenMockIsGeneratedCanStubVerify()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mocks.startStubbing();
@@ -750,35 +735,30 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual('>Two', mockList.get(3));
 	}
 
-	@isTest
+	@IsTest
 	static void whenMockVoidMethodRecordsCallCanVerify()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
-		mocks.mockVoidMethod(
-			mockList,
-			'clear',
-			new List<Type>(),
-			new List<Object>()
-		);
+		mocks.mockVoidMethod(mockList, 'clear', new List<Type>(), new List<Object>());
 
 		// Then
 		((fflib_MyList.IList) mocks.verify(mockList, 1)).clear();
 	}
 
-	@isTest
+	@IsTest
 	static void thatMultipleInstancesCanBeMockedIndependently()
 	{
 		fflib_ApexMocksConfig.HasIndependentMocks = true;
 
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList first = (fflib_MyList)mocks.mock(fflib_MyList.class);
-		fflib_MyList second = (fflib_MyList)mocks.mock(fflib_MyList.class);
-		
+		fflib_MyList first = (fflib_MyList) mocks.mock(fflib_MyList.class);
+		fflib_MyList second = (fflib_MyList) mocks.mock(fflib_MyList.class);
+
 		mocks.startStubbing();
 		mocks.when(first.get(0)).thenReturn('First');
 		mocks.when(second.get(0)).thenReturn('Second');
@@ -789,20 +769,20 @@ private class fflib_ApexMocksTest
 
 		// Then
 		System.Assert.areEqual('First', actual, 'Should have returned stubbed value');
-		((fflib_MyList)mocks.verify(first)).get(0);
-		((fflib_MyList)mocks.verify(second, mocks.never())).get(0);
+		((fflib_MyList) mocks.verify(first)).get(0);
+		((fflib_MyList) mocks.verify(second, mocks.never())).get(0);
 	}
 
-	@isTest
+	@IsTest
 	static void thatMultipleInstancesCanBeMockedDependently()
 	{
 		fflib_ApexMocksConfig.HasIndependentMocks = false;
 
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList first = (fflib_MyList)mocks.mock(fflib_MyList.class);
-		fflib_MyList second = (fflib_MyList)mocks.mock(fflib_MyList.class);
-		
+		fflib_MyList first = (fflib_MyList) mocks.mock(fflib_MyList.class);
+		fflib_MyList second = (fflib_MyList) mocks.mock(fflib_MyList.class);
+
 		mocks.startStubbing();
 		mocks.when(first.get(0)).thenReturn('First');
 		mocks.when(second.get(0)).thenReturn('Second');
@@ -813,8 +793,8 @@ private class fflib_ApexMocksTest
 
 		// Then
 		System.Assert.areEqual('Second', actual, 'Should have returned stubbed value');
-		((fflib_MyList)mocks.verify(first)).get(0);
-		((fflib_MyList)mocks.verify(second)).get(0);
+		((fflib_MyList) mocks.verify(first)).get(0);
+		((fflib_MyList) mocks.verify(second)).get(0);
 	}
 
 	static void thatStubbingCanBeChainedFirstExceptionThenValue()
@@ -830,7 +810,7 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('One');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingCanBeChainedFirstValueThenException()
 	{
 		// Given
@@ -844,7 +824,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('Stubbed exception.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleMethodsCanBeChainedFirstExceptionThenValue()
 	{
 		// Given
@@ -861,7 +841,7 @@ private class fflib_ApexMocksTest
 		assertReturnedValueForGet2('One2');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleMethodsCanBeChainedFirstValueThenException()
 	{
 		// Given
@@ -878,13 +858,13 @@ private class fflib_ApexMocksTest
 		assertExceptionMessageForGet2('Stubbed exception2.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingReturnsDifferentValuesForDifferentCalls()
 	{
 		// Given
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'One', 'Two', 'Three'});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -893,13 +873,13 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Three');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingReturnsDifferentValuesForDifferentCallsAndRepeatLastValuesForFurtherCalls()
 	{
 		// Given
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'One', 'Two', 'Three'});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -911,7 +891,7 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Three');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingThrowsDifferentExceptionsForDifferentCalls()
 	{
 		// Given
@@ -921,7 +901,7 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{first, second, third});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -930,7 +910,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('third.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingThrowsDifferentExceptionsForDifferentCallsAndRepeatLastExceptionForFurtherCalls()
 	{
 		// Given
@@ -940,7 +920,7 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{first, second, third});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -952,7 +932,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('third.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingThrowsAndReturnsDifferentExceptionsAndValuesForDifferentCalls()
 	{
 		// Given
@@ -962,9 +942,7 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).
-			thenThrowMulti(new List<Exception>{first, second, third}).
-			thenReturnMulti(new List<String>{'One', 'Two', 'Three'});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third }).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -980,7 +958,7 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Three');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingReturnsAndThrowsDifferentValuesAndExceptionsForDifferentCalls()
 	{
 		// Given
@@ -990,9 +968,7 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).
-			thenReturnMulti(new List<String>{'One', 'Two', 'Three'}).
-			thenThrowMulti(new List<Exception>{first, second, third});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' }).thenThrowMulti(new List<Exception>{ first, second, third });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1008,7 +984,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('third.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenReturnWithSingleValue()
 	{
 		// Given
@@ -1023,13 +999,13 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Two');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenReturnMultiWithSingleValue()
 	{
 		// Given
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'One', 'Two', 'Three'});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' });
 		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturn('Two');
 		MY_MOCKS.stopStubbing();
 
@@ -1038,14 +1014,14 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Two');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenReturnMultiWithMultiValue()
 	{
 		// Given
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'One', 'Two', 'Three'});
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'Four', 'Five', 'Six'});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' });
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'Four', 'Five', 'Six' });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1057,14 +1033,14 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Six');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenReturnWithMultiValues()
 	{
 		// Given
 		// When
 		MY_MOCKS.startStubbing();
 		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturn('Two');
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'One', 'Two', 'Three'});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1076,7 +1052,7 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Three');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenReturnMultiWithSingleException()
 	{
 		// Given
@@ -1084,7 +1060,7 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'One', 'Two', 'Three'});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' });
 		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrow(first);
 		MY_MOCKS.stopStubbing();
 
@@ -1093,7 +1069,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('first.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenReturnMultiWithMultiExceptions()
 	{
 		// Given
@@ -1103,8 +1079,8 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'One', 'Two', 'Three'});
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{first, second, third});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' });
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1116,7 +1092,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('third.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenReturnWithMultiExceptions()
 	{
 		// Given
@@ -1127,7 +1103,7 @@ private class fflib_ApexMocksTest
 		// When
 		MY_MOCKS.startStubbing();
 		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturn('Two');
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{first, second, third});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1139,7 +1115,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('third.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenReturnWithSingleException()
 	{
 		// Given
@@ -1156,7 +1132,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('first.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenThrowWithSingleValue()
 	{
 		// Given
@@ -1173,7 +1149,7 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Two');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenThrowMultiWithSingleValue()
 	{
 		// Given
@@ -1183,7 +1159,7 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{first, second, third});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third });
 		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturn('Two');
 		MY_MOCKS.stopStubbing();
 
@@ -1192,7 +1168,7 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Two');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenThrowMultiWithMultiValue()
 	{
 		// Given
@@ -1202,8 +1178,8 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{first, second, third});
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'Four', 'Five', 'Six'});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third });
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'Four', 'Five', 'Six' });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1215,7 +1191,7 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Six');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenThrowWithMultiValues()
 	{
 		// Given
@@ -1224,7 +1200,7 @@ private class fflib_ApexMocksTest
 		// When
 		MY_MOCKS.startStubbing();
 		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrow(first);
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{'One', 'Two', 'Three'});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturnMulti(new List<String>{ 'One', 'Two', 'Three' });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1236,7 +1212,7 @@ private class fflib_ApexMocksTest
 		assertReturnedValue('Three');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenThrowMultiWithSingleException()
 	{
 		// Given
@@ -1247,7 +1223,7 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{first, second, third});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third });
 		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrow(fourth);
 		MY_MOCKS.stopStubbing();
 
@@ -1256,7 +1232,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('fourth.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenThrowMultiWithMultiExceptions()
 	{
 		// Given
@@ -1270,8 +1246,8 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{first, second, third});
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{fourth, fifth, sixth});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third });
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ fourth, fifth, sixth });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1283,7 +1259,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('sixth.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenThrowWithMultiExceptions()
 	{
 		// Given
@@ -1296,7 +1272,7 @@ private class fflib_ApexMocksTest
 		// When
 		MY_MOCKS.startStubbing();
 		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrow(beforeFirst);
-		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{first, second, third});
+		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenThrowMulti(new List<Exception>{ first, second, third });
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1308,7 +1284,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('third.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMultipleTimesOverridePreviousThenThrowWithSingleException()
 	{
 		// Given
@@ -1326,7 +1302,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessage('first.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVoidMethodThrowsMultipleExceptions()
 	{
 		// Given
@@ -1338,7 +1314,7 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{first, second, third},  MY_MOCK_LIST)).add('Hello');
+		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{ first, second, third }, MY_MOCK_LIST)).add('Hello');
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1350,7 +1326,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessageOnVoidMethod('third.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatMultipleVoidMethodsThrowsMultipleExceptions()
 	{
 		// Given
@@ -1364,8 +1340,8 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{first2, second2, third2},  MY_MOCK_LIST)).addMore('Hello');
-		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{first, second, third},  MY_MOCK_LIST)).add('Hello');
+		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{ first2, second2, third2 }, MY_MOCK_LIST)).addMore('Hello');
+		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{ first, second, third }, MY_MOCK_LIST)).add('Hello');
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1376,7 +1352,6 @@ private class fflib_ApexMocksTest
 		assertExceptionMessageOnVoidMethod('third.');
 		assertExceptionMessageOnVoidMethod('third.');
 
-
 		assertExceptionMessageOnAddMoreVoidMethod('first2.');
 		assertExceptionMessageOnAddMoreVoidMethod('second2.');
 		assertExceptionMessageOnAddMoreVoidMethod('third2.');
@@ -1385,7 +1360,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessageOnAddMoreVoidMethod('third2.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMutipleTimesVoidMethodThrowsMultipleExceptionsOverride()
 	{
 		// Given
@@ -1401,8 +1376,8 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{first, second, third},  MY_MOCK_LIST)).add('Hello');
-		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{fourth, fifth, sixth},  MY_MOCK_LIST)).add('Hello');
+		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{ first, second, third }, MY_MOCK_LIST)).add('Hello');
+		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{ fourth, fifth, sixth }, MY_MOCK_LIST)).add('Hello');
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1414,7 +1389,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessageOnVoidMethod('sixth.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStubbingMutipleTimesVoidMethodThrowsMultipleExceptionsOverrideWithSingleException()
 	{
 		// Given
@@ -1430,8 +1405,8 @@ private class fflib_ApexMocksTest
 
 		// When
 		MY_MOCKS.startStubbing();
-		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{first, second, third},  MY_MOCK_LIST)).add('Hello');
-		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(fourth,  MY_MOCK_LIST)).add('Hello');
+		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(new List<Exception>{ first, second, third }, MY_MOCK_LIST)).add('Hello');
+		((fflib_MyList.IList) MY_MOCKS.doThrowWhen(fourth, MY_MOCK_LIST)).add('Hello');
 		MY_MOCKS.stopStubbing();
 
 		// Then
@@ -1439,7 +1414,7 @@ private class fflib_ApexMocksTest
 		assertExceptionMessageOnVoidMethod('fourth.');
 	}
 
-	@isTest
+	@IsTest
 	static void thatExceptionIsthrownWhenStubbingIsNotDone()
 	{
 		MY_MOCKS.startStubbing();
@@ -1452,15 +1427,13 @@ private class fflib_ApexMocksTest
 
 			System.Assert.fail('an exception was expected');
 		}
-		catch(fflib_ApexMocks.ApexMocksException myex)
+		catch (fflib_ApexMocks.ApexMocksException myex)
 		{
-			System.Assert.areEqual(
-				'The stubbing is not correct, no return values have been set.',
-				myex.getMessage(), 'the message reported by the exception is not correct');
+			System.Assert.areEqual('The stubbing is not correct, no return values have been set.', myex.getMessage(), 'the message reported by the exception is not correct');
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatExceptionIsthrownWhenReturnMultiPassEmptyList()
 	{
 		try
@@ -1470,15 +1443,13 @@ private class fflib_ApexMocksTest
 			MY_MOCKS.stopStubbing();
 			System.Assert.fail('an exception was expected');
 		}
-		catch(fflib_ApexMocks.ApexMocksException myex)
+		catch (fflib_ApexMocks.ApexMocksException myex)
 		{
-			System.Assert.areEqual(
-				'The stubbing is not correct, no return values have been set.',
-				myex.getMessage(), 'the message reported by the exception is not correct');
+			System.Assert.areEqual('The stubbing is not correct, no return values have been set.', myex.getMessage(), 'the message reported by the exception is not correct');
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatExceptionIsthrownWhenReturnMultiPassNullList()
 	{
 		try
@@ -1488,15 +1459,13 @@ private class fflib_ApexMocksTest
 			MY_MOCKS.stopStubbing();
 			System.Assert.fail('an exception was expected');
 		}
-		catch(fflib_ApexMocks.ApexMocksException myex)
+		catch (fflib_ApexMocks.ApexMocksException myex)
 		{
-			System.Assert.areEqual(
-				'The stubbing is not correct, no return values have been set.',
-				myex.getMessage(), 'the message reported by the exception is not correct');
+			System.Assert.areEqual('The stubbing is not correct, no return values have been set.', myex.getMessage(), 'the message reported by the exception is not correct');
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatExceptionIsthrownWhenThrowMultiPassEmptyList()
 	{
 		try
@@ -1506,15 +1475,13 @@ private class fflib_ApexMocksTest
 			MY_MOCKS.stopStubbing();
 			System.Assert.fail('an exception was expected');
 		}
-		catch(fflib_ApexMocks.ApexMocksException myex)
+		catch (fflib_ApexMocks.ApexMocksException myex)
 		{
-			System.Assert.areEqual(
-				'The stubbing is not correct, no return values have been set.',
-				myex.getMessage(), 'the message reported by the exception is not correct');
+			System.Assert.areEqual('The stubbing is not correct, no return values have been set.', myex.getMessage(), 'the message reported by the exception is not correct');
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatExceptionIsthrownWhenThrowMultiPassNullList()
 	{
 		try
@@ -1525,26 +1492,23 @@ private class fflib_ApexMocksTest
 
 			System.Assert.fail('an exception was expected');
 		}
-		catch(fflib_ApexMocks.ApexMocksException myex)
+		catch (fflib_ApexMocks.ApexMocksException myex)
 		{
-			System.Assert.areEqual(
-				'The stubbing is not correct, no return values have been set.',
-				myex.getMessage(), 'the message reported by the exception is not correct');
+			System.Assert.areEqual('The stubbing is not correct, no return values have been set.', myex.getMessage(), 'the message reported by the exception is not correct');
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatNullCanBeUsedAsReturnValue()
 	{
 		MY_MOCKS.startStubbing();
 		MY_MOCKS.when(MY_MOCK_LIST.get(1)).thenReturn(null);
 		MY_MOCKS.stopStubbing();
 
-
 		System.Assert.areEqual(null, MY_MOCK_LIST.get(1), 'it should be possible stub using the null value');
 	}
 
-	@isTest
+	@IsTest
 	static void thatNullCanBeUsedAsExceptionvalue()
 	{
 		MY_MOCKS.startStubbing();
@@ -1554,8 +1518,6 @@ private class fflib_ApexMocksTest
 		System.Assert.areEqual(null, MY_MOCK_LIST.get(1), 'it should be possible stub using the null value');
 	}
 
-
-
 	private static void assertExceptionMessage(String expectedMessage)
 	{
 		try
@@ -1563,7 +1525,7 @@ private class fflib_ApexMocksTest
 			MY_MOCK_LIST.get(1);
 			System.Assert.fail('an exception was expected');
 		}
-		catch(MyException myex)
+		catch (MyException myex)
 		{
 			System.Assert.areEqual(expectedMessage, myex.getMessage(), 'the message reported by the exception is not correct');
 		}
@@ -1576,7 +1538,7 @@ private class fflib_ApexMocksTest
 			MY_MOCK_LIST.get2(2, 'Hello.');
 			System.Assert.fail('an exception was expected');
 		}
-		catch(MyException myex)
+		catch (MyException myex)
 		{
 			System.Assert.areEqual(expectedMessage, myex.getMessage(), 'the message reported by the exception is not correct');
 		}
@@ -1589,7 +1551,7 @@ private class fflib_ApexMocksTest
 			MY_MOCK_LIST.add('Hello');
 			System.Assert.fail('an exception was expected');
 		}
-		catch(MyException myex)
+		catch (MyException myex)
 		{
 			System.Assert.areEqual(expectedMessage, myex.getMessage(), 'the message reported by the exception is not correct');
 		}
@@ -1602,7 +1564,7 @@ private class fflib_ApexMocksTest
 			MY_MOCK_LIST.addMore('Hello');
 			System.Assert.fail('an exception was expected');
 		}
-		catch(MyException myex)
+		catch (MyException myex)
 		{
 			System.Assert.areEqual(expectedMessage, myex.getMessage(), 'the message reported by the exception is not correct');
 		}
@@ -1617,8 +1579,8 @@ private class fflib_ApexMocksTest
 	{
 		System.Assert.areEqual(expectedValue, MY_MOCK_LIST.get2(2, 'Hello.'), 'the method did not returned the expected value');
 	}
-	
-	@isTest
+
+	@IsTest
 	static void thatToStringReturnsSimpleStringValue()
 	{
 		System.Assert.areEqual('fflib_ApexMocks', '' + new fflib_ApexMocks());
@@ -1632,7 +1594,7 @@ private class fflib_ApexMocksTest
 	{
 		public Boolean matches(Object arg)
 		{
-			return arg instanceof Integer ? Math.mod((Integer)arg, 2) == 1: false;
+			return arg instanceof Integer ? Math.mod((Integer) arg, 2) == 1 : false;
 		}
 	}
 
@@ -1640,7 +1602,7 @@ private class fflib_ApexMocksTest
 	{
 		public Boolean matches(Object arg)
 		{
-			return arg instanceof Integer ? Math.mod((Integer)arg, 2) == 0: false;
+			return arg instanceof Integer ? Math.mod((Integer) arg, 2) == 0 : false;
 		}
 	}
 }

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
@@ -1,29 +1,29 @@
 /**
- * Copyright (c) 2014-2016, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-@isTest
+* Copyright (c) 2014-2016, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+@IsTest
 public class fflib_ApexMocksUtilsTest
 {
 	public static Schema.FieldSet findAnyFieldSet()
@@ -39,39 +39,24 @@ public class fflib_ApexMocksUtilsTest
 		return null;
 	}
 
-	@isTest
+	@IsTest
 	private static void makeRelationship_returnsObjectsWithRelationFieldSet()
 	{
 		//Given
-		Account acc = new Account(
-			Id = fflib_IDGenerator.generate(Account.SObjectType),
-			Name = 'AccName',
-			NumberOfEmployees = 7
-		);
+		Account acc = new Account(Id = fflib_IDGenerator.generate(Account.SObjectType), Name = 'AccName', NumberOfEmployees = 7);
 
-		Contact contact1 = new Contact(
-			Id = fflib_IDGenerator.generate(Contact.SObjectType),
-			DoNotCall = true
-		);
+		Contact contact1 = new Contact(Id = fflib_IDGenerator.generate(Contact.SObjectType), DoNotCall = true);
 
-		Contact contact2 = new Contact(
-			Id = fflib_IDGenerator.generate(Contact.SObjectType),
-			DoNotCall = false
-		);
+		Contact contact2 = new Contact(Id = fflib_IDGenerator.generate(Contact.SObjectType), DoNotCall = false);
 
 		//When
-		Account accWithRelationships = ((List<Account>)fflib_ApexMocksUtils.makeRelationship(
-			List<Account>.class,
-			new List<Account> { acc },
-			Contact.AccountId,
-			new List<List<Contact>> { new List<Contact> { contact1, contact2 }}
-		))[0];
+		Account accWithRelationships = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(List<Account>.class, new List<Account>{ acc }, Contact.AccountId, new List<List<Contact>>{ new List<Contact>{ contact1, contact2 } }))[0];
 
 		//Then
 		System.Assert.areEqual(acc.Id, accWithRelationships.Id);
 		System.Assert.areEqual(acc.Name, accWithRelationships.Name);
 		System.Assert.areEqual(acc.NumberOfEmployees, accWithRelationships.NumberOfEmployees);
-		
+
 		//Assert relationship fields
 		List<Contact> contacts = accWithRelationships.Contacts;
 		System.Assert.areNotEqual(null, contacts);
@@ -84,8 +69,8 @@ public class fflib_ApexMocksUtilsTest
 		System.Assert.areEqual(contact2.DoNotCall, contacts[1].DoNotCall);
 	}
 
-	@isTest
-	private static void makeRelationship_GenericOverload_ReturnsObjectsWithRelationFieldSet() 
+	@IsTest
+	private static void makeRelationship_GenericOverload_ReturnsObjectsWithRelationFieldSet()
 	{
 		//Given
 		SObject acc = Schema.getGlobalDescribe().get('Account').newSObject();
@@ -102,14 +87,7 @@ public class fflib_ApexMocksUtilsTest
 		contact2.put('DoNotCall', false);
 
 		//When
-		SObject accWithRelationships = ((List<SObject>)fflib_ApexMocksUtils.makeRelationship(
-				'Account',
-				'Contact',
-				new List<SObject> { acc },
-				'AccountId',
-				new List<List<SObject>> { new List<SObject> { contact1, contact2 }}
-
-		))[0];
+		SObject accWithRelationships = ((List<SObject>) fflib_ApexMocksUtils.makeRelationship('Account', 'Contact', new List<SObject>{ acc }, 'AccountId', new List<List<SObject>>{ new List<SObject>{ contact1, contact2 } }))[0];
 
 		//Then
 		System.Assert.areEqual(acc.Id, accWithRelationships.Id);
@@ -122,14 +100,14 @@ public class fflib_ApexMocksUtilsTest
 		System.Assert.areEqual(2, contacts.size());
 
 		System.Assert.areEqual(contact1.Id, contacts[0].Id);
-		System.Assert.areEqual((Boolean)contact1.get('DoNotCall'), (Boolean)contacts[0].get('DoNotCall'));
+		System.Assert.areEqual((Boolean) contact1.get('DoNotCall'), (Boolean) contacts[0].get('DoNotCall'));
 
 		System.Assert.areEqual(contact2.Id, contacts[1].Id);
-		System.Assert.areEqual((Boolean)contact2.get('DoNotCall'), (Boolean)contacts[1].get('DoNotCall'));
+		System.Assert.areEqual((Boolean) contact2.get('DoNotCall'), (Boolean) contacts[1].get('DoNotCall'));
 	}
 
-	@isTest
-	private static void makeRelationship_GenericOverload_ThrowsErrorOnInvalidParentType() 
+	@IsTest
+	private static void makeRelationship_GenericOverload_ThrowsErrorOnInvalidParentType()
 	{
 		// Setup parent object
 		SObject acc = Schema.getGlobalDescribe().get('Account').newSObject();
@@ -140,23 +118,20 @@ public class fflib_ApexMocksUtilsTest
 		cont.put('Id', fflib_IDGenerator.generate(cont.getSObjectType()));
 
 		String errorMessage = '';
-		try {
+		try
+		{
 			// Call method under test
-			SObject accWithRelationships = ((List<SObject>)fflib_ApexMocksUtils.makeRelationship(
-					'MyInvalidParentType',
-					'Contact',
-					new List<SObject> { acc },
-					'AccountId',
-					new List<List<SObject>> { new List<SObject> { cont }}
-			))[0];
-		} catch (Exception exc) {
+			SObject accWithRelationships = ((List<SObject>) fflib_ApexMocksUtils.makeRelationship('MyInvalidParentType', 'Contact', new List<SObject>{ acc }, 'AccountId', new List<List<SObject>>{ new List<SObject>{ cont } }))[0];
+		}
+		catch (Exception exc)
+		{
 			errorMessage = exc.getMessage();
 		}
 		System.Assert.areEqual('SObject type not found: MyInvalidParentType', errorMessage);
 	}
 
-	@isTest
-	private static void makeRelationship_GenericOverload_ThrowsErrorOnInvalidChildType() 
+	@IsTest
+	private static void makeRelationship_GenericOverload_ThrowsErrorOnInvalidChildType()
 	{
 		// Setup parent object
 		SObject acc = Schema.getGlobalDescribe().get('Account').newSObject();
@@ -167,23 +142,20 @@ public class fflib_ApexMocksUtilsTest
 		cont.put('Id', fflib_IDGenerator.generate(cont.getSObjectType()));
 
 		String errorMessage = '';
-		try {
+		try
+		{
 			// Call method under test
-			SObject accWithRelationships = ((List<SObject>)fflib_ApexMocksUtils.makeRelationship(
-					'Account',
-					'MyInvalidChildType',
-					new List<SObject> { acc },
-					'AccountId',
-					new List<List<SObject>> { new List<SObject> { cont }}
-			))[0];
-		} catch (Exception exc) {
+			SObject accWithRelationships = ((List<SObject>) fflib_ApexMocksUtils.makeRelationship('Account', 'MyInvalidChildType', new List<SObject>{ acc }, 'AccountId', new List<List<SObject>>{ new List<SObject>{ cont } }))[0];
+		}
+		catch (Exception exc)
+		{
 			errorMessage = exc.getMessage();
 		}
 		System.Assert.areEqual('SObject type not found: MyInvalidChildType', errorMessage);
 	}
 
-	@isTest
-	private static void makeRelationship_GenericOverload_ThrowsErrorOnInvalidFieldName() 
+	@IsTest
+	private static void makeRelationship_GenericOverload_ThrowsErrorOnInvalidFieldName()
 	{
 		// Setup parent object
 		SObject acc = Schema.getGlobalDescribe().get('Account').newSObject();
@@ -194,56 +166,29 @@ public class fflib_ApexMocksUtilsTest
 		cont.put('Id', fflib_IDGenerator.generate(cont.getSObjectType()));
 
 		String errorMessage = '';
-		try {
+		try
+		{
 			// Call method under test
-			SObject accWithRelationships = ((List<SObject>)fflib_ApexMocksUtils.makeRelationship(
-					'Account',
-					'Contact',
-					new List<SObject> { acc },
-					'MyInvalidField',
-					new List<List<SObject>> { new List<SObject> { cont }}
-			))[0];
-		} catch (Exception exc) {
+			SObject accWithRelationships = ((List<SObject>) fflib_ApexMocksUtils.makeRelationship('Account', 'Contact', new List<SObject>{ acc }, 'MyInvalidField', new List<List<SObject>>{ new List<SObject>{ cont } }))[0];
+		}
+		catch (Exception exc)
+		{
 			errorMessage = exc.getMessage();
 		}
 		System.Assert.areEqual('SObject field not found: MyInvalidField', errorMessage);
 	}
 
-	@IsTest 
-	private static void makeRelationship_ObjectWithNull_DoesNotThrowErrorOnJSONExceptionCanNotWriteAFieldNameExpectingAValue() 
-	{	
+	@IsTest
+	private static void makeRelationship_ObjectWithNull_DoesNotThrowErrorOnJSONExceptionCanNotWriteAFieldNameExpectingAValue()
+	{
 		// Given
-		Product2 prod1 = new Product2(
-			Id = fflib_IDGenerator.generate(Product2.SObjectType),
-			Name = 'Product1',
-			ProductCode = 'P1',
-			Description = null,
-			StockKeepingUnit = 'P1'
-		);
+		Product2 prod1 = new Product2(Id = fflib_IDGenerator.generate(Product2.SObjectType), Name = 'Product1', ProductCode = 'P1', Description = null, StockKeepingUnit = 'P1');
 
-		Product2 prod2 = new Product2(
-			Id = fflib_IDGenerator.generate(Product2.SObjectType),
-			Name = 'Product2',
-			ProductCode = 'P2',
-			Description = 'this is another product',
-			StockKeepingUnit = 'P2'
-		);
+		Product2 prod2 = new Product2(Id = fflib_IDGenerator.generate(Product2.SObjectType), Name = 'Product2', ProductCode = 'P2', Description = 'this is another product', StockKeepingUnit = 'P2');
 
-		OpportunityLineItem oli1 = new OpportunityLineItem(
-			Id = fflib_IDGenerator.generate(OpportunityLineItem.SObjectType),
-			Product2Id = prod1.Id,
-			Product2 = prod1,
-			UnitPrice = 10,
-			Quantity = 1
-		);
+		OpportunityLineItem oli1 = new OpportunityLineItem(Id = fflib_IDGenerator.generate(OpportunityLineItem.SObjectType), Product2Id = prod1.Id, Product2 = prod1, UnitPrice = 10, Quantity = 1);
 
-		OpportunityLineItem oli2 = new OpportunityLineItem(
-			Id = fflib_IDGenerator.generate(OpportunityLineItem.SObjectType),
-			Product2Id = prod2.Id,
-			Product2 = prod2,
-			UnitPrice = 10,
-			Quantity = 1
-		);
+		OpportunityLineItem oli2 = new OpportunityLineItem(Id = fflib_IDGenerator.generate(OpportunityLineItem.SObjectType), Product2Id = prod2.Id, Product2 = prod2, UnitPrice = 10, Quantity = 1);
 
 		Opportunity opportunity = new Opportunity();
 
@@ -251,15 +196,13 @@ public class fflib_ApexMocksUtilsTest
 
 		// When
 		Test.startTest();
-		
-		try {
-			fflib_ApexMocksUtils.makeRelationship(
-				List<Opportunity>.class,
-				new List<Opportunity>{ opportunity },
-				OpportunityLineItem.OpportunityId,
-				new List<List<OpportunityLineItem>>{ new List<OpportunityLineItem>{oli1, oli2} }
-			);
-		} catch (JSONException e) {
+
+		try
+		{
+			fflib_ApexMocksUtils.makeRelationship(List<Opportunity>.class, new List<Opportunity>{ opportunity }, OpportunityLineItem.OpportunityId, new List<List<OpportunityLineItem>>{ new List<OpportunityLineItem>{ oli1, oli2 } });
+		}
+		catch (JSONException e)
+		{
 			exceptionThatWasCalled = e;
 		}
 
@@ -270,156 +213,101 @@ public class fflib_ApexMocksUtilsTest
 		Assert.isNull(exceptionThatWasCalled, 'Exception should not have been called');
 	}
 
-	@isTest
-	static void setReadOnlyFields_CreatedByIdSetToCurrentUserId_IdFieldSetSuccessfully() {
-		
+	@IsTest
+	static void setReadOnlyFields_CreatedByIdSetToCurrentUserId_IdFieldSetSuccessfully()
+	{
 		Account acc = new Account();
 		Id userId = fflib_IDGenerator.generate((new User()).getSObjectType());
 
 		Test.startTest();
-		acc = (Account)fflib_ApexMocksUtils.setReadOnlyFields(
-				acc,
-				Account.class,
-				new Map<SObjectField, Object>{Account.CreatedById => userId}
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.CreatedById => userId });
 		Test.stopTest();
 
 		System.Assert.areEqual(userId, acc.CreatedById);
 	}
 
-	@isTest
-	static void setReadOnlyFields_LastReferencedDateSetOnAccount_DateTimeFieldSetSuccessfully() {
-		
+	@IsTest
+	static void setReadOnlyFields_LastReferencedDateSetOnAccount_DateTimeFieldSetSuccessfully()
+	{
 		Account acc = new Account();
 		DateTime lastRefDate = DateTime.newInstanceGmt(2020, 1, 7, 23, 30, 0);
 
 		Test.startTest();
-		acc = (Account)fflib_ApexMocksUtils.setReadOnlyFields(
-				acc,
-				Account.class,
-				new Map<SObjectField, Object> {Account.LastReferencedDate => lastRefDate}
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.LastReferencedDate => lastRefDate });
 		Test.stopTest();
 
 		System.Assert.areEqual(lastRefDate, acc.LastReferencedDate);
 	}
 
-	@isTest
-	static void setReadOnlyFields_IsDeletedSetOnAccount_BooleanFieldSetSuccessfully() {
-
+	@IsTest
+	static void setReadOnlyFields_IsDeletedSetOnAccount_BooleanFieldSetSuccessfully()
+	{
 		Account acc = new Account();
 		Boolean isDeleted = true;
 
 		Test.startTest();
-		acc = (Account)fflib_ApexMocksUtils.setReadOnlyFields(
-				acc,
-				Account.class,
-				new Map<SObjectField, Object> {Account.IsDeleted => isDeleted}
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.IsDeleted => isDeleted });
 		Test.stopTest();
 
 		System.Assert.areEqual(isDeleted, acc.IsDeleted);
 	}
 
-	@isTest
-	static void setReadOnlyFields_PolymorphicRelationJoin_FieldSetSuccessfully() {
-
-		Account acc = new Account(Name='TestAccount');
+	@IsTest
+	static void setReadOnlyFields_PolymorphicRelationJoin_FieldSetSuccessfully()
+	{
+		Account acc = new Account(Name = 'TestAccount');
 		Task t = new Task();
 
 		Test.startTest();
-		t = (Task)fflib_ApexMocksUtils.setReadOnlyFields(
-			t,
-			Task.class,
-			new Map<String, Object> {'What' => acc}
-		);
+		t = (Task) fflib_ApexMocksUtils.setReadOnlyFields(t, Task.class, new Map<String, Object>{ 'What' => acc });
 		Test.stopTest();
 
 		System.Assert.areEqual(acc.Name, t.What.Name);
 	}
 
-	@isTest
-	static void setReadOnlyFields_WithChildren_FieldSetSuccessfully() {
+	@IsTest
+	static void setReadOnlyFields_WithChildren_FieldSetSuccessfully()
+	{
 		// Given
-		Contact cont = new Contact(
-			Id = fflib_IDGenerator.generate(Contact.SObjectType),
-			LastName = 'ContactName'
-		);
+		Contact cont = new Contact(Id = fflib_IDGenerator.generate(Contact.SObjectType), LastName = 'ContactName');
 
-		Opportunity opp = new Opportunity(
-			Id = fflib_IDGenerator.generate(Opportunity.SObjectType),
-			Name = 'OpportunityName'
-		);
+		Opportunity opp = new Opportunity(Id = fflib_IDGenerator.generate(Opportunity.SObjectType), Name = 'OpportunityName');
 
 		Account acc = new Account();
 
 		Id userId = fflib_IDGenerator.generate((new User()).getSObjectType());
 
-		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
-			List<Account>.class,
-			new List<Account>{ acc },
-			Contact.AccountId,
-			new List<List<Contact>>{ new List<Contact>{cont} }
-		))[0];
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(List<Account>.class, new List<Account>{ acc }, Contact.AccountId, new List<List<Contact>>{ new List<Contact>{ cont } }))[0];
 
-		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
-			List<Account>.class,
-			new List<Account>{ acc },
-			Opportunity.AccountId,
-			new List<List<Opportunity>>{ new List<Opportunity>{opp} }
-		))[0];
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(List<Account>.class, new List<Account>{ acc }, Opportunity.AccountId, new List<List<Opportunity>>{ new List<Opportunity>{ opp } }))[0];
 
 		// When
 		Test.startTest();
-		acc = (Account)fflib_ApexMocksUtils.setReadOnlyFields(
-				acc,
-				Account.class,
-				new Map<SObjectField, Object>{Account.CreatedById => userId}
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.CreatedById => userId });
 		Test.stopTest();
 
 		Assert.areEqual(userId, acc.CreatedById);
 	}
 
-	@isTest
+	@IsTest
 	static void setReadOnlyFields_WithChildren_PreservesChildRelationships()
 	{
 		// Given
-		Contact cont = new Contact(
-			Id = fflib_IDGenerator.generate(Contact.SObjectType),
-			LastName = 'ContactName'
-		);
+		Contact cont = new Contact(Id = fflib_IDGenerator.generate(Contact.SObjectType), LastName = 'ContactName');
 
-		Opportunity opp = new Opportunity(
-			Id = fflib_IDGenerator.generate(Opportunity.SObjectType),
-			Name = 'OpportunityName'
-		);
+		Opportunity opp = new Opportunity(Id = fflib_IDGenerator.generate(Opportunity.SObjectType), Name = 'OpportunityName');
 
 		Account acc = new Account();
 
 		Id userId = fflib_IDGenerator.generate((new User()).getSObjectType());
 
-		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
-			List<Account>.class,
-			new List<Account>{ acc },
-			Contact.AccountId,
-			new List<List<Contact>>{ new List<Contact>{ cont } }
-		))[0];
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(List<Account>.class, new List<Account>{ acc }, Contact.AccountId, new List<List<Contact>>{ new List<Contact>{ cont } }))[0];
 
-		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
-			List<Account>.class,
-			new List<Account>{ acc },
-			Opportunity.AccountId,
-			new List<List<Opportunity>>{ new List<Opportunity>{ opp } }
-		))[0];
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(List<Account>.class, new List<Account>{ acc }, Opportunity.AccountId, new List<List<Opportunity>>{ new List<Opportunity>{ opp } }))[0];
 
 		// When
 		Test.startTest();
-		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
-			acc,
-			Account.class,
-			new Map<SObjectField, Object>{ Account.CreatedById => userId }
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.CreatedById => userId });
 		Test.stopTest();
 
 		// Then
@@ -434,37 +322,21 @@ public class fflib_ApexMocksUtilsTest
 		System.Assert.areEqual(opp.Name, acc.Opportunities[0].Name);
 	}
 
-	@isTest
+	@IsTest
 	static void setReadOnlyFields_WithChildren_PreservesWritableFields()
 	{
 		// Given - Name and NumberOfEmployees are updateable=true; CreatedById is updateable=false (the injected field)
-		Contact cont = new Contact(
-			Id = fflib_IDGenerator.generate(Contact.SObjectType),
-			LastName = 'ContactName'
-		);
+		Contact cont = new Contact(Id = fflib_IDGenerator.generate(Contact.SObjectType), LastName = 'ContactName');
 
-		Account acc = new Account(
-			Id = fflib_IDGenerator.generate(Account.SObjectType),
-			Name = 'AccName',
-			NumberOfEmployees = 7
-		);
+		Account acc = new Account(Id = fflib_IDGenerator.generate(Account.SObjectType), Name = 'AccName', NumberOfEmployees = 7);
 
 		Id userId = fflib_IDGenerator.generate((new User()).getSObjectType());
 
-		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
-			List<Account>.class,
-			new List<Account>{ acc },
-			Contact.AccountId,
-			new List<List<Contact>>{ new List<Contact>{ cont } }
-		))[0];
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(List<Account>.class, new List<Account>{ acc }, Contact.AccountId, new List<List<Contact>>{ new List<Contact>{ cont } }))[0];
 
 		// When
 		Test.startTest();
-		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
-			acc,
-			Account.class,
-			new Map<SObjectField, Object>{ Account.CreatedById => userId }
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.CreatedById => userId });
 		Test.stopTest();
 
 		// Then - writable fields (updateable=true) must survive the round-trip
@@ -475,7 +347,7 @@ public class fflib_ApexMocksUtilsTest
 		System.Assert.areEqual(cont.LastName, acc.Contacts[0].LastName);
 	}
 
-	@isTest
+	@IsTest
 	static void setReadOnlyFields_OverwritesExistingNonUpdateableField()
 	{
 		// Given - CreatedById is updateable=false; second call should replace the injected value
@@ -483,54 +355,30 @@ public class fflib_ApexMocksUtilsTest
 		Id firstUserId = fflib_IDGenerator.generate((new User()).getSObjectType());
 		Id secondUserId = fflib_IDGenerator.generate((new User()).getSObjectType());
 
-		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
-			acc,
-			Account.class,
-			new Map<SObjectField, Object>{ Account.CreatedById => firstUserId }
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.CreatedById => firstUserId });
 
 		// When - field already present in serialized JSON; properties map should overwrite it
 		Test.startTest();
-		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
-			acc,
-			Account.class,
-			new Map<SObjectField, Object>{ Account.CreatedById => secondUserId }
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.CreatedById => secondUserId });
 		Test.stopTest();
 
 		// Then
 		System.Assert.areEqual(secondUserId, acc.CreatedById);
 	}
 
-	@isTest
+	@IsTest
 	static void setReadOnlyFields_EmptyProperties_PreservesRecord()
 	{
 		// Given
-		Contact cont = new Contact(
-			Id = fflib_IDGenerator.generate(Contact.SObjectType),
-			LastName = 'ContactName'
-		);
+		Contact cont = new Contact(Id = fflib_IDGenerator.generate(Contact.SObjectType), LastName = 'ContactName');
 
-		Account acc = new Account(
-			Id = fflib_IDGenerator.generate(Account.SObjectType),
-			Name = 'AccName',
-			NumberOfEmployees = 7
-		);
+		Account acc = new Account(Id = fflib_IDGenerator.generate(Account.SObjectType), Name = 'AccName', NumberOfEmployees = 7);
 
-		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(
-			List<Account>.class,
-			new List<Account>{ acc },
-			Contact.AccountId,
-			new List<List<Contact>>{ new List<Contact>{ cont } }
-		))[0];
+		acc = ((List<Account>) fflib_ApexMocksUtils.makeRelationship(List<Account>.class, new List<Account>{ acc }, Contact.AccountId, new List<List<Contact>>{ new List<Contact>{ cont } }))[0];
 
 		// When
 		Test.startTest();
-		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
-			acc,
-			Account.class,
-			new Map<String, Object>()
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<String, Object>());
 		Test.stopTest();
 
 		// Then
@@ -540,38 +388,22 @@ public class fflib_ApexMocksUtilsTest
 		System.Assert.areEqual(cont.LastName, acc.Contacts[0].LastName);
 	}
 
-	@isTest
+	@IsTest
 	static void setReadOnlyFields_WithChildren_NonUpdateableNumericFieldSetSuccessfully()
 	{
 		// Given - mirrors issue #163: inject a non-updateable numeric field (ExpectedRevenue: updateable=false, type=currency)
 		// on a parent that already has children via makeRelationship
-		OpportunityLineItem oli = new OpportunityLineItem(
-			Id = fflib_IDGenerator.generate(OpportunityLineItem.SObjectType),
-			UnitPrice = 10,
-			Quantity = 1
-		);
+		OpportunityLineItem oli = new OpportunityLineItem(Id = fflib_IDGenerator.generate(OpportunityLineItem.SObjectType), UnitPrice = 10, Quantity = 1);
 
-		Opportunity opp = new Opportunity(
-			Id = fflib_IDGenerator.generate(Opportunity.SObjectType),
-			Name = 'OpportunityName'
-		);
+		Opportunity opp = new Opportunity(Id = fflib_IDGenerator.generate(Opportunity.SObjectType), Name = 'OpportunityName');
 
 		Decimal expectedRevenue = 4200;
 
-		opp = ((List<Opportunity>) fflib_ApexMocksUtils.makeRelationship(
-			List<Opportunity>.class,
-			new List<Opportunity>{ opp },
-			OpportunityLineItem.OpportunityId,
-			new List<List<OpportunityLineItem>>{ new List<OpportunityLineItem>{ oli } }
-		))[0];
+		opp = ((List<Opportunity>) fflib_ApexMocksUtils.makeRelationship(List<Opportunity>.class, new List<Opportunity>{ opp }, OpportunityLineItem.OpportunityId, new List<List<OpportunityLineItem>>{ new List<OpportunityLineItem>{ oli } }))[0];
 
 		// When
 		Test.startTest();
-		opp = (Opportunity) fflib_ApexMocksUtils.setReadOnlyFields(
-			opp,
-			Opportunity.class,
-			new Map<SObjectField, Object>{ Opportunity.ExpectedRevenue => expectedRevenue }
-		);
+		opp = (Opportunity) fflib_ApexMocksUtils.setReadOnlyFields(opp, Opportunity.class, new Map<SObjectField, Object>{ Opportunity.ExpectedRevenue => expectedRevenue });
 		Test.stopTest();
 
 		// Then
@@ -581,7 +413,7 @@ public class fflib_ApexMocksUtilsTest
 		System.Assert.areEqual(oli.Id, opp.OpportunityLineItems[0].Id);
 	}
 
-	@isTest
+	@IsTest
 	static void setReadOnlyFields_MultipleProperties_AllFieldsSet()
 	{
 		// Given
@@ -591,15 +423,7 @@ public class fflib_ApexMocksUtilsTest
 
 		// When
 		Test.startTest();
-		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
-			acc,
-			Account.class,
-			new Map<SObjectField, Object>{
-				Account.CreatedById => userId,
-				Account.LastReferencedDate => lastRefDate,
-				Account.IsDeleted => true
-			}
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.CreatedById => userId, Account.LastReferencedDate => lastRefDate, Account.IsDeleted => true });
 		Test.stopTest();
 
 		// Then
@@ -608,7 +432,7 @@ public class fflib_ApexMocksUtilsTest
 		System.Assert.areEqual(true, acc.IsDeleted);
 	}
 
-	@isTest
+	@IsTest
 	static void setReadOnlyFields_NullPropertyValue_FieldSetToNull()
 	{
 		// Given - LastReferencedDate is updateable=false; null must round-trip via writeNullField
@@ -616,11 +440,7 @@ public class fflib_ApexMocksUtilsTest
 
 		// When
 		Test.startTest();
-		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(
-			acc,
-			Account.class,
-			new Map<SObjectField, Object>{ Account.LastReferencedDate => null }
-		);
+		acc = (Account) fflib_ApexMocksUtils.setReadOnlyFields(acc, Account.class, new Map<SObjectField, Object>{ Account.LastReferencedDate => null });
 		Test.stopTest();
 
 		// Then

--- a/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ApexMocksUtilsTest.cls
@@ -1,28 +1,28 @@
 /**
-* Copyright (c) 2014-2016, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014-2016, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @IsTest
 public class fflib_ApexMocksUtilsTest
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_ArgumentCaptorTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ArgumentCaptorTest.cls
@@ -2,8 +2,8 @@
 * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
 */
 /**
-* @nodoc
-*/
+ * @nodoc
+ */
 @IsTest
 private class fflib_ArgumentCaptorTest
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_ArgumentCaptorTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_ArgumentCaptorTest.cls
@@ -1,18 +1,18 @@
 /*
- * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
- */
+* Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
+*/
 /**
- * @nodoc
- */
-@isTest
+* @nodoc
+*/
+@IsTest
 private class fflib_ArgumentCaptorTest
 {
-	@isTest
+	@IsTest
 	static void thatArgumentValueIsCaptured()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Fred');
@@ -21,15 +21,15 @@ private class fflib_ArgumentCaptorTest
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 		((fflib_MyList.IList) mocks.verify(mockList)).add((String) argument.capture());
 
-		System.Assert.areEqual('Fred', (String)argument.getValue(), 'the argument captured is not as expected');
+		System.Assert.areEqual('Fred', (String) argument.getValue(), 'the argument captured is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCanPerformFurtherAssertionsOnCapturedArgumentValue()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		//When
 		TestInnerClass testValue = new TestInnerClass();
@@ -41,25 +41,25 @@ private class fflib_ArgumentCaptorTest
 		//Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(TestInnerClass.class);
 
-		((fflib_MyList.IList) mocks.verify(mockList)).set(fflib_Match.anyInteger(),  argument.capture());
+		((fflib_MyList.IList) mocks.verify(mockList)).set(fflib_Match.anyInteger(), argument.capture());
 
 		Object capturedArg = argument.getValue();
 		System.Assert.areNotEqual(null, capturedArg, 'CapturedArg should not be null');
 
 		System.Assert.isInstanceOfType(capturedArg, TestInnerClass.class, 'CapturedArg should be SObject, instead was ' + capturedArg);
 
-		TestInnerClass testValueCaptured = (TestInnerClass)capturedArg;
+		TestInnerClass testValueCaptured = (TestInnerClass) capturedArg;
 
 		System.Assert.areEqual(4, testValueCaptured.i, 'the values inside the argument captured should be the same of the original one');
 		System.Assert.areEqual('5', testValueCaptured.s, 'the values inside the argument captured should be the same of the original one');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureArgumentOnlyFromVerifiedMethod()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Fred');
@@ -72,18 +72,18 @@ private class fflib_ArgumentCaptorTest
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 		((fflib_MyList.IList) mocks.verify(mockList)).add((String) argument.capture());
 
-		System.Assert.areEqual('Fred', (String)argument.getValue(), 'the argument captured is not as expected');
+		System.Assert.areEqual('Fred', (String) argument.getValue(), 'the argument captured is not as expected');
 		System.Assert.areEqual(1, argument.getAllValues().size(), 'the argument captured should be only one');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureAllArgumentsForTheVerifiedMethods()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
-		List<String> stringList = new List<String> {'3'};
+		List<String> stringList = new List<String>{ '3' };
 		// When
 		mockList.add('Fred');
 		mockList.add(stringList);
@@ -96,7 +96,7 @@ private class fflib_ArgumentCaptorTest
 		((fflib_MyList.IList) mocks.verify(mockList)).add((String) argument.capture());
 		((fflib_MyList.IList) mocks.verify(mockList)).add((List<String>) argument.capture());
 
-		System.Assert.areEqual(stringList, (List<String>)argument.getValue(), 'the argument captured is not as expected');
+		System.Assert.areEqual(stringList, (List<String>) argument.getValue(), 'the argument captured is not as expected');
 
 		List<Object> argsCaptured = argument.getAllValues();
 
@@ -105,12 +105,12 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual('Fred', (String) argsCaptured[0], 'the first value is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureArgumentFromRequestedParameter()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Fred', 'Barney', 'Wilma', 'Betty');
@@ -118,23 +118,17 @@ private class fflib_ArgumentCaptorTest
 		// Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList) mocks.verify(mockList))
-			.add(
-				(String) fflib_Match.eq('Fred'),
-				(String) fflib_Match.eq('Barney'),
-				(String)  argument.capture(),
-				(String) fflib_Match.eq('Betty'));
+		((fflib_MyList.IList) mocks.verify(mockList)).add((String) fflib_Match.eq('Fred'), (String) fflib_Match.eq('Barney'), (String) argument.capture(), (String) fflib_Match.eq('Betty'));
 
-		System.Assert.areEqual('Wilma', (String)argument.getValue(),
-			'the argument captured is not as expected, should be Wilma because is the 3rd parameter in the call');
+		System.Assert.areEqual('Wilma', (String) argument.getValue(), 'the argument captured is not as expected, should be Wilma because is the 3rd parameter in the call');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureLastArgument()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Barney');
@@ -145,15 +139,15 @@ private class fflib_ArgumentCaptorTest
 
 		((fflib_MyList.IList) mocks.verify(mockList, 2)).add((String) argument.capture());
 
-		System.Assert.areEqual('Fred', (String)argument.getValue(), 'the argument captured is not as expected');
+		System.Assert.areEqual('Fred', (String) argument.getValue(), 'the argument captured is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureAllArguments()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Fred');
@@ -176,12 +170,12 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual('Betty', (String) argsCaptured[3], 'the forth value is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureAllArgumentsFromMultipleMethods()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Fred');
@@ -193,10 +187,7 @@ private class fflib_ArgumentCaptorTest
 
 		((fflib_MyList.IList) mocks.verify(mockList, 2)).add((String) argument.capture());
 
-		((fflib_MyList.IList) mocks.verify(mockList))
-			.get2(
-				(Integer) fflib_Match.eq(3),
-				(String) argument.capture());
+		((fflib_MyList.IList) mocks.verify(mockList)).get2((Integer) fflib_Match.eq(3), (String) argument.capture());
 
 		List<Object> argsCaptured = argument.getAllValues();
 
@@ -208,12 +199,12 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual('pebble', (String) argsCaptured[2], 'the third value is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCanHandleMultipleCapturesInOneMethodCall()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Fred', 'Barney', 'Wilma', 'Betty');
@@ -221,12 +212,7 @@ private class fflib_ArgumentCaptorTest
 		// Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList) mocks.verify(mockList))
-			.add(
-				(String) fflib_Match.eq('Fred'),
-				(String)  argument.capture(),
-				(String)  argument.capture(),
-				(String) fflib_Match.eq('Betty'));
+		((fflib_MyList.IList) mocks.verify(mockList)).add((String) fflib_Match.eq('Fred'), (String) argument.capture(), (String) argument.capture(), (String) fflib_Match.eq('Betty'));
 
 		List<Object> argsCaptured = argument.getAllValues();
 
@@ -237,12 +223,12 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual('Wilma', (String) argsCaptured[1], 'the second value is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatDoesNotCaptureIfNotVerified()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('3');
@@ -250,8 +236,7 @@ private class fflib_ArgumentCaptorTest
 		// Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(List<String>.class);
 
-		((fflib_MyList.IList) mocks.verify(mockList, fflib_ApexMocks.NEVER))
-			.add((List<String>) argument.capture());
+		((fflib_MyList.IList) mocks.verify(mockList, fflib_ApexMocks.NEVER)).add((List<String>) argument.capture());
 
 		List<Object> argsCaptured = argument.getAllValues();
 
@@ -260,12 +245,12 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual(null, argument.getValue(), 'no value should be captured, so must return null');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureOnlyMethodsThatMatchesWithOtherMatcherAsWell()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Same', 'Same', 'First call', 'First call');
@@ -274,21 +259,17 @@ private class fflib_ArgumentCaptorTest
 		// Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList) mocks.verify(mockList)).add(
-			fflib_Match.eqString('Same'),
-			fflib_Match.eqString('Same'),
-			(String)argument.capture(),
-			fflib_Match.eqString('First call'));
+		((fflib_MyList.IList) mocks.verify(mockList)).add(fflib_Match.eqString('Same'), fflib_Match.eqString('Same'), (String) argument.capture(), fflib_Match.eqString('First call'));
 
-		System.Assert.areEqual('First call', (String)argument.getValue());
+		System.Assert.areEqual('First call', (String) argument.getValue());
 	}
 
-	@isTest
+	@IsTest
 	static void thatDoesNotCaptureAnythingWhenCaptorIsWrappedInAMatcher()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Same', 'Same', 'First call', 'First call');
@@ -298,36 +279,24 @@ private class fflib_ArgumentCaptorTest
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
 		((fflib_MyList.IList) mocks.verify(mockList)).add(
-			(String) fflib_Match.allOf(
-				fflib_Match.eqString('Same'),
-				fflib_Match.eqString('Same'),
-				argument.capture()),
-			(String) fflib_Match.allOf(
-				fflib_Match.eqString('Same'),
-				fflib_Match.eqString('Same'),
-				argument.capture()),
-			(String) fflib_Match.allOf(
-				argument.capture(),
-				fflib_Match.eqString('First call')),
-			(String) fflib_Match.allOf(
-				argument.capture(),
-				fflib_Match.eqString('First call'))
-			);
+			(String) fflib_Match.allOf(fflib_Match.eqString('Same'), fflib_Match.eqString('Same'), argument.capture()),
+			(String) fflib_Match.allOf(fflib_Match.eqString('Same'), fflib_Match.eqString('Same'), argument.capture()),
+			(String) fflib_Match.allOf(argument.capture(), fflib_Match.eqString('First call')),
+			(String) fflib_Match.allOf(argument.capture(), fflib_Match.eqString('First call'))
+		);
 
 		List<Object> capturedValues = argument.getAllValues();
 
-		System.Assert.areEqual(0, capturedValues.size(),
-			'nothing should have been capture because the matcher it not really a capture type, but a allOf()');
-		System.Assert.isNull((String)argument.getValue(),
-			'nothing should have been capture because the matcher it not really a capture type, but a allOf()');
+		System.Assert.areEqual(0, capturedValues.size(), 'nothing should have been capture because the matcher it not really a capture type, but a allOf()');
+		System.Assert.isNull((String) argument.getValue(), 'nothing should have been capture because the matcher it not really a capture type, but a allOf()');
 	}
 
-	@isTest
+	@IsTest
 	static void thatArgumentValueIsCapturedWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
 
 		// When
@@ -336,19 +305,18 @@ private class fflib_ArgumentCaptorTest
 		// Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList)inOrder1.verify(mockList, mocks.calls(1))).add((String) argument.capture());
+		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).add((String) argument.capture());
 
-		System.Assert.areEqual('Fred', (String)argument.getValue(), 'the argument captured is not as expected');
+		System.Assert.areEqual('Fred', (String) argument.getValue(), 'the argument captured is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCanPerformFurtherAssertionsOnCapturedArgumentValueWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		//When
 		TestInnerClass testValue = new TestInnerClass();
@@ -360,27 +328,26 @@ private class fflib_ArgumentCaptorTest
 		//Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(TestInnerClass.class);
 
-		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).set(fflib_Match.anyInteger(),  argument.capture());
+		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).set(fflib_Match.anyInteger(), argument.capture());
 
 		Object capturedArg = argument.getValue();
 		System.Assert.areNotEqual(null, capturedArg, 'CapturedArg should not be null');
 
 		System.Assert.isInstanceOfType(capturedArg, TestInnerClass.class, 'CapturedArg should be SObject, instead was ' + capturedArg);
 
-		TestInnerClass testValueCaptured = (TestInnerClass)capturedArg;
+		TestInnerClass testValueCaptured = (TestInnerClass) capturedArg;
 
 		System.Assert.areEqual(4, testValueCaptured.i, 'the values inside the argument captured should be the same of the original one');
 		System.Assert.areEqual('5', testValueCaptured.s, 'the values inside the argument captured should be the same of the original one');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureArgumentOnlyFromVerifiedMethodWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		// When
 		mockList.add('Fred');
@@ -393,20 +360,19 @@ private class fflib_ArgumentCaptorTest
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).add((String) argument.capture());
 
-		System.Assert.areEqual('Fred', (String)argument.getValue(), 'the argument captured is not as expected');
+		System.Assert.areEqual('Fred', (String) argument.getValue(), 'the argument captured is not as expected');
 		System.Assert.areEqual(1, argument.getAllValues().size(), 'the argument captured should be only one');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureAllArgumentsForTheVerifiedMethodsWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
 
-
-		List<String> stringList = new List<String> {'3'};
+		List<String> stringList = new List<String>{ '3' };
 		// When
 		mockList.add('Fred');
 		mockList.add(stringList);
@@ -419,7 +385,7 @@ private class fflib_ArgumentCaptorTest
 		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).add((String) argument.capture());
 		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).add((List<String>) argument.capture());
 
-		System.Assert.areEqual(stringList, (List<String>)argument.getValue(), 'the argument captured is not as expected');
+		System.Assert.areEqual(stringList, (List<String>) argument.getValue(), 'the argument captured is not as expected');
 
 		List<Object> argsCaptured = argument.getAllValues();
 
@@ -428,14 +394,13 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual('Fred', (String) argsCaptured[0], 'the first value is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureArgumentFromRequestedParameterWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		// When
 		mockList.add('Fred', 'Barney', 'Wilma', 'Betty');
@@ -443,25 +408,18 @@ private class fflib_ArgumentCaptorTest
 		// Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1)))
-			.add(
-				(String) fflib_Match.eq('Fred'),
-				(String) fflib_Match.eq('Barney'),
-				(String)  argument.capture(),
-				(String) fflib_Match.eq('Betty'));
+		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).add((String) fflib_Match.eq('Fred'), (String) fflib_Match.eq('Barney'), (String) argument.capture(), (String) fflib_Match.eq('Betty'));
 
-		System.Assert.areEqual('Wilma', (String)argument.getValue(),
-			'the argument captured is not as expected, should be Wilma because is the 3rd parameter in the call');
+		System.Assert.areEqual('Wilma', (String) argument.getValue(), 'the argument captured is not as expected, should be Wilma because is the 3rd parameter in the call');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureLastArgumentWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		// When
 		mockList.add('Barney');
@@ -472,17 +430,16 @@ private class fflib_ArgumentCaptorTest
 
 		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(2))).add((String) argument.capture());
 
-		System.Assert.areEqual('Fred', (String)argument.getValue(), 'the argument captured is not as expected');
+		System.Assert.areEqual('Fred', (String) argument.getValue(), 'the argument captured is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureAllArgumentsWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		// When
 		mockList.add('Fred');
@@ -505,14 +462,13 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual('Betty', (String) argsCaptured[3], 'the forth value is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureAllArgumentsFromMultipleMethodsWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		// When
 		mockList.add('Fred');
@@ -524,10 +480,7 @@ private class fflib_ArgumentCaptorTest
 
 		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(2))).add((String) argument.capture());
 
-		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1)))
-			.get2(
-				(Integer) fflib_Match.eq(3),
-				(String) argument.capture());
+		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).get2((Integer) fflib_Match.eq(3), (String) argument.capture());
 
 		List<Object> argsCaptured = argument.getAllValues();
 
@@ -539,14 +492,13 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual('pebble', (String) argsCaptured[2], 'the third value is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCanHandleMultipleCapturesInOneMethodCallWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		// When
 		mockList.add('Fred', 'Barney', 'Wilma', 'Betty');
@@ -554,12 +506,7 @@ private class fflib_ArgumentCaptorTest
 		// Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1)))
-			.add(
-				(String) fflib_Match.eq('Fred'),
-				(String)  argument.capture(),
-				(String)  argument.capture(),
-				(String) fflib_Match.eq('Betty'));
+		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).add((String) fflib_Match.eq('Fred'), (String) argument.capture(), (String) argument.capture(), (String) fflib_Match.eq('Betty'));
 
 		List<Object> argsCaptured = argument.getAllValues();
 
@@ -570,14 +517,13 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual('Wilma', (String) argsCaptured[1], 'the second value is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void thatDoesNotCaptureIfNotVerifiedWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		// When
 		mockList.add('3');
@@ -585,8 +531,7 @@ private class fflib_ArgumentCaptorTest
 		// Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(List<String>.class);
 
-		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.never()))
-			.add((List<String>) argument.capture());
+		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.never())).add((List<String>) argument.capture());
 
 		List<Object> argsCaptured = argument.getAllValues();
 
@@ -595,14 +540,13 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual(null, argument.getValue(), 'no value should be captured, so must return null');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureOnlyMethodsThatMatchesWithOtherMatcherAsWellWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		// When
 		mockList.add('Same', 'Same', 'First call', 'First call');
@@ -611,23 +555,18 @@ private class fflib_ArgumentCaptorTest
 		// Then
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).add(
-			fflib_Match.eqString('Same'),
-			fflib_Match.eqString('Same'),
-			(String)argument.capture(),
-			fflib_Match.eqString('First call'));
+		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).add(fflib_Match.eqString('Same'), fflib_Match.eqString('Same'), (String) argument.capture(), fflib_Match.eqString('First call'));
 
-		System.Assert.areEqual('First call', (String)argument.getValue());
+		System.Assert.areEqual('First call', (String) argument.getValue());
 	}
 
-	@isTest
+	@IsTest
 	static void thatDoesNotCaptureAnythingWhenCaptorIsWrappedInAMatcherWithInOrderVerification()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = new fflib_InOrder(mocks, new List<Object>{ mockList });
-
 
 		// When
 		mockList.add('Same', 'Same', 'First call', 'First call');
@@ -637,36 +576,24 @@ private class fflib_ArgumentCaptorTest
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
 		((fflib_MyList.IList) inOrder1.verify(mockList, mocks.calls(1))).add(
-			(String) fflib_Match.allOf(
-				fflib_Match.eqString('Same'),
-				fflib_Match.eqString('Same'),
-				argument.capture()),
-			(String) fflib_Match.allOf(
-				fflib_Match.eqString('Same'),
-				fflib_Match.eqString('Same'),
-				argument.capture()),
-			(String) fflib_Match.allOf(
-				argument.capture(),
-				fflib_Match.eqString('First call')),
-			(String) fflib_Match.allOf(
-				argument.capture(),
-				fflib_Match.eqString('First call'))
-			);
+			(String) fflib_Match.allOf(fflib_Match.eqString('Same'), fflib_Match.eqString('Same'), argument.capture()),
+			(String) fflib_Match.allOf(fflib_Match.eqString('Same'), fflib_Match.eqString('Same'), argument.capture()),
+			(String) fflib_Match.allOf(argument.capture(), fflib_Match.eqString('First call')),
+			(String) fflib_Match.allOf(argument.capture(), fflib_Match.eqString('First call'))
+		);
 
 		List<Object> capturedValues = argument.getAllValues();
 
-		System.Assert.areEqual(0, capturedValues.size(),
-			'nothing should have been capture because the matcher it not really a capture type, but a allOf()');
-		System.Assert.isNull((String)argument.getValue(),
-			'nothing should have been capture because the matcher it not really a capture type, but a allOf()');
+		System.Assert.areEqual(0, capturedValues.size(), 'nothing should have been capture because the matcher it not really a capture type, but a allOf()');
+		System.Assert.isNull((String) argument.getValue(), 'nothing should have been capture because the matcher it not really a capture type, but a allOf()');
 	}
 
-	@isTest
+	@IsTest
 	static void thatCaptureAllArgumentswhenMethodIsCalledWithTheSameArgument()
 	{
 		// Given
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
-		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList mockList = (fflib_MyList) mocks.mock(fflib_MyList.class);
 
 		// When
 		mockList.add('Fred');
@@ -692,7 +619,6 @@ private class fflib_ArgumentCaptorTest
 		System.Assert.areEqual('Barney', (String) argsCaptured[4], 'the fifth value is not as expected');
 		System.Assert.areEqual('Betty', (String) argsCaptured[5], 'the sixth value is not as expected');
 	}
-
 
 	private class TestInnerClass
 	{

--- a/sfdx-source/apex-mocks/test/classes/fflib_IDGeneratorTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_IDGeneratorTest.cls
@@ -1,28 +1,28 @@
 /**
-* Copyright (c) 2014, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @IsTest
 private class fflib_IDGeneratorTest
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_IDGeneratorTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_IDGeneratorTest.cls
@@ -1,32 +1,32 @@
 /**
- * Copyright (c) 2014, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-@isTest
+* Copyright (c) 2014, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+@IsTest
 private class fflib_IDGeneratorTest
 {
-	@isTest
+	@IsTest
 	static void itShouldGenerateValidIDs()
 	{
 		String id1 = fflib_IDGenerator.generate(Account.SObjectType);

--- a/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_InOrderTest.cls
@@ -1,17 +1,17 @@
 /*
- Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
-@isTest
+@IsTest
 private class fflib_InOrderTest
 {
 	private static fflib_ApexMocks MY_MOCKS = new fflib_ApexMocks();
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderAllTheMethodsCalled()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -21,35 +21,33 @@ private class fflib_InOrderTest
 		firstMock.add('1-4');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-3');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-3');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
 			System.Assert.fail('It should fail because 1-2 is in the wrong order');
 		}
 		catch (fflib_ApexMocks.ApexMocksException error)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+'\nACTUAL COUNT: 0'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("1-2"), ("1-3"), ("1-4")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "1-2"',
-				error.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("1-2"), ("1-3"), ("1-4")' + '\n---' + '\nEXPECTED ARGS: "1-2"',
+					error.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderDifferentMethodsCalledWithSameArguments()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -63,17 +61,17 @@ private class fflib_InOrderTest
 		firstMock.addMore('1-4');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-3');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-3');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderDifferentMethodsCalledWithSameArgumentsOrderFail()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -83,32 +81,30 @@ private class fflib_InOrderTest
 		firstMock.addMore('1-2');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
 			System.Assert.fail('It should fail because 1-1 is called before the addMore(1-1)');
 		}
 		catch (fflib_ApexMocks.ApexMocksException error)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+'\nACTUAL COUNT: 0'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("1-1"), ("1-2"), ("1-2")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "1-1"',
-				error.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("1-1"), ("1-2"), ("1-2")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					error.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderDifferentMethodsCalledWithSameArgumentsDoubleCallFail()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -118,32 +114,30 @@ private class fflib_InOrderTest
 		firstMock.addMore('1-2');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('1-1');
 			System.Assert.fail('It should fail because addMore(1-1) is called only Once');
 		}
 		catch (fflib_ApexMocks.ApexMocksException error)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+ '\nACTUAL COUNT: 0'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.addMore(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("1-1"), ("1-2"), ("1-2")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "1-1"',
-				error.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.addMore(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("1-1"), ("1-2"), ("1-2")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					error.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCallMethodWithMatches()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -154,15 +148,15 @@ private class fflib_InOrderTest
 		firstMock.add('1-4');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(2))).add(fflib_Match.stringStartsWith('1-1'));
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(2))).add(fflib_Match.stringStartsWith('1-1'));
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCallMethodWithMatchesFailsIfVerifyACallAlreadyInTheMatcher()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -173,33 +167,31 @@ private class fflib_InOrderTest
 		firstMock.add('1-4');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(2))).add(fflib_Match.stringStartsWith('1-1'));
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(2))).add(fflib_Match.stringStartsWith('1-1'));
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-11');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-11');
 			System.Assert.fail('It should fail because addMore(1-11) has been already verified using the matchers');
 		}
 		catch (fflib_ApexMocks.ApexMocksException error)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+'\nACTUAL COUNT: 0'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-0"), ("1-11"), ("1-12"), ("1-3"), ("1-4")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "1-11"',
-				error.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-0"), ("1-11"), ("1-12"), ("1-3"), ("1-4")' + '\n---' + '\nEXPECTED ARGS: "1-11"',
+					error.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCallMethodWithMultipleMatches()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -208,7 +200,6 @@ private class fflib_InOrderTest
 		firstMock.add('1-1');
 		firstMock.add('1-3');
 		firstMock.add('1-4');
-
 
 		firstMock.add('2-0');
 		firstMock.add('2-1');
@@ -216,15 +207,15 @@ private class fflib_InOrderTest
 		firstMock.add('2-4');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add(fflib_Match.stringStartsWith('1-'));
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add(fflib_Match.stringStartsWith('2-'));
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add(fflib_Match.stringStartsWith('1-'));
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add(fflib_Match.stringStartsWith('2-'));
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCallMethodWithMultipleMatchesMixed()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -238,15 +229,15 @@ private class fflib_InOrderTest
 		firstMock.add('2-4');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add(fflib_Match.stringStartsWith('1-'));
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add(fflib_Match.stringStartsWith('2-'));
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add(fflib_Match.stringStartsWith('1-'));
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add(fflib_Match.stringStartsWith('2-'));
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCallMethodWithMultipleMatchesMixedFailWhenMatcherHaveAlreadyVerifiedMethod()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -260,32 +251,30 @@ private class fflib_InOrderTest
 		firstMock.add('2-4');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add(fflib_Match.stringStartsWith('1-'));
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add(fflib_Match.stringStartsWith('1-'));
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add('1-11');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add('1-11');
 			System.Assert.fail('It should fail because only one call for the 2- is available to verify');
 		}
 		catch (fflib_ApexMocks.ApexMocksException error)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 4 in order'
-				+'\nACTUAL COUNT: 0'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-2"), ("2-2"), ("1-3"), ("2-3"), ("1-4"), ("2-4")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "1-11"',
-				error.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 4 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-2"), ("2-2"), ("1-3"), ("2-3"), ("1-4"), ("2-4")' + '\n---' + '\nEXPECTED ARGS: "1-11"',
+					error.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCanSkipMethodsCalledUntilFindTheOneThatNeedsVerify()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -295,33 +284,31 @@ private class fflib_InOrderTest
 		firstMock.add('1-4');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
 			System.Assert.fail('It should fail because is out of order');
 		}
 		catch (fflib_ApexMocks.ApexMocksException error)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+'\nACTUAL COUNT: 0'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("1-2"), ("1-3"), ("1-4")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "1-2"',
-				error.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("1-2"), ("1-3"), ("1-4")' + '\n---' + '\nEXPECTED ARGS: "1-2"',
+					error.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCanHandleMultipleMethodsCalls()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -333,15 +320,15 @@ private class fflib_InOrderTest
 		firstMock.add('1-4');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(3))).add('1-2');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(3))).add('1-2');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-4');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCanHandleMultipleMethodsCallsAndNotFailsIfVerifyCountIsGreaterThenExpected()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -354,14 +341,14 @@ private class fflib_InOrderTest
 
 		// Then
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(2))).add('1-2');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(2))).add('1-2');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCanHandleMultipleMethodsCallsButFailsIfVerifyCountIsLessThenExpected()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -375,30 +362,28 @@ private class fflib_InOrderTest
 		// Then
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add('1-2');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(4))).add('1-2');
 			System.Assert.fail('It should fail because is actually called only 3 times');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 4 in order'
-				+'\nACTUAL COUNT: 3'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("1-2"), ("1-2"), ("1-2"), ("1-3"), ("1-4")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "1-2"',
-				e.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 4 in order' + '\nACTUAL COUNT: 3' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("1-2"), ("1-2"), ("1-2"), ("1-3"), ("1-4")' + '\n---' + '\nEXPECTED ARGS: "1-2"',
+					e.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCanHandleMultipleMocks()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_MyList thirdMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList secondMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList thirdMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 
 		fflib_InOrder inOrder = MY_MOCKS.inOrder(new List<Object>{ firstMock, secondMock });
 
@@ -417,23 +402,23 @@ private class fflib_InOrderTest
 		thirdMock.add('3-3');
 
 		// Then
-		((fflib_MyList.IList)inOrder.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder.verify(secondMock, MY_MOCKS.calls(1))).add('2-1');
-		((fflib_MyList.IList)inOrder.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
-		((fflib_MyList.IList)inOrder.verify(secondMock, MY_MOCKS.calls(1))).add('2-2');
-		((fflib_MyList.IList)inOrder.verify(firstMock, MY_MOCKS.calls(1))).add('1-3');
-		((fflib_MyList.IList)inOrder.verify(secondMock, MY_MOCKS.calls(1))).add('2-3');
+		((fflib_MyList.IList) inOrder.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder.verify(secondMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
+		((fflib_MyList.IList) inOrder.verify(secondMock, MY_MOCKS.calls(1))).add('2-2');
+		((fflib_MyList.IList) inOrder.verify(firstMock, MY_MOCKS.calls(1))).add('1-3');
+		((fflib_MyList.IList) inOrder.verify(secondMock, MY_MOCKS.calls(1))).add('2-3');
 
-		((fflib_MyList.IList)MY_MOCKS.verify(thirdMock, MY_MOCKS.times(3))).add(fflib_Match.stringStartsWith('3-'));
+		((fflib_MyList.IList) MY_MOCKS.verify(thirdMock, MY_MOCKS.times(3))).add(fflib_Match.stringStartsWith('3-'));
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderCanHandleMixedInOrderInstance()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_MyList thirdMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList secondMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList thirdMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 		fflib_InOrder inOrder2 = MY_MOCKS.inOrder(new List<Object>{ firstMock, secondMock });
@@ -453,26 +438,25 @@ private class fflib_InOrderTest
 		thirdMock.add('3-3');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(2))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-3');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(2))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-3');
 
+		((fflib_MyList.IList) inOrder2.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
 
-		((fflib_MyList.IList)inOrder2.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder2.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
+		((fflib_MyList.IList) inOrder2.verify(secondMock, MY_MOCKS.calls(1))).add('2-2');
+		((fflib_MyList.IList) inOrder2.verify(firstMock, MY_MOCKS.calls(1))).add('1-3');
+		((fflib_MyList.IList) inOrder2.verify(secondMock, MY_MOCKS.calls(1))).add('2-3');
 
-		((fflib_MyList.IList)inOrder2.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
-		((fflib_MyList.IList)inOrder2.verify(secondMock, MY_MOCKS.calls(1))).add('2-2');
-		((fflib_MyList.IList)inOrder2.verify(firstMock, MY_MOCKS.calls(1))).add('1-3');
-		((fflib_MyList.IList)inOrder2.verify(secondMock, MY_MOCKS.calls(1))).add('2-3');
-
-		((fflib_MyList.IList)MY_MOCKS.verify(thirdMock, MY_MOCKS.times(3))).add(fflib_Match.stringStartsWith('3-'));
+		((fflib_MyList.IList) MY_MOCKS.verify(thirdMock, MY_MOCKS.times(3))).add(fflib_Match.stringStartsWith('3-'));
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderThrownExceptionIfVerifyMockInstanceNotInTheSet()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList secondMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
@@ -484,28 +468,26 @@ private class fflib_InOrderTest
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(secondMock, MY_MOCKS.calls(1))).add('2-1');
+			((fflib_MyList.IList) inOrder1.verify(secondMock, MY_MOCKS.calls(1))).add('2-1');
 			System.Assert.fail('An exception was expected, because this verify is not in the list of the mocks to verify');
 		}
-		catch(fflib_ApexMocks.ApexMocksException mockexcep)
+		catch (fflib_ApexMocks.ApexMocksException mockexcep)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+ '\nACTUAL COUNT: 0'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("2-1")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "2-1"',
-				mockexcep.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "2-1"',
+					mockexcep.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyInOrderThrownExceptionWithCustomMessage()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
@@ -515,33 +497,30 @@ private class fflib_InOrderTest
 		firstMock.add('1-1');
 		firstMock.add('1-2');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-2');
 		// Then
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.description(customErrorMesage))).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.description(customErrorMesage))).add('1-1');
 			System.Assert.fail('expected some exception ');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+ '\nACTUAL COUNT: 0'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\nSome custom error message'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("1-2")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "1-1"',
-				e.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\nSome custom error message' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("1-2")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					e.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtMostThrowsExceptionBecauseNotImplemented()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -553,12 +532,12 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atMost(3))).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atMost(3))).add('1-1');
 			System.Assert.fail('an exception was expected because the method is not implemented for the InOrder class');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
@@ -568,11 +547,11 @@ private class fflib_InOrderTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyBetweenThrowsExceptionBecauseNotImplemented()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -585,12 +564,12 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.between(3, 5))).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.between(3, 5))).add('1-1');
 			System.Assert.fail('an exception was expected because the method is not implemented for the InOrder class');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
@@ -600,11 +579,11 @@ private class fflib_InOrderTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNever()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -617,17 +596,17 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.never())).add('3-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.never())).add('3-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNeverWithMatchers()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -640,17 +619,17 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.never())).add(fflib_Match.stringStartsWith('3-'));
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.never())).add(fflib_Match.stringStartsWith('3-'));
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNeverFailsWhenCalled()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -663,33 +642,31 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.never())).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.never())).add('1-1');
 			System.Assert.fail('expected some exception because the method has been called');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 0 in order'
-				+ '\nACTUAL COUNT: 4'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "1-1"',
-				e.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 0 in order' + '\nACTUAL COUNT: 4' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					e.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNeverFailsWhenCalledWithMatchers()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -702,33 +679,37 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.never())).add(fflib_Match.stringStartsWith('1-'));
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.never())).add(fflib_Match.stringStartsWith('1-'));
 			System.Assert.fail('expected some exception because the method has been called');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 0 in order'
-				+ '\nACTUAL COUNT: 4'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: [starts with "1-"]',
-				e.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 0 in order'
+					+ '\nACTUAL COUNT: 4'
+					+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+					+ '\n---'
+					+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
+					+ '\n---'
+					+ '\nEXPECTED ARGS: [starts with "1-"]',
+					e.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyThrowsExceptionWhenCallsIsInvochedFromStandardMock()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -749,11 +730,11 @@ private class fflib_InOrderTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNoMoreInteractionsFails()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -761,7 +742,7 @@ private class fflib_InOrderTest
 		firstMock.addMore('2-1');
 		firstMock.add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1', '1-1', '1-1', '1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1', '1-1', '1-1', '1-1');
 
 		// Then
 		try
@@ -776,11 +757,11 @@ private class fflib_InOrderTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNoMoreInteractionsFailsWhenOnLyOneMethodLeft()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -788,7 +769,7 @@ private class fflib_InOrderTest
 		firstMock.addMore('2-1');
 		firstMock.add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).addMore('2-1');
 
 		// Then
 		try
@@ -803,12 +784,12 @@ private class fflib_InOrderTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNoMoreInteractionsPass()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList secondMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 		fflib_InOrder inOrder2 = MY_MOCKS.inOrder(new List<Object>{ secondMock });
 
@@ -819,22 +800,22 @@ private class fflib_InOrderTest
 		secondMock.add('1-1');
 		secondMock.add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
 
 		inOrder1.verifyNoMoreInteractions();
 
-		((fflib_MyList.IList)inOrder2.verify(secondMock, MY_MOCKS.calls(2))).add('1-1');
+		((fflib_MyList.IList) inOrder2.verify(secondMock, MY_MOCKS.calls(2))).add('1-1');
 
 		inOrder2.verifyNoMoreInteractions();
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNoMoreInteractionsFailsWhenNoInteracionOccurs()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -855,11 +836,11 @@ private class fflib_InOrderTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNoInteractionsFails()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -880,12 +861,12 @@ private class fflib_InOrderTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyNoInteractionsPass()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
-		fflib_MyList secondMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList secondMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -894,10 +875,10 @@ private class fflib_InOrderTest
 		inOrder1.verifyNoInteractions();
 	}
 
-	@isTest
+	@IsTest
 	static void thatStrictVerificationCanBePerformed()
 	{
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -906,16 +887,16 @@ private class fflib_InOrderTest
 		firstMock.add('1-1');
 		firstMock.add('4-1');
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('4-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('4-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatMixedVerificationDoNotInterfierWithOtherImplementationChecking()
 	{
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -924,21 +905,21 @@ private class fflib_InOrderTest
 		firstMock.add('1-1');
 		firstMock.add('4-1');
 		// Then
-		((fflib_MyList.IList)MY_MOCKS.verify(firstMock, MY_MOCKS.times(2))).add('1-1');
+		((fflib_MyList.IList) MY_MOCKS.verify(firstMock, MY_MOCKS.times(2))).add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('4-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('4-1');
 
-		((fflib_MyList.IList)MY_MOCKS.verify(firstMock, MY_MOCKS.times(2))).add('1-1');
+		((fflib_MyList.IList) MY_MOCKS.verify(firstMock, MY_MOCKS.times(2))).add('1-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastPassWithSameCallsOfAssertion()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -950,18 +931,18 @@ private class fflib_InOrderTest
 		firstMock.add('2-1'); //finally consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeast(3))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeast(3))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastPassWithMoreCallsThenAsserted()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -973,18 +954,18 @@ private class fflib_InOrderTest
 		firstMock.add('2-1'); //finally consumed by -> verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastThrowsErrorIfCalledLessTimes()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -996,33 +977,31 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeast(4))).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeast(4))).add('1-1');
 			System.Assert.fail('an exception was expected because the atLeast is asserting for 4 calls when instead there are only 3 not consumed calls');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 4 in order'
-				+'\nACTUAL COUNT: 3'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "1-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 4 in order' + '\nACTUAL COUNT: 3' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastConsumeAllTheInstances()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1035,37 +1014,34 @@ private class fflib_InOrderTest
 		firstMock.add('1-1');
 		firstMock.add('1-1');
 
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
-
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('1-1');
 
 		// Then
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 			System.Assert.fail('an exception was expected because the atLeast have consumed all the interactions of 1-1');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+'\nACTUAL COUNT: 0'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("1-1")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "2-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("1-1")' + '\n---' + '\nEXPECTED ARGS: "2-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastConsumeAllTheInstancesForOnlyTheMethodVerified()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1079,15 +1055,15 @@ private class fflib_InOrderTest
 		firstMock.add('1-1'); //those are then free for the second atLeast assertion
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('1-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastOnce()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1095,14 +1071,14 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 		firstMock.add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('1-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastOnceConsumesInstancesUntilLastMethodVerified()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1111,15 +1087,15 @@ private class fflib_InOrderTest
 		firstMock.add('1-1'); // consumed until there by -> verify(firstMock, MY_MOCKS.atLeastOnce())).add('1-1');
 		firstMock.add('2-1'); // free for another assertion
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('2-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastOnceThrowsErrorIfCalledLessTimes()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1130,28 +1106,26 @@ private class fflib_InOrderTest
 		// Then
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('1-3');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('1-3');
 			System.Assert.fail('an exception was expected because the atLeastOnce is asserting for 1 calls when instead the method is not called at all with that argument');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+'\nACTUAL COUNT: 0'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "1-3"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1")' + '\n---' + '\nEXPECTED ARGS: "1-3"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastOnceConsumesAllTheInstances()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1162,33 +1136,31 @@ private class fflib_InOrderTest
 		firstMock.add('1-1');
 		firstMock.add('1-1'); //all the instance have been consumed
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeastOnce())).add('1-1');
 
 		// Then
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 			System.Assert.fail('an exception was expected because the atLeast have consumed all the interactions of 1-1');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+'\nACTUAL COUNT: 0'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("2-1"), ("1-1"), ("1-1")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "2-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 0' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("2-1"), ("1-1"), ("1-1")' + '\n---' + '\nEXPECTED ARGS: "2-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyTimes()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1200,17 +1172,17 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(3))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(3))).add('1-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyTimesThrowsExceptionIfCalledMoreTimesThanExpected()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1222,33 +1194,31 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(2))).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(2))).add('1-1');
 			System.Assert.fail('exception expected because the method is called more times than expected in the verification');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 2 in order'
-				+ '\nACTUAL COUNT: 3'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "1-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 2 in order' + '\nACTUAL COUNT: 3' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyTimesThrowsExceptionIfCalledLessTimesThanExpected()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1260,33 +1230,31 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(4))).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(4))).add('1-1');
 			System.Assert.fail('exception expected because the method is called more times than expected in the verification');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 4 in order'
-				+ '\nACTUAL COUNT: 3'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "1-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 4 in order' + '\nACTUAL COUNT: 3' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyTimesPassWhenAnotherMethodIsCalledBetweenMethodsCalls()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1300,19 +1268,19 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(4))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(4))).add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyTimesPassWhenAnotherMethodIsCalledBetweenMethodsCalls2()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1326,20 +1294,20 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(3))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(3))).add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyTimesPassWhenAnotherMethodIsCalledBetweenMethodsCalls3()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1355,23 +1323,23 @@ private class fflib_InOrderTest
 		firstMock.add('1-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(3))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(3))).add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(2))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(2))).add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyTimesPassWhenAnotherMethodIsCalledBetweenMethodsCalls4()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1387,20 +1355,20 @@ private class fflib_InOrderTest
 		firstMock.add('1-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(5))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(5))).add('1-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyTimesThrowsExceptionWhenAnotherMethodIsCalledBetweenMethodsCalls()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1414,33 +1382,31 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(5))).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(5))).add('1-1');
 			System.Assert.fail('exception expected because the method is called more times than expected in the verification');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 5 in order'
-				+ '\nACTUAL COUNT: 4'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("2-1")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "1-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 5 in order' + '\nACTUAL COUNT: 4' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatStrictVerificationCanBeEnforced()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1454,19 +1420,19 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(3))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(3))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(1))).add('2-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatTimesOneIsTheDefaultVerification()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1480,33 +1446,31 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock)).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock)).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock)).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock)).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock)).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock)).add('1-1');
 			System.Assert.fail('exception expected because the method is called more times than expected in the verification');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+'\nACTUAL COUNT: 4'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("2-1")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "1-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order' + '\nACTUAL COUNT: 4' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatWithOldNotation()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1518,17 +1482,17 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, 3)).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, 3)).add('1-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatWithOldNotationThrowsExceptionIfCalledMoreTimesThanExpected()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1540,33 +1504,31 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, 2)).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, 2)).add('1-1');
 			System.Assert.fail('exception expected because the method is called more times than expected in the verification');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 2 in order'
-				+ '\nACTUAL COUNT: 3'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "1-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 2 in order' + '\nACTUAL COUNT: 3' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatWithOldNotationThrowsExceptionIfCalledLessTimesThanExpected()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1578,33 +1540,31 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, 4)).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, 4)).add('1-1');
 			System.Assert.fail('exception expected because the method is called more times than expected in the verification');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 4 in order'
-				+ '\nACTUAL COUNT: 3'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "1-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 4 in order' + '\nACTUAL COUNT: 3' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatWithOldNotationPassWhenAnotherMethodIsCalledBetweenMethodsCalls()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1618,17 +1578,17 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, 4)).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, 4)).add('1-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatWithOldNotationThrowsExceptionWhenAnotherMethodIsCalledBetweenMethodsCalls()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1642,33 +1602,31 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, 5)).add('1-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, 5)).add('1-1');
 			System.Assert.fail('exception expected because the method is called more times than expected in the verification');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 5 in order'
-				+ '\nACTUAL COUNT: 4'
-				+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+ '\n---'
-				+ '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("2-1")'
-				+ '\n---'
-				+ '\nEXPECTED ARGS: "1-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 5 in order' + '\nACTUAL COUNT: 4' + '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)' + '\n---' + '\nACTUAL ARGS: ("1-1"), ("2-1"), ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("1-1"), ("2-1")' + '\n---' + '\nEXPECTED ARGS: "1-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void thatStrictVerificationCanBeEnforcedWithOldNotation()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1682,19 +1640,19 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, 1)).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, 1)).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, 3)).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, 1)).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, 1)).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, 1)).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, 1)).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, 1)).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, 3)).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, 1)).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, 1)).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, 1)).add('2-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatStrictVerificationCanBeEnforcedWithOldNotationUsingDefaultTimesOne()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		// When
@@ -1708,19 +1666,19 @@ private class fflib_InOrderTest
 		firstMock.add('2-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock)).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock)).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock, 3)).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock)).add('2-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock)).add('1-1');
-		((fflib_MyList.IList)inOrder1.verify(firstMock)).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock)).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock)).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, 3)).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock)).add('2-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock)).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock)).add('2-1');
 	}
 
-	@isTest
+	@IsTest
 	static void thatVerifyAtLeastConsumesAllTheInstances2()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
@@ -1735,32 +1693,36 @@ private class fflib_InOrderTest
 		firstMock.add('1-1');
 
 		// Then
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('1-1');
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).add('1-1');
 
 		try
 		{
-			((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
+			((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(1))).add('2-1');
 			System.Assert.fail('exception expected because the atLeast have consumed all the calls');
 		}
 		catch (fflib_ApexMocks.ApexMocksException mockExcept)
 		{
-			System.Assert.areEqual('EXPECTED COUNT: 1 in order'
-				+'\nACTUAL COUNT: 0'
-				+'\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
-				+'\n---'
-				+'\nACTUAL ARGS: ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("2-1"), ("2-1"), ("2-1"), ("2-1"), ("1-1")'
-				+'\n---'
-				+'\nEXPECTED ARGS: "2-1"',
-				mockExcept.getMessage(),
-				'Unexpected verify fail message');
+			System
+				.Assert
+				.areEqual(
+					'EXPECTED COUNT: 1 in order'
+					+ '\nACTUAL COUNT: 0'
+					+ '\nMETHOD: fflib_MyList__sfdc_ApexStub.add(String)'
+					+ '\n---'
+					+ '\nACTUAL ARGS: ("1-1"), ("1-1"), ("1-1"), ("2-1"), ("2-1"), ("2-1"), ("2-1"), ("2-1"), ("1-1")'
+					+ '\n---'
+					+ '\nEXPECTED ARGS: "2-1"',
+					mockExcept.getMessage(),
+					'Unexpected verify fail message'
+				);
 		}
 	}
 
-	@isTest
+	@IsTest
 	static void verifyAtLeastAndCapture()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
@@ -1772,16 +1734,16 @@ private class fflib_InOrderTest
 
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).get2( fflib_Match.eqInteger(1), (String) argument.capture());
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.atLeast(2))).get2(fflib_Match.eqInteger(1), (String) argument.capture());
 
 		System.Assert.areEqual('4-1', (string) argument.getValue(), 'the last value captured is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void verifyTimesAndCaptor()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
@@ -1798,16 +1760,16 @@ private class fflib_InOrderTest
 
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.times(5))).get2(fflib_Match.eqInteger(1), (String) argument.capture());
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.times(5))).get2(fflib_Match.eqInteger(1), (String) argument.capture());
 
 		System.Assert.areEqual('5-1', (string) argument.getValue(), 'the last value captured is not as expected');
 	}
 
-	@isTest
+	@IsTest
 	static void verifyCallsAndCapture()
 	{
 		// Given
-		fflib_MyList firstMock = (fflib_MyList)MY_MOCKS.mock(fflib_MyList.class);
+		fflib_MyList firstMock = (fflib_MyList) MY_MOCKS.mock(fflib_MyList.class);
 		fflib_InOrder inOrder1 = MY_MOCKS.inOrder(new List<Object>{ firstMock });
 
 		//When
@@ -1824,7 +1786,7 @@ private class fflib_InOrderTest
 
 		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
 
-		((fflib_MyList.IList)inOrder1.verify(firstMock, MY_MOCKS.calls(2))).get2(fflib_Match.eqInteger(1), (String) argument.capture());
+		((fflib_MyList.IList) inOrder1.verify(firstMock, MY_MOCKS.calls(2))).get2(fflib_Match.eqInteger(1), (String) argument.capture());
 
 		System.Assert.areEqual('2-1', (string) argument.getValue(), 'the last value captured is not as expected');
 	}

--- a/sfdx-source/apex-mocks/test/classes/fflib_InheritorTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_InheritorTest.cls
@@ -1,33 +1,33 @@
 /*
- * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
- */
-@isTest
+* Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
+*/
+@IsTest
 public class fflib_InheritorTest
 {
- 	@isTest
-    public static void canInstantiateMultipleInterfaceInheritor()
-    {
-        fflib_ApexMocks mocks = new fflib_ApexMocks();
-        Object inheritor = mocks.mock(fflib_Inheritor.class);
-        System.Assert.isInstanceOfType(inheritor, fflib_Inheritor.IA.class);
-        System.Assert.isInstanceOfType(inheritor, fflib_Inheritor.IB.class);
-        System.Assert.isInstanceOfType(inheritor, fflib_Inheritor.IC.class);
-    }
+	@IsTest
+	public static void canInstantiateMultipleInterfaceInheritor()
+	{
+		fflib_ApexMocks mocks = new fflib_ApexMocks();
+		Object inheritor = mocks.mock(fflib_Inheritor.class);
+		System.Assert.isInstanceOfType(inheritor, fflib_Inheritor.IA.class);
+		System.Assert.isInstanceOfType(inheritor, fflib_Inheritor.IB.class);
+		System.Assert.isInstanceOfType(inheritor, fflib_Inheritor.IC.class);
+	}
 
- 	@isTest
-    public static void canStubMultipleInterfaceInheritor()
-    {
-        fflib_ApexMocks mocks = new fflib_ApexMocks();
-        fflib_Inheritor inheritor = (fflib_Inheritor)mocks.mock(fflib_Inheritor.class);
+	@IsTest
+	public static void canStubMultipleInterfaceInheritor()
+	{
+		fflib_ApexMocks mocks = new fflib_ApexMocks();
+		fflib_Inheritor inheritor = (fflib_Inheritor) mocks.mock(fflib_Inheritor.class);
 
-        mocks.startStubbing();
-        mocks.when(inheritor.doA()).thenReturn('Did not do A');
-        mocks.when(inheritor.doB()).thenReturn('Did not do B');
-        mocks.when(inheritor.doC()).thenReturn('Did not do C');
-        mocks.stopStubbing();
-        
-        System.Assert.areEqual('Did not do A', inheritor.doA());
-        System.Assert.areEqual('Did not do B', inheritor.doB());
-        System.Assert.areEqual('Did not do C', inheritor.doC());
-    }
+		mocks.startStubbing();
+		mocks.when(inheritor.doA()).thenReturn('Did not do A');
+		mocks.when(inheritor.doB()).thenReturn('Did not do B');
+		mocks.when(inheritor.doC()).thenReturn('Did not do C');
+		mocks.stopStubbing();
+
+		System.Assert.areEqual('Did not do A', inheritor.doA());
+		System.Assert.areEqual('Did not do B', inheritor.doB());
+		System.Assert.areEqual('Did not do C', inheritor.doC());
+	}
 }

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatchTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatchTest.cls
@@ -1,141 +1,111 @@
 /**
- * Copyright (c) 2014-2016, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-@isTest
+* Copyright (c) 2014-2016, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+@IsTest
 public with sharing class fflib_MatchTest
 {
-	@isTest
+	@IsTest
 	private static void whenMatchesAllArgsWithOneMatchReturnsTrue()
 	{
 		//Given
 		fflib_MethodArgValues argValues = new fflib_MethodArgValues(new List<Object>{ null });
 		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{ new AlwaysMatch() };
-		
+
 		//When
 		Boolean match = fflib_Match.matchesAllArgs(argValues, targetMatchers);
 
 		//Then
 		System.Assert.isTrue(match);
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesAllArgsWithManyMatchesReturnsTrue()
 	{
 		//Given
-		fflib_MethodArgValues argValues = new fflib_MethodArgValues(new List<Object>{
-			null,
-			null,
-			null,
-			null
-		});
-		
-		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{
-			new AlwaysMatch(),
-			new AlwaysMatch(),
-			new AlwaysMatch(),
-			new AlwaysMatch()
-		};
-		
+		fflib_MethodArgValues argValues = new fflib_MethodArgValues(new List<Object>{ null, null, null, null });
+
+		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{ new AlwaysMatch(), new AlwaysMatch(), new AlwaysMatch(), new AlwaysMatch() };
+
 		//When
 		Boolean match = fflib_Match.matchesAllArgs(argValues, targetMatchers);
 
 		//Then
 		System.Assert.isTrue(match);
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesAllArgsWithOneMismatchReturnsFalse()
 	{
 		//Given
 		fflib_MethodArgValues argValues = new fflib_MethodArgValues(new List<Object>{ null });
 		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{ new NeverMatch() };
-		
+
 		//When
 		Boolean match = fflib_Match.matchesAllArgs(argValues, targetMatchers);
 
 		//Then
 		System.Assert.isFalse(match);
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesAllArgsWithManyMismatchesReturnsFalse()
 	{
 		//Given
-		fflib_MethodArgValues argValues = new fflib_MethodArgValues(new List<Object>{
-			null,
-			null,
-			null,
-			null
-		});
-		
-		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{
-			new NeverMatch(),
-			new NeverMatch(),
-			new NeverMatch(),
-			new NeverMatch()
-		};
-		
+		fflib_MethodArgValues argValues = new fflib_MethodArgValues(new List<Object>{ null, null, null, null });
+
+		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{ new NeverMatch(), new NeverMatch(), new NeverMatch(), new NeverMatch() };
+
 		//When
 		Boolean match = fflib_Match.matchesAllArgs(argValues, targetMatchers);
 
 		//Then
 		System.Assert.isFalse(match);
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesAllArgsWithMatchesAndMismatchesReturnsFalse()
 	{
 		//Given
-		fflib_MethodArgValues argValues = new fflib_MethodArgValues(new List<Object>{
-			null,
-			null,
-			null,
-			null
-		});
-		
-		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{
-			new AlwaysMatch(),
-			new AlwaysMatch(),
-			new NeverMatch(),
-			new AlwaysMatch()
-		};
-		
+		fflib_MethodArgValues argValues = new fflib_MethodArgValues(new List<Object>{ null, null, null, null });
+
+		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{ new AlwaysMatch(), new AlwaysMatch(), new NeverMatch(), new AlwaysMatch() };
+
 		//When
 		Boolean match = fflib_Match.matchesAllArgs(argValues, targetMatchers);
 
 		//Then
 		System.Assert.isFalse(match);
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesAllArgsWithNullMethodArgsThrowsException()
 	{
 		//Given
 		fflib_MethodArgValues methodArg = null;
 		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{ new AlwaysMatch() };
-		
+
 		//When
 		try
 		{
@@ -148,14 +118,14 @@ public with sharing class fflib_MatchTest
 			System.Assert.areEqual('MethodArgs cannot be null', e.getMessage());
 		}
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesAllArgsWithNullMethodArgsArgValuesThrowsException()
 	{
 		//Given
 		fflib_MethodArgValues methodArg = new fflib_MethodArgValues(null);
 		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{ new AlwaysMatch() };
-		
+
 		//When
 		try
 		{
@@ -168,14 +138,14 @@ public with sharing class fflib_MatchTest
 			System.Assert.areEqual('MethodArgs.argValues cannot be null', e.getMessage());
 		}
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesAllArgsWithNullMatchersThrowsException()
 	{
 		//Given
 		fflib_MethodArgValues methodArg = new fflib_MethodArgValues(new List<Object>{ 'Test' });
 		List<fflib_IMatcher> targetMatchers = null;
-		
+
 		//When
 		try
 		{
@@ -188,14 +158,14 @@ public with sharing class fflib_MatchTest
 			System.Assert.areEqual('Matchers cannot be null', e.getMessage());
 		}
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesAllArgsWithDifferentSizeArgValuesAndMatchersThrowsException()
 	{
 		//Given
 		fflib_MethodArgValues methodArg = new fflib_MethodArgValues(new List<Object>{ 'Test' });
 		List<fflib_IMatcher> targetMatchers = new List<fflib_IMatcher>{ new AlwaysMatch(), new AlwaysMatch() };
-		
+
 		//When
 		try
 		{
@@ -205,64 +175,62 @@ public with sharing class fflib_MatchTest
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
 			//Then
-			String expectedMessage = 'MethodArgs and matchers must have the same count'
-				+ ', MethodArgs: (' + methodArg.argValues.size() + ') ' + methodArg.argValues
-				+ ', Matchers: (' + targetMatchers.size() + ') ' + targetMatchers;
+			String expectedMessage = 'MethodArgs and matchers must have the same count' + ', MethodArgs: (' + methodArg.argValues.size() + ') ' + methodArg.argValues + ', Matchers: (' + targetMatchers.size() + ') ' + targetMatchers;
 
 			System.Assert.areEqual(expectedMessage, e.getMessage());
 		}
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesWithOneMatcherSetsMatchingToTrue()
 	{
 		//Given
 		fflib_IMatcher matcher = new AlwaysMatch();
-		
+
 		//When
 		fflib_Match.matches(matcher);
-		
+
 		//Then
 		System.Assert.isTrue(fflib_Match.Matching);
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesWithOneMatcherRegistersMatcher()
 	{
 		//Given
 		fflib_IMatcher matcher = new AlwaysMatch();
-		
+
 		//When
 		fflib_Match.matches(matcher);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
-		
+
 		System.Assert.areNotEqual(null, registeredMatchers);
 		System.Assert.areEqual(1, registeredMatchers.size());
 		System.Assert.areEqual(matcher, registeredMatchers[0]);
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void whenMatchesWithOneMatcherReturnsNull()
 	{
 		//Given
 		fflib_IMatcher matcher = new AlwaysMatch();
-		
+
 		//When
 		Object retval = fflib_Match.matches(matcher);
-		
+
 		//Then
 		System.Assert.areEqual(null, retval);
 	}
 
-	@isTest
+	@IsTest
 	private static void allOfWithNoArgsThrowsException()
 	{
 		//Given/When
 		try
 		{
-			Object x = fflib_Match.allOf((List<Object>)null);
+			Object x = fflib_Match.allOf((List<Object>) null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -272,7 +240,7 @@ public with sharing class fflib_MatchTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void allOfWithEmptyArgsThrowsException()
 	{
 		//Given/When
@@ -288,7 +256,7 @@ public with sharing class fflib_MatchTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void allOfWithoutRegisteringInnerMatchersThrowsException()
 	{
 		//Given/When
@@ -302,18 +270,17 @@ public with sharing class fflib_MatchTest
 		catch (fflib_ApexMocks.ApexMocksException e)
 		{
 			//Then
-			String expectedMessage = 'Error reclaiming inner matchers for combined matcher. '
-				+ 'Wanted 1 matchers but only got ' + new List<fflib_IMatcher>();
+			String expectedMessage = 'Error reclaiming inner matchers for combined matcher. ' + 'Wanted 1 matchers but only got ' + new List<fflib_IMatcher>();
 			System.Assert.areEqual(expectedMessage, e.getMessage());
 		}
 	}
-	
-	@isTest
+
+	@IsTest
 	private static void allOfWith2ArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.allOf(fflib_Match.eq('hello1'), fflib_Match.eq('hello2'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -321,12 +288,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void allOfWith3ArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.allOf(fflib_Match.eq('hello1'), fflib_Match.eq('hello2'), fflib_Match.eq('hello3'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -334,12 +301,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void allOfWith4ArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.allOf(fflib_Match.eq('hello1'), fflib_Match.eq('hello2'), fflib_Match.eq('hello3'), fflib_Match.eq('hello4'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -347,12 +314,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void allOfWithListArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.allOf(new List<Object>{ fflib_Match.eq('hello') });
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -360,12 +327,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyOfWith2ArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.anyOf(fflib_Match.eq('hello1'), fflib_Match.eq('hello2'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -373,12 +340,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyOfWith3ArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.anyOf(fflib_Match.eq('hello1'), fflib_Match.eq('hello2'), fflib_Match.eq('hello3'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -386,12 +353,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyOfWith4ArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.anyOf(fflib_Match.eq('hello1'), fflib_Match.eq('hello2'), fflib_Match.eq('hello3'), fflib_Match.eq('hello4'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -399,12 +366,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyOfWithListArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.anyOf(new List<Object>{ fflib_Match.eq('hello') });
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -412,12 +379,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void isNotRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.isNot(fflib_Match.eq('hello1'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -425,12 +392,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void noneOfWith2ArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.noneOf(fflib_Match.eq('hello1'), fflib_Match.eq('hello2'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -438,12 +405,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void noneOfWith3ArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.noneOf(fflib_Match.eq('hello1'), fflib_Match.eq('hello2'), fflib_Match.eq('hello3'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -451,12 +418,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void noneOfWith4ArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.noneOf(fflib_Match.eq('hello1'), fflib_Match.eq('hello2'), fflib_Match.eq('hello3'), fflib_Match.eq('hello4'));
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -464,12 +431,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void noneOfWithListArgsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.noneOf(new List<Object>{ fflib_Match.eq('hello') });
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -477,12 +444,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Combined.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void eqRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eq('hello');
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -490,12 +457,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqBooleanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqBoolean(true);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -503,12 +470,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqDateRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqDate(Date.today());
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -516,12 +483,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqDatetimeRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqDatetime(System.now());
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -529,12 +496,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqDecimalRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqDecimal(123);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -542,12 +509,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqDoubleRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqDouble(123);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -555,12 +522,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqIdRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqId('001000000000001AAA');
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -568,12 +535,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqIntegerRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqInteger(123);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -581,12 +548,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqListRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqList(new List<String>{ 'hello' });
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -594,12 +561,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqLongRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqLong(123);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -607,13 +574,13 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqSObjectFieldRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Schema.SObjectField f = Schema.getGlobalDescribe().get('Account').getDescribe().fields.getMap().get('Id');
 		Object x = fflib_Match.eqSObjectField(f);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -621,13 +588,13 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqSObjectTypeRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Schema.SObjectType ot = Schema.getGlobalDescribe().get('Account');
 		Object x = fflib_Match.eqSObjectType(ot);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -635,12 +602,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	public static void eqStringRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.eqString('hello');
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -648,12 +615,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.Eq.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void refEqRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.refEq('hello');
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -661,12 +628,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.RefEq.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyBooleanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Boolean x = fflib_Match.anyBoolean();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -674,12 +641,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyBoolean.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyDateRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Date x = fflib_Match.anyDate();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -687,12 +654,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyDate.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyDatetimeRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Datetime x = fflib_Match.anyDatetime();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -700,12 +667,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyDatetime.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyDecimalRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Decimal x = fflib_Match.anyDecimal();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -713,12 +680,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyDecimal.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyDoubleRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Double x = fflib_Match.anyDouble();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -726,12 +693,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyDouble.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyFieldSetRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Schema.FieldSet x = fflib_Match.anyFieldSet();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -739,12 +706,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyFieldSet.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyIdRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Id x = fflib_Match.anyId();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -752,12 +719,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyId.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyIntegerRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Integer x = fflib_Match.anyInteger();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -765,12 +732,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyInteger.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyListRegistersCorrectMatcherType()
 	{
 		//Given/When
 		List<Object> x = fflib_Match.anyList();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -778,12 +745,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyList.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyLongRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Long x = fflib_Match.anyLong();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -791,12 +758,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyLong.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyObjectRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.anyObject();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -804,12 +771,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyObject.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anyStringRegistersCorrectMatcherType()
 	{
 		//Given/When
 		String x = fflib_Match.anyString();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -817,12 +784,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnyString.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anySObjectRegistersCorrectMatcherType()
 	{
 		//Given/When
 		SObject x = fflib_Match.anySObject();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -830,12 +797,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnySObject.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anySObjectFieldRegistersCorrectMatcherType()
 	{
 		//Given/When
 		SObjectField x = fflib_Match.anySObjectField();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -843,12 +810,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnySObjectField.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void anySObjectTypeRegistersCorrectMatcherType()
 	{
 		//Given/When
 		SObjectType x = fflib_Match.anySObjectType();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -856,7 +823,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.AnySObjectType.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void dateAfterRegistersCorrectMatcherType()
 	{
 		//Given/When
@@ -869,7 +836,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DatetimeAfter.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void dateBeforeRegistersCorrectMatcherType()
 	{
 		//Given/When
@@ -882,7 +849,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DatetimeBefore.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void dateBetweenRegistersCorrectMatcherType()
 	{
 		//Given/When
@@ -895,7 +862,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DatetimeBetween.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void datetimeAfterRegistersCorrectMatcherType()
 	{
 		//Given/When
@@ -908,7 +875,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DatetimeAfter.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void datetimeBeforeRegistersCorrectMatcherType()
 	{
 		//Given/When
@@ -921,7 +888,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DatetimeBefore.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void datetimeBetweenRegistersCorrectMatcherType()
 	{
 		//Given/When
@@ -934,12 +901,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DatetimeBetween.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void decimalBetweenRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Decimal x = fflib_Match.decimalBetween(0, 10);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -947,12 +914,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalBetween.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void decimalLessThanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Decimal x = fflib_Match.decimalLessThan(0);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -960,12 +927,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalLessThan.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void decimalMoreThanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Decimal x = fflib_Match.decimalMoreThan(0);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -973,12 +940,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalMoreThan.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void doubleBetweenRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Double x = fflib_Match.doubleBetween(0, 10);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -986,12 +953,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalBetween.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void doubleLessThanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Double x = fflib_Match.doubleLessThan(0);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -999,12 +966,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalLessThan.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void doubleMoreThanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Double x = fflib_Match.doubleMoreThan(0);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1012,7 +979,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalMoreThan.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void fieldSetEquivalentWithNullFieldSetThrowsException()
 	{
 		try
@@ -1026,7 +993,7 @@ public with sharing class fflib_MatchTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void fieldSetEquivalentToRegistersCorrectMatcherType()
 	{
 		Schema.FieldSet anyFieldSet = fflib_ApexMocksUtilsTest.findAnyFieldSet();
@@ -1037,7 +1004,7 @@ public with sharing class fflib_MatchTest
 
 		//Given/When
 		Schema.FieldSet x = fflib_Match.fieldSetEquivalentTo(anyFieldSet);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1045,12 +1012,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.FieldSetEquivalentTo.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void integerBetweenRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Integer x = fflib_Match.integerBetween(0, 10);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1058,12 +1025,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalBetween.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void integerLessThanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Integer x = fflib_Match.integerLessThan(0);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1071,12 +1038,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalLessThan.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void integerMoreThanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Integer x = fflib_Match.integerMoreThan(0);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1084,12 +1051,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalMoreThan.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void isNotNullRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.isNotNull();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1097,12 +1064,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.IsNotNull.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void isNullRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.isNull();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1110,12 +1077,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.IsNull.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void listContainsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.listContains('fred');
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1123,12 +1090,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.ListContains.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void listIsEmptyRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Object x = fflib_Match.listIsEmpty();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1136,12 +1103,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.ListIsEmpty.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void longBetweenRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Long x = fflib_Match.longBetween(0, 10);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1149,12 +1116,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalBetween.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void longLessThanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Long x = fflib_Match.longLessThan(0);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1162,12 +1129,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalLessThan.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void longMoreThanRegistersCorrectMatcherType()
 	{
 		//Given/When
 		Long x = fflib_Match.longMoreThan(0);
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1175,7 +1142,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.DecimalMoreThan.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void sObjectOfTypeRegistersCorrectMatcherType()
 	{
 		//Given
@@ -1195,7 +1162,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.SObjectOfType.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void sObjectWithRegistersCorrectMatcherType()
 	{
 		//Given
@@ -1208,7 +1175,7 @@ public with sharing class fflib_MatchTest
 		Schema.SObjectField f = ot.getDescribe().fields.getMap().get('Id');
 
 		//When
-		SObject x = fflib_Match.sObjectWith(new Map<Schema.SObjectField, Object>{ f=>null });
+		SObject x = fflib_Match.sObjectWith(new Map<Schema.SObjectField, Object>{ f => null });
 
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
@@ -1217,7 +1184,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.SObjectWith.class);
 	}
 
-    @isTest
+	@IsTest
 	private static void sObjectsWithRegistersCorrectMatcherType()
 	{
 		//Given
@@ -1230,9 +1197,7 @@ public with sharing class fflib_MatchTest
 		Schema.SObjectField f = ot.getDescribe().fields.getMap().get('Id');
 
 		//When
-		SObject[] x = fflib_Match.sObjectsWith(new list<Map<Schema.SObjectField, Object>>{ 
-            new map<Schema.SObjectField,Object> {f=>null}
-        	});
+		SObject[] x = fflib_Match.sObjectsWith(new list<Map<Schema.SObjectField, Object>>{ new map<Schema.SObjectField, Object>{ f => null } });
 
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
@@ -1241,7 +1206,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.SObjectsWith.class);
 	}
 
-    @isTest
+	@IsTest
 	private static void sObjectsWithMatchInOrderRegistersCorrectMatcherType()
 	{
 		//Given
@@ -1254,9 +1219,7 @@ public with sharing class fflib_MatchTest
 		Schema.SObjectField f = ot.getDescribe().fields.getMap().get('Id');
 
 		//When
-		SObject[] x = fflib_Match.sObjectsWith(new list<Map<Schema.SObjectField, Object>>{ 
-            new map<Schema.SObjectField,Object> {f=>null}
-        	}, false);
+		SObject[] x = fflib_Match.sObjectsWith(new list<Map<Schema.SObjectField, Object>>{ new map<Schema.SObjectField, Object>{ f => null } }, false);
 
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
@@ -1264,8 +1227,8 @@ public with sharing class fflib_MatchTest
 		System.Assert.areEqual(1, registeredMatchers.size());
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.SObjectsWith.class, String.valueOf(registeredMatchers));
 	}
-    
-	@isTest
+
+	@IsTest
 	private static void sObjectWithIdRegistersCorrectMatcherType()
 	{
 		//Given/When
@@ -1278,7 +1241,7 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.SObjectWithId.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void sObjectWithNameRegistersCorrectMatcherType()
 	{
 		//Given/When
@@ -1291,12 +1254,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.SObjectWithName.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void stringContainsRegistersCorrectMatcherType()
 	{
 		//Given/When
 		String x = fflib_Match.stringContains('hello');
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1304,12 +1267,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.StringContains.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void stringEndsWithRegistersCorrectMatcherType()
 	{
 		//Given/When
 		String x = fflib_Match.stringEndsWith('hello');
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1317,12 +1280,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.StringEndsWith.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void stringIsBlankRegistersCorrectMatcherType()
 	{
 		//Given/When
 		String x = fflib_Match.stringIsBlank();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1330,12 +1293,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.StringIsBlank.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void stringIsNotBlankRegistersCorrectMatcherType()
 	{
 		//Given/When
 		String x = fflib_Match.stringIsNotBlank();
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1343,12 +1306,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.StringIsNotBlank.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void stringMatchesRegistersCorrectMatcherType()
 	{
 		//Given/When
 		String x = fflib_Match.stringMatches('[a-z]*');
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1356,12 +1319,12 @@ public with sharing class fflib_MatchTest
 		System.Assert.isInstanceOfType(registeredMatchers[0], fflib_MatcherDefinitions.StringMatches.class);
 	}
 
-	@isTest
+	@IsTest
 	private static void stringStartsWithRegistersCorrectMatcherType()
 	{
 		//Given/When
 		String x = fflib_Match.stringStartsWith('hello');
-		
+
 		//Then
 		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
 		System.Assert.areNotEqual(null, registeredMatchers);
@@ -1376,7 +1339,7 @@ public with sharing class fflib_MatchTest
 			return true;
 		}
 	}
-	
+
 	private class NeverMatch implements fflib_IMatcher
 	{
 		public Boolean matches(Object arg)

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatchTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatchTest.cls
@@ -1,28 +1,28 @@
 /**
-* Copyright (c) 2014-2016, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014-2016, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @IsTest
 public with sharing class fflib_MatchTest
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
@@ -1,28 +1,28 @@
 /**
-* Copyright (c) 2014-2016, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014-2016, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @IsTest
 public class fflib_MatcherDefinitionsTest
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MatcherDefinitionsTest.cls
@@ -1,36 +1,32 @@
 /**
- * Copyright (c) 2014-2016, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
- @isTest
+* Copyright (c) 2014-2016, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+@IsTest
 public class fflib_MatcherDefinitionsTest
 {
-	private static final List<fflib_IMatcher> INTERNAL_MATCHERS = new List<fflib_IMatcher>{
-																new fflib_MatcherDefinitions.StringContains('bob'),
-																new fflib_MatcherDefinitions.StringContains('tom'),
-																new fflib_MatcherDefinitions.StringContains('fred')
-															};
+	private static final List<fflib_IMatcher> INTERNAL_MATCHERS = new List<fflib_IMatcher>{ new fflib_MatcherDefinitions.StringContains('bob'), new fflib_MatcherDefinitions.StringContains('tom'), new fflib_MatcherDefinitions.StringContains('fred') };
 
 	private static final Date TODAY = System.today();
 	private static final Datetime NOW = System.now();
@@ -40,7 +36,7 @@ public class fflib_MatcherDefinitionsTest
 	private static final Schema.SObjectType OPPORTUNITY_OBJECT_TYPE;
 	private static final Schema.SobjectType GROUP_OBJECT_TYPE;
 	private static final Sobject[] GROUP_RECORDS;
-	
+
 	static
 	{
 		Map<String, Schema.SObjectType> globalDescribe = Schema.getGlobalDescribe();
@@ -48,21 +44,21 @@ public class fflib_MatcherDefinitionsTest
 		ACCOUNT_OBJECT_TYPE = globalDescribe.get('Account');
 		OPPORTUNITY_OBJECT_TYPE = globalDescribe.get('Opportunity');
 		GROUP_OBJECT_TYPE = globalDescribe.get('Group');
-		
+
 		SObject accountRecord = ACCOUNT_OBJECT_TYPE.newSObject();
 		accountRecord.put('Name', 'MatcherDefinitionTestAccount' + System.now());
 		accountRecord.Id = fflib_IDGenerator.generate(Account.SObjectType);
 		ACCOUNT_RECORD = accountRecord;
-        
-		GROUP_RECORDS = new list<Group> {
-			new Group(Name = 'MatcherDefnTestGroup0'+System.now(), DeveloperName='MatcherDefnTestGroup0'+System.now().getTime(),Type='Queue'),
-			new Group(Name = 'MatcherDefnTestGroup1'+System.now(), DeveloperName='MatcherDefnTestGroup1'+System.now().getTime(),Type='Queue')
-		};
-		insert GROUP_RECORDS;    
-        
+
+		GROUP_RECORDS =
+			new list<Group>{
+				new Group(Name = 'MatcherDefnTestGroup0' + System.now(), DeveloperName = 'MatcherDefnTestGroup0' + System.now().getTime(), Type = 'Queue'),
+				new Group(Name = 'MatcherDefnTestGroup1' + System.now(), DeveloperName = 'MatcherDefnTestGroup1' + System.now().getTime(), Type = 'Queue')
+			};
+		insert GROUP_RECORDS;
 	}
 
-	@isTest
+	@IsTest
 	private static void whenConstructingCombinedWithNullConnectiveExpressionShouldThrowException()
 	{
 		try
@@ -76,7 +72,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenConstructingCombinedWithNullInternalMatchersShouldThrowException()
 	{
 		try
@@ -90,7 +86,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenConstructingCombinedWithEmptyInternalMatchersShouldThrowException()
 	{
 		try
@@ -104,7 +100,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenCombinedMatchesWithAllExpressionShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.ALL, INTERNAL_MATCHERS);
@@ -115,7 +111,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches('bobtomfred'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenCombinedMatchesWithAtLeastOneExpressionShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.AT_LEAST_ONE, INTERNAL_MATCHERS);
@@ -126,7 +122,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches('bobtomfred'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenCombinedMatchesWithNoneExpressionShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.NONE, INTERNAL_MATCHERS);
@@ -137,35 +133,22 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isFalse(matcher.matches('bobtomfred'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenCombinedMatcherToStringReturnsExpectedString()
 	{
-		List<fflib_IMatcher> innerMatchers = new List<fflib_IMatcher>{
-			new StringMatcher('one'),
-			new StringMatcher('two'),
-			new StringMatcher('three')
-		};
+		List<fflib_IMatcher> innerMatchers = new List<fflib_IMatcher>{ new StringMatcher('one'), new StringMatcher('two'), new StringMatcher('three') };
 
-		System.Assert.areEqual(
-			'[any of: "one", "two", "three"]',
-			'' + new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.AT_LEAST_ONE, innerMatchers)
-		);
-		System.Assert.areEqual(
-			'[all of: "one", "two", "three"]',
-			'' + new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.ALL, innerMatchers)
-		);
-		System.Assert.areEqual(
-			'[none of: "one", "two", "three"]',
-			'' + new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.NONE, innerMatchers)
-		);
+		System.Assert.areEqual('[any of: "one", "two", "three"]', '' + new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.AT_LEAST_ONE, innerMatchers));
+		System.Assert.areEqual('[all of: "one", "two", "three"]', '' + new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.ALL, innerMatchers));
+		System.Assert.areEqual('[none of: "one", "two", "three"]', '' + new fflib_MatcherDefinitions.Combined(fflib_MatcherDefinitions.Connective.NONE, innerMatchers));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructEq_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.Eq(null);	
+			new fflib_MatcherDefinitions.Eq(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -174,30 +157,30 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenEqMatchesShouldReturnCorrectResults()
 	{
-		List<String> s1 = new List<String> {'bob', 'tom'};
-		List<String> s2 = new List<String> {'bob', 'tom'};
+		List<String> s1 = new List<String>{ 'bob', 'tom' };
+		List<String> s2 = new List<String>{ 'bob', 'tom' };
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.Eq(s1);
 		System.Assert.isFalse(matcher.matches(null));
-		System.Assert.isFalse(matcher.matches(new List<String> {'bob'}));
+		System.Assert.isFalse(matcher.matches(new List<String>{ 'bob' }));
 		System.Assert.isTrue(matcher.matches(s2));
 		System.Assert.isTrue(matcher.matches(s1));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenEqToStringShouldReturnExpectedString()
 	{
 		System.Assert.areEqual('[equals 1]', '' + new fflib_MatcherDefinitions.Eq(1));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructRefEq_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.RefEq(null);	
+			new fflib_MatcherDefinitions.RefEq(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -206,25 +189,25 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenRefEqMatchesShouldReturnCorrectResults()
 	{
-		List<String> s1 = new List<String> {'bob', 'tom'};
-		List<String> s2 = new List<String> {'bob', 'tom'};
+		List<String> s1 = new List<String>{ 'bob', 'tom' };
+		List<String> s2 = new List<String>{ 'bob', 'tom' };
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.RefEq(s1);
 		System.Assert.isFalse(matcher.matches(null));
 		System.Assert.isFalse(matcher.matches(s2));
 		System.Assert.isTrue(matcher.matches(s1));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenRefEqToStringReturnsExpectedString()
 	{
-        List<String> s1 = new List<String> {'bob', 'tom'};
+		List<String> s1 = new List<String>{ 'bob', 'tom' };
 		System.Assert.areEqual('[reference equals ' + JSON.serialize(s1, false) + ']', '' + new fflib_MatcherDefinitions.RefEq(s1));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyBooleanMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyBoolean();
@@ -234,13 +217,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(false));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyBooleanToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any Boolean]', '' + new fflib_MatcherDefinitions.AnyBoolean());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyDateMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyDate();
@@ -249,13 +232,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(TODAY));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyDateToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any Date]', '' + new fflib_MatcherDefinitions.AnyDate());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyDatetimeMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyDatetime();
@@ -264,13 +247,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(TODAY));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyDatetimeToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any DateTime]', '' + new fflib_MatcherDefinitions.AnyDatetime());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyDecimalMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyDecimal();
@@ -281,13 +264,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(9.99));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyDecimalToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any Decimal]', '' + new fflib_MatcherDefinitions.AnyDecimal());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyDoubleMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyDouble();
@@ -298,13 +281,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(9.99));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyDoubleToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any Double]', '' + new fflib_MatcherDefinitions.AnyDouble());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyFieldSetMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyFieldSet();
@@ -318,13 +301,13 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyFieldSetToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any FieldSet]', '' + new fflib_MatcherDefinitions.AnyFieldSet());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyIdMatchesShouldReturnCorrectResults()
 	{
 		String idString = fflib_IDGenerator.generate(Account.SObjectType);
@@ -336,13 +319,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(accountId));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyIdToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any Id]', '' + new fflib_MatcherDefinitions.AnyId());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyIntegerMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyInteger();
@@ -353,13 +336,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(9));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyIntegerToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any Integer]', '' + new fflib_MatcherDefinitions.AnyInteger());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyListMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyList();
@@ -370,13 +353,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(new List<Object>()));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyListToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any list]', '' + new fflib_MatcherDefinitions.AnyList());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyLongMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyLong();
@@ -387,13 +370,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(9L));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyLongToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any Long]', '' + new fflib_MatcherDefinitions.AnyLong());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyObjectMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyObject();
@@ -403,13 +386,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(new List<String>()));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyObjectToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any Object]', '' + new fflib_MatcherDefinitions.AnyObject());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyStringMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnyString();
@@ -418,13 +401,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches('bob'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnyStringToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any String]', '' + new fflib_MatcherDefinitions.AnyString());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnySObjectMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnySObject();
@@ -433,13 +416,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(new Account()));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnySObjectToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any SObject]', '' + new fflib_MatcherDefinitions.AnySObject());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnySObjectFieldMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnySObjectField();
@@ -448,13 +431,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(Account.Id));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnySObjectFieldToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any SObjectField]', '' + new fflib_MatcherDefinitions.AnySObjectField());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnySObjectTypeMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.AnySObjectType();
@@ -463,18 +446,18 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(Account.SObjectType));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenAnySObjectTypeToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[any SObjectType]', '' + new fflib_MatcherDefinitions.AnySObjectType());
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDatetimeAfter_WithNullFromDatetime_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DatetimeAfter(null, true);	
+			new fflib_MatcherDefinitions.DatetimeAfter(null, true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -483,12 +466,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDatetimeAfter_WithNullInclusive_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DatetimeAfter(System.now(), null);	
+			new fflib_MatcherDefinitions.DatetimeAfter(System.now(), null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -497,7 +480,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeAfterMatchesWithoutInclusiveShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeAfter(NOW, false);
@@ -508,7 +491,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(NOW.addSeconds(1)));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeAfterMatchesWithInclusiveShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeAfter(NOW, true);
@@ -519,7 +502,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(NOW.addSeconds(1)));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeAfterWithInclusiveToStringReturnsExpectedString()
 	{
 		// Given
@@ -533,7 +516,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.areEqual('[on or after "2019-01-01T12:00:00.000Z"]', actual);
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeAfterWithNotInclusiveToStringReturnsExpectedString()
 	{
 		// Given
@@ -547,12 +530,12 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.areEqual('[after "2019-01-01T12:00:00.000Z"]', actual);
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDatetimeBefore_WithNullToDatetime_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DatetimeBefore(null, true);	
+			new fflib_MatcherDefinitions.DatetimeBefore(null, true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -561,12 +544,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDatetimeBefore_WithNullInclusive_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DatetimeBefore(System.now(), null);	
+			new fflib_MatcherDefinitions.DatetimeBefore(System.now(), null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -575,7 +558,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeBeforeMatchesWithoutInclusiveShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeBefore(NOW, false);
@@ -586,7 +569,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(NOW.addSeconds(-1)));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeBeforeMatchesWithInclusiveShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeBefore(NOW, true);
@@ -597,7 +580,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(NOW.addSeconds(-1)));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeBeforeWithInclusiveToStringReturnsExpectedString()
 	{
 		// Given
@@ -611,7 +594,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.areEqual('[on or before "2019-01-01T12:00:00.000Z"]', actual);
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeBeforeWithNotInclusiveToStringReturnsExpectedString()
 	{
 		// Given
@@ -625,12 +608,12 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.areEqual('[before "2019-01-01T12:00:00.000Z"]', actual);
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDatetimeBetween_WithNullFromDatetime_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DatetimeBetween(null, true, System.now(), true);	
+			new fflib_MatcherDefinitions.DatetimeBetween(null, true, System.now(), true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -639,12 +622,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDatetimeBetween_WithNullToDatetime_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DatetimeBetween(System.now(), true, null, true);	
+			new fflib_MatcherDefinitions.DatetimeBetween(System.now(), true, null, true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -653,12 +636,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDatetimeBetween_WithNullInclusiveFrom_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DatetimeBetween(System.now(), null, System.now(), true);	
+			new fflib_MatcherDefinitions.DatetimeBetween(System.now(), null, System.now(), true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -667,12 +650,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDatetimeBetween_WithNullInclusiveTo_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DatetimeBetween(System.now(), true, System.now(), null);	
+			new fflib_MatcherDefinitions.DatetimeBetween(System.now(), true, System.now(), null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -681,7 +664,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeBetweenMatchesWithInclusiveFromWithoutInclusiveToShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeBetween(NOW.addSeconds(-1), true, NOW.addSeconds(1), false);
@@ -693,7 +676,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(NOW));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeBetweenMatchesWithInclusiveToWithoutInclusiveFromShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.DatetimeBetween(NOW.addSeconds(-1), false, NOW.addSeconds(1), true);
@@ -705,7 +688,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(NOW.addSeconds(1)));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeBetweenWithInclusiveToStringReturnsExpectedString()
 	{
 		// Given
@@ -720,7 +703,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.areEqual('[on or after "2019-01-01T12:00:00.000Z" and on or before "2019-01-03T12:00:00.000Z"]', actual);
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDatetimeBetweenWithNotInclusiveToStringReturnsExpectedString()
 	{
 		// Given
@@ -735,12 +718,12 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.areEqual('[after "2019-01-01T12:00:00.000Z" and before "2019-01-03T12:00:00.000Z"]', actual);
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDecimalBetween_WithNullLower_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DecimalBetween(null, true, 123, true);	
+			new fflib_MatcherDefinitions.DecimalBetween(null, true, 123, true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -749,12 +732,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDecimalBetween_WithNullInclusiveLower_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DecimalBetween(123, null, 123, true);	
+			new fflib_MatcherDefinitions.DecimalBetween(123, null, 123, true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -763,12 +746,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDecimalBetween_WithNullUpper_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DecimalBetween(123, true, null, true);	
+			new fflib_MatcherDefinitions.DecimalBetween(123, true, null, true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -777,12 +760,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDecimalBetween_WithNullInclusiveUpper_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DecimalBetween(123, true, 123, null);	
+			new fflib_MatcherDefinitions.DecimalBetween(123, true, 123, null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -791,7 +774,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDecimalBetweenMatchesShouldReturnCorrectResults()
 	{
 		Integer lower = 5;
@@ -821,7 +804,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isFalse(exLowerInUpper.matches(upper + 1));
 		System.Assert.isFalse(exLowerInUpper.matches(null));
 		System.Assert.isFalse(exLowerInUpper.matches('NotADecimal'));
-		
+
 		//Inclusive lower, exclusive upper
 		System.Assert.isFalse(inLowerExUpper.matches(lower - 1));
 		System.Assert.isTrue(inLowerExUpper.matches(lower));
@@ -831,7 +814,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isFalse(inLowerExUpper.matches(upper + 1));
 		System.Assert.isFalse(inLowerExUpper.matches(null));
 		System.Assert.isFalse(inLowerExUpper.matches('NotADecimal'));
-		
+
 		//Inclusive lower, inclusive upper
 		System.Assert.isFalse(inLowerInUpper.matches(lower - 1));
 		System.Assert.isTrue(inLowerInUpper.matches(lower));
@@ -843,30 +826,26 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isFalse(inLowerInUpper.matches('NotADecimal'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDecimalBetweenToStringReturnsExpectedString()
 	{
 		Integer lower = 5;
 		Integer upper = 10;
 
-		List<Integer> formatList = new List<Integer>{lower, upper};
+		List<Integer> formatList = new List<Integer>{ lower, upper };
 
-		System.Assert.areEqual(String.format('greater than {0} and less than {1}', formatList),
-			'' + new fflib_MatcherDefinitions.DecimalBetween(lower, false, upper, false));
-		System.Assert.areEqual(String.format('greater than {0} and less than or equal to {1}', formatList),
-			'' + new fflib_MatcherDefinitions.DecimalBetween(lower, false, upper, true));
-		System.Assert.areEqual(String.format('greater than or equal to {0} and less than {1}', formatList),
-			'' + new fflib_MatcherDefinitions.DecimalBetween(lower, true, upper, false));
-		System.Assert.areEqual(String.format('greater than or equal to {0} and less than or equal to {1}', formatList),
-			'' + new fflib_MatcherDefinitions.DecimalBetween(lower, true, upper, true));
+		System.Assert.areEqual(String.format('greater than {0} and less than {1}', formatList), '' + new fflib_MatcherDefinitions.DecimalBetween(lower, false, upper, false));
+		System.Assert.areEqual(String.format('greater than {0} and less than or equal to {1}', formatList), '' + new fflib_MatcherDefinitions.DecimalBetween(lower, false, upper, true));
+		System.Assert.areEqual(String.format('greater than or equal to {0} and less than {1}', formatList), '' + new fflib_MatcherDefinitions.DecimalBetween(lower, true, upper, false));
+		System.Assert.areEqual(String.format('greater than or equal to {0} and less than or equal to {1}', formatList), '' + new fflib_MatcherDefinitions.DecimalBetween(lower, true, upper, true));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDecimalLessThan_WithNullToMatch_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DecimalLessThan(null, true);	
+			new fflib_MatcherDefinitions.DecimalLessThan(null, true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -875,12 +854,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDecimalLessThan_WithNullInclusive_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DecimalLessThan(123, null);	
+			new fflib_MatcherDefinitions.DecimalLessThan(123, null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -889,14 +868,14 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDecimalLessThanMatchesShouldReturnCorrectResults()
 	{
 		Integer toMatch = 5;
 
 		fflib_IMatcher exclusive = new fflib_MatcherDefinitions.DecimalLessThan(toMatch, false);
 		fflib_IMatcher inclusive = new fflib_MatcherDefinitions.DecimalLessThan(toMatch, true);
-		
+
 		//Exclusive
 		System.Assert.isTrue(exclusive.matches(toMatch - 1));
 		System.Assert.isFalse(exclusive.matches(toMatch));
@@ -912,23 +891,21 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isFalse(inclusive.matches('NotADecimal'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDecimalLessThanToStringReturnsExpectedString()
 	{
 		Integer toMatch = 5;
 
-		System.Assert.areEqual('[less than or equal to ' + toMatch + ']',
-			'' + new fflib_MatcherDefinitions.DecimalLessThan(toMatch, true));
-		System.Assert.areEqual('[less than ' + toMatch + ']',
-			'' + new fflib_MatcherDefinitions.DecimalLessThan(toMatch, false));
+		System.Assert.areEqual('[less than or equal to ' + toMatch + ']', '' + new fflib_MatcherDefinitions.DecimalLessThan(toMatch, true));
+		System.Assert.areEqual('[less than ' + toMatch + ']', '' + new fflib_MatcherDefinitions.DecimalLessThan(toMatch, false));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructDecimalMoreThan_WithNullToMatch_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DecimalMoreThan(null, true);	
+			new fflib_MatcherDefinitions.DecimalMoreThan(null, true);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -936,13 +913,13 @@ public class fflib_MatcherDefinitionsTest
 			System.Assert.areEqual('Arg cannot be null: null', e.getMessage());
 		}
 	}
-		
-	@isTest
+
+	@IsTest
 	private static void constructDecimalMoreThan_WithNullInclusive_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.DecimalMoreThan(123, null);	
+			new fflib_MatcherDefinitions.DecimalMoreThan(123, null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -950,15 +927,15 @@ public class fflib_MatcherDefinitionsTest
 			System.Assert.areEqual('Arg cannot be null: null', e.getMessage());
 		}
 	}
-		
-	@isTest
+
+	@IsTest
 	private static void whenDecimalMoreThanMatchesShouldReturnCorrectResults()
 	{
 		Integer toMatch = 5;
 
 		fflib_IMatcher exclusive = new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, false);
 		fflib_IMatcher inclusive = new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, true);
-		
+
 		//Exclusive
 		System.Assert.isFalse(exclusive.matches(toMatch - 1));
 		System.Assert.isFalse(exclusive.matches(toMatch));
@@ -974,23 +951,21 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isFalse(inclusive.matches('NotADecimal'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenDecimalMoreThanToStringReturnsExpectedString()
 	{
 		Integer toMatch = 5;
 
-		System.Assert.areEqual('[greater than or equal to ' + toMatch + ']',
-			'' + new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, true));
-		System.Assert.areEqual('[greater than ' + toMatch + ']',
-			'' + new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, false));
+		System.Assert.areEqual('[greater than or equal to ' + toMatch + ']', '' + new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, true));
+		System.Assert.areEqual('[greater than ' + toMatch + ']', '' + new fflib_MatcherDefinitions.DecimalMoreThan(toMatch, false));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructFieldSetEquivalentTo_WithNullFieldSet_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.FieldSetEquivalentTo(null);	
+			new fflib_MatcherDefinitions.FieldSetEquivalentTo(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -999,7 +974,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenFieldSetEquivalentToWithoutFieldSetShouldNeverMatch()
 	{
 		//Cheap test to maintain 100% code coverage, even in orgs without field sets defined.
@@ -1007,7 +982,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isFalse(matcher.matches(null));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenFieldSetEquivalentToMatchesShouldReturnCorrectResults()
 	{
 		Schema.FieldSet anyFieldSet = fflib_ApexMocksUtilsTest.findAnyFieldSet();
@@ -1022,7 +997,7 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(anyFieldSet));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenFieldSetEquivalentToToStringReturnsExpectedString()
 	{
 		Schema.FieldSet anyFieldSet = fflib_ApexMocksUtilsTest.findAnyFieldSet();
@@ -1032,11 +1007,10 @@ public class fflib_MatcherDefinitionsTest
 		}
 		Set<Schema.FieldSetMember> fieldSetMembers = new Set<Schema.FieldSetMember>((anyFieldSet).getFields());
 
-		System.Assert.areEqual('[FieldSet with fields ' + JSON.serialize(fieldSetMembers, false) + ']',
-			'' + new fflib_MatcherDefinitions.FieldSetEquivalentTo(anyFieldSet));
+		System.Assert.areEqual('[FieldSet with fields ' + JSON.serialize(fieldSetMembers, false) + ']', '' + new fflib_MatcherDefinitions.FieldSetEquivalentTo(anyFieldSet));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenIsNullMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.IsNull();
@@ -1044,13 +1018,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(null));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenIsNullToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[is null]', '' + new fflib_MatcherDefinitions.IsNull());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenIsNotNullMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.IsNotNull();
@@ -1058,18 +1032,18 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches('bob'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenIsNotNullToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[is not null]', '' + new fflib_MatcherDefinitions.IsNotNull());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenListContainsMatchesShouldReturnCorrectResults()
 	{
 		List<String> names = new List<String>{ 'bob', 'tom', 'fred' };
 		List<String> empty = new List<String>();
-		
+
 		System.Assert.isFalse(new fflib_MatcherDefinitions.ListContains('fred').matches(null));
 		System.Assert.isFalse(new fflib_MatcherDefinitions.ListContains('fred').matches(empty));
 		System.Assert.isFalse(new fflib_MatcherDefinitions.ListContains('jack').matches(names));
@@ -1077,38 +1051,38 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isFalse(new fflib_MatcherDefinitions.ListContains('fred').matches('NotAList'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenListContainsToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[list containing "hello"]', '' + new fflib_MatcherDefinitions.ListContains('hello'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenListIsEmptyMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.ListIsEmpty();
-		
+
 		List<String> names = new List<String>{ 'bob', 'tom', 'fred' };
 		List<String> empty = new List<String>();
-		
+
 		System.Assert.isFalse(matcher.matches(null));
 		System.Assert.isFalse(matcher.matches(names));
 		System.Assert.isTrue(matcher.matches(empty));
 		System.Assert.isFalse(matcher.matches('NotAList'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenListIsEmptyToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[empty list]', '' + new fflib_MatcherDefinitions.ListIsEmpty());
 	}
 
-	@isTest
+	@IsTest
 	private static void constructSObjectOfType_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.SObjectOfType(null);	
+			new fflib_MatcherDefinitions.SObjectOfType(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -1117,7 +1091,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectOfTypeMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectOfType(ACCOUNT_OBJECT_TYPE);
@@ -1130,18 +1104,18 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(ACCOUNT_RECORD));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectOfTypeToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[SObject of type Account]', '' + new fflib_MatcherDefinitions.SObjectOfType(ACCOUNT_OBJECT_TYPE));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructSObjectWith_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.SObjectWith(null);	
+			new fflib_MatcherDefinitions.SObjectWith(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -1150,12 +1124,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructSObjectWith_WithEmptyArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.SObjectWith(new Map<Schema.SObjectField, Object>());	
+			new fflib_MatcherDefinitions.SObjectWith(new Map<Schema.SObjectField, Object>());
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -1164,27 +1138,20 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectWithMatchesShouldReturnCorrectResults()
 	{
 		Map<String, Schema.SObjectField> fields = ACCOUNT_OBJECT_TYPE.getDescribe().fields.getMap();
 		Schema.SObjectField idField = fields.get('Id');
 		Schema.SObjectField nameField = fields.get('Name');
 		Schema.SObjectField createdDateField = fields.get('CreatedDate');
-		
-		Map<Schema.SObjectField, Object> queriedFieldValues = new Map<Schema.SObjectField, Object>
-		{
-			idField => ACCOUNT_RECORD.Id,
-			nameField => ACCOUNT_RECORD.get('Name')
-		};
 
-		Map<Schema.SObjectField, Object> notQueriedFieldValues = new Map<Schema.SObjectField, Object>
-		{
-			createdDateField => System.now()
-		};
+		Map<Schema.SObjectField, Object> queriedFieldValues = new Map<Schema.SObjectField, Object>{ idField => ACCOUNT_RECORD.Id, nameField => ACCOUNT_RECORD.get('Name') };
+
+		Map<Schema.SObjectField, Object> notQueriedFieldValues = new Map<Schema.SObjectField, Object>{ createdDateField => System.now() };
 
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectWith(queriedFieldValues);
-		
+
 		System.Assert.isFalse(matcher.matches(null));
 		System.Assert.isFalse(matcher.matches(OPPORTUNITY_OBJECT_TYPE.newSObject()));
 		System.Assert.isFalse(matcher.matches(ACCOUNT_OBJECT_TYPE.newSObject()));
@@ -1195,177 +1162,102 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isFalse(new fflib_MatcherDefinitions.SObjectWith(notQueriedFieldValues).matches(ACCOUNT_RECORD));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectWithToStringReturnsExpectedString()
 	{
-		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectWith(new Map<Schema.SObjectField, Object>{
-			Account.Name => 'Test'
-		});
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectWith(new Map<Schema.SObjectField, Object>{ Account.Name => 'Test' });
 		System.Assert.areEqual('[SObject with fields {"Name":"Test"}]', '' + matcher);
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectsWithInOrderMatchesShouldReturnCorrectResults()
 	{
 		Map<String, Schema.SObjectField> fields = GROUP_OBJECT_TYPE.getDescribe().fields.getMap();
 		Schema.SObjectField idField = fields.get('Id');
 		Schema.SObjectField nameField = fields.get('Name');
 		Schema.SObjectField createdDateField = fields.get('CreatedDate');
-		
-		list<Map<Schema.SObjectField, Object>> queriedFieldValues = new list<Map<Schema.SObjectField, Object>>
-		{
-            new map<Schema.SObjectField,Object> 
-            {
-                idField => GROUP_RECORDS[0].Id,
-				nameField => GROUP_RECORDS[0].get('Name')
-            },
-            new map<Schema.SObjectField,Object> 
-            {
-                idField => GROUP_RECORDS[1].Id,
-				nameField => GROUP_RECORDS[1].get('Name')
-            }               
-		};
 
-		list<Map<Schema.SObjectField, Object>> failingFieldValues = new list<Map<Schema.SObjectField, Object>>
-		{
-			new map<Schema.SObjectField,Object>
-			{
-				idField => GROUP_RECORDS[0].Id,
-				nameField => GROUP_RECORDS[0].get('Name')
-			},
-			new map<Schema.SObjectField,Object>
-			{
-				idField => GROUP_RECORDS[1].Id,
-				nameField => GROUP_RECORDS[1].get('Name') + 'test'
-			}
-		};
+		list<Map<Schema.SObjectField, Object>> queriedFieldValues =
+			new list<Map<Schema.SObjectField, Object>>{
+				new map<Schema.SObjectField, Object>{ idField => GROUP_RECORDS[0].Id, nameField => GROUP_RECORDS[0].get('Name') },
+				new map<Schema.SObjectField, Object>{ idField => GROUP_RECORDS[1].Id, nameField => GROUP_RECORDS[1].get('Name') }
+			};
 
-		list<Map<Schema.SObjectField, Object>> notQueriedFieldValues = new list<Map<Schema.SObjectField, Object>>
-		{
-			new map<Schema.SObjectField,Object> 
-            {
-                createdDateField => System.now()
-            },
-            new map<Schema.SObjectField,Object> 
-            {
-                createdDateField => System.now()
-            }    
-		};
+		list<Map<Schema.SObjectField, Object>> failingFieldValues =
+			new list<Map<Schema.SObjectField, Object>>{
+				new map<Schema.SObjectField, Object>{ idField => GROUP_RECORDS[0].Id, nameField => GROUP_RECORDS[0].get('Name') },
+				new map<Schema.SObjectField, Object>{ idField => GROUP_RECORDS[1].Id, nameField => GROUP_RECORDS[1].get('Name') + 'test' }
+			};
+
+		list<Map<Schema.SObjectField, Object>> notQueriedFieldValues =
+			new list<Map<Schema.SObjectField, Object>>{ new map<Schema.SObjectField, Object>{ createdDateField => System.now() }, new map<Schema.SObjectField, Object>{ createdDateField => System.now() } };
 
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectsWith(queriedFieldValues);
-		
+
 		System.Assert.isFalse(matcher.matches(null));
-		System.Assert.isFalse(matcher.matches(new list<SObject>
-                                       {
-                                           OPPORTUNITY_OBJECT_TYPE.newSObject(),
-                                           OPPORTUNITY_OBJECT_TYPE.newSObject()    
-                                       }
-                                      ));
-		System.Assert.isFalse(matcher.matches(new list<SObject>
-                                       {
-                                           GROUP_OBJECT_TYPE.newSObject(),
-                                           GROUP_OBJECT_TYPE.newSObject()
-                                       }
-                                      ),'sObjectsWith arity agrees but arg doesn\'t');
+		System.Assert.isFalse(matcher.matches(new list<SObject>{ OPPORTUNITY_OBJECT_TYPE.newSObject(), OPPORTUNITY_OBJECT_TYPE.newSObject() }));
+		System.Assert.isFalse(matcher.matches(new list<SObject>{ GROUP_OBJECT_TYPE.newSObject(), GROUP_OBJECT_TYPE.newSObject() }), 'sObjectsWith arity agrees but arg doesn\'t');
 		System.Assert.isFalse(matcher.matches('NotAListofSObject'));
 
-		System.Assert.isTrue(matcher.matches(GROUP_RECORDS),'toMatch and args have same arity and in same order');
-        System.Assert.isTrue (!matcher.matches(new list<SObject> {GROUP_RECORDS[1],GROUP_RECORDS[0]}),
-                                     'sObjectsWith toMatch and args have same arity but args are in different order than toMatch') ;            
-                      
+		System.Assert.isTrue(matcher.matches(GROUP_RECORDS), 'toMatch and args have same arity and in same order');
+		System.Assert.isTrue(!matcher.matches(new list<SObject>{ GROUP_RECORDS[1], GROUP_RECORDS[0] }), 'sObjectsWith toMatch and args have same arity but args are in different order than toMatch');
 
 		System.Assert.isFalse(new fflib_MatcherDefinitions.SObjectsWith(notQueriedFieldValues).matches(GROUP_RECORDS));
 		System.Assert.isFalse(new fflib_MatcherDefinitions.SObjectsWith(failingFieldValues).matches(GROUP_RECORDS));
 	}
 
-    @isTest
+	@IsTest
 	private static void whenSObjectsInAnyOrderWithMatchesShouldReturnCorrectResults()
 	{
 		Map<String, Schema.SObjectField> fields = GROUP_OBJECT_TYPE.getDescribe().fields.getMap();
 		Schema.SObjectField idField = fields.get('Id');
 		Schema.SObjectField nameField = fields.get('Name');
 		Schema.SObjectField createdDateField = fields.get('CreatedDate');
-		
-		list<Map<Schema.SObjectField, Object>> queriedFieldValues = new list<Map<Schema.SObjectField, Object>>
-		{
-            new map<Schema.SObjectField,Object> 
-            {
-                idField => GROUP_RECORDS[0].Id,
-				nameField => GROUP_RECORDS[0].get('Name')
-            },
-            new map<Schema.SObjectField,Object> 
-            {
-                idField => GROUP_RECORDS[1].Id,
-				nameField => GROUP_RECORDS[1].get('Name')
-            }               
-		};
 
-		list<Map<Schema.SObjectField, Object>> notQueriedFieldValues = new list<Map<Schema.SObjectField, Object>>
-		{
-			new map<Schema.SObjectField,Object> 
-            {
-                createdDateField => System.now()
-            },
-            new map<Schema.SObjectField,Object> 
-            {
-                createdDateField => System.now()
-            }    
-		};
+		list<Map<Schema.SObjectField, Object>> queriedFieldValues =
+			new list<Map<Schema.SObjectField, Object>>{
+				new map<Schema.SObjectField, Object>{ idField => GROUP_RECORDS[0].Id, nameField => GROUP_RECORDS[0].get('Name') },
+				new map<Schema.SObjectField, Object>{ idField => GROUP_RECORDS[1].Id, nameField => GROUP_RECORDS[1].get('Name') }
+			};
 
-		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectsWith(queriedFieldValues,false); // any order
-		
+		list<Map<Schema.SObjectField, Object>> notQueriedFieldValues =
+			new list<Map<Schema.SObjectField, Object>>{ new map<Schema.SObjectField, Object>{ createdDateField => System.now() }, new map<Schema.SObjectField, Object>{ createdDateField => System.now() } };
+
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectsWith(queriedFieldValues, false); // any order
+
 		System.Assert.isFalse(matcher.matches(null));
-		System.Assert.isFalse(matcher.matches(new list<SObject>
-                                       {
-                                           OPPORTUNITY_OBJECT_TYPE.newSObject(),
-                                           OPPORTUNITY_OBJECT_TYPE.newSObject()    
-                                       }
-                                      ));
-		System.Assert.isFalse(matcher.matches(new list<SObject>
-                                       {
-                                           GROUP_OBJECT_TYPE.newSObject(),
-                                           GROUP_OBJECT_TYPE.newSObject()
-                                       }
-                                      ),'sObjectsWith arity agrees but arg doesn\'t match matcher');
+		System.Assert.isFalse(matcher.matches(new list<SObject>{ OPPORTUNITY_OBJECT_TYPE.newSObject(), OPPORTUNITY_OBJECT_TYPE.newSObject() }));
+		System.Assert.isFalse(matcher.matches(new list<SObject>{ GROUP_OBJECT_TYPE.newSObject(), GROUP_OBJECT_TYPE.newSObject() }), 'sObjectsWith arity agrees but arg doesn\'t match matcher');
 		System.Assert.isFalse(matcher.matches('NotAListofSObject'));
 
-		System.Assert.isTrue(matcher.matches(GROUP_RECORDS),'toMatch and args have same arity and in same order. Match should be OK');
-        System.Assert.isTrue (matcher.matches(new list<SObject> {GROUP_RECORDS[1],GROUP_RECORDS[0]}),
-                                     'sObjectsWith toMatch and args have same arity but args are in diff order than matcher. Should be OK') ;            
-                      
+		System.Assert.isTrue(matcher.matches(GROUP_RECORDS), 'toMatch and args have same arity and in same order. Match should be OK');
+		System.Assert.isTrue(matcher.matches(new list<SObject>{ GROUP_RECORDS[1], GROUP_RECORDS[0] }), 'sObjectsWith toMatch and args have same arity but args are in diff order than matcher. Should be OK');
 
-		System.Assert.isFalse(new fflib_MatcherDefinitions.SObjectsWith(notQueriedFieldValues,false).matches(GROUP_RECORDS));
+		System.Assert.isFalse(new fflib_MatcherDefinitions.SObjectsWith(notQueriedFieldValues, false).matches(GROUP_RECORDS));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectsWithToStringReturnsExpectedString()
 	{
-		List<Map<Schema.SObjectField, Object>> toMatch = new List<Map<Schema.SObjectField, Object>>{
-			new Map<Schema.SObjectField, Object> {
-				Account.Name => 'Test'
-			}
-		};
+		List<Map<Schema.SObjectField, Object>> toMatch = new List<Map<Schema.SObjectField, Object>>{ new Map<Schema.SObjectField, Object>{ Account.Name => 'Test' } };
 
 		System.Assert.areEqual('[ordered SObjects with [{"Name":"Test"}]]', '' + new fflib_MatcherDefinitions.SObjectsWith(toMatch, true));
 		System.Assert.areEqual('[unordered SObjects with [{"Name":"Test"}]]', '' + new fflib_MatcherDefinitions.SObjectsWith(toMatch, false));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectsWithDifferentArityMatchesShouldReturnFalse()
 	{
-		List<Map<Schema.SObjectField, Object>> toMatch = new List<Map<Schema.SObjectField, Object>>{
-			new Map<Schema.SObjectField, Object> {
-				Account.Name => 'Test'
-			}
-		};
+		List<Map<Schema.SObjectField, Object>> toMatch = new List<Map<Schema.SObjectField, Object>>{ new Map<Schema.SObjectField, Object>{ Account.Name => 'Test' } };
 		Boolean matchResult = new fflib_MatcherDefinitions.SObjectsWith(toMatch).matches(new List<SObject>{});
 		System.Assert.areEqual(matchResult, false);
 	}
 
-	@isTest
+	@IsTest
 	private static void constructSObjectsWith_WithNullArg_ThrowsException()
 	{
-		try {
+		try
+		{
 			new fflib_MatcherDefinitions.SObjectsWith(null);
 			System.Assert.fail('Expected exception');
 		}
@@ -1375,12 +1267,12 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void constructSObjectWithId_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.SObjectWithId(null);	
+			new fflib_MatcherDefinitions.SObjectWithId(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -1389,7 +1281,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectWithIdMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectWithId(ACCOUNT_RECORD.Id);
@@ -1402,19 +1294,19 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(ACCOUNT_RECORD));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectWithIdToStringReturnsExpectedString()
 	{
 		Id recordId = '001000000000001AAA';
 		System.Assert.areEqual('[SObject with Id "001000000000001AAA"]', '' + new fflib_MatcherDefinitions.SObjectWithId(recordId));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructSObjectWithName_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.SObjectWithName(null);	
+			new fflib_MatcherDefinitions.SObjectWithName(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -1423,10 +1315,10 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectWithNameMatchesShouldReturnCorrectResults()
 	{
-		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectWithName((String)ACCOUNT_RECORD.get('Name'));
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectWithName((String) ACCOUNT_RECORD.get('Name'));
 
 		System.Assert.isFalse(matcher.matches(null));
 		System.Assert.isFalse(matcher.matches(OPPORTUNITY_OBJECT_TYPE.newSObject()));
@@ -1436,13 +1328,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(ACCOUNT_RECORD));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenSObjectWithNameToStringReturnsExpectedString()
 	{
 		System.Assert.areEqual('[SObject with Name "Test"]', '' + new fflib_MatcherDefinitions.SObjectWithName('Test'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringContainsMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.StringContains('bob');
@@ -1454,12 +1346,12 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches('bobby'));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructStringContains_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.StringContains(null);	
+			new fflib_MatcherDefinitions.StringContains(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -1468,13 +1360,13 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringContainsToStringReturnsExpectedStrings()
 	{
 		System.Assert.areEqual('[contains "hello"]', '' + new fflib_MatcherDefinitions.StringContains('hello'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringEndsWithMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.StringEndsWith('bob');
@@ -1486,12 +1378,12 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches('jimbob'));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructStringEndsWith_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.StringEndsWith(null);	
+			new fflib_MatcherDefinitions.StringEndsWith(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -1500,13 +1392,13 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringEndsWithToStringReturnsExpectedStrings()
 	{
 		System.Assert.areEqual('[ends with "hello"]', '' + new fflib_MatcherDefinitions.StringEndsWith('hello'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenIsBlankWithMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.StringIsBlank();
@@ -1516,13 +1408,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches(''));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringIsBlankToStringReturnsExpectedStrings()
 	{
 		System.Assert.areEqual('[blank String]', '' + new fflib_MatcherDefinitions.StringIsBlank());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenIsNotBlankWithMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.StringIsNotBlank();
@@ -1532,13 +1424,13 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches('bob'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringIsNotBlankToStringReturnsExpectedStrings()
 	{
 		System.Assert.areEqual('[non-blank String]', '' + new fflib_MatcherDefinitions.StringIsNotBlank());
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringMatchesMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.StringMatches('(b|m)o[a-z]*');
@@ -1552,18 +1444,18 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches('mo'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringMatchesToStringReturnsExpectedStrings()
 	{
 		System.Assert.areEqual('[matches regex "hello"]', '' + new fflib_MatcherDefinitions.StringMatches('hello'));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructStringMatches_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.StringMatches(null);	
+			new fflib_MatcherDefinitions.StringMatches(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -1572,7 +1464,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringStartsWithMatchesShouldReturnCorrectResults()
 	{
 		fflib_IMatcher matcher = new fflib_MatcherDefinitions.StringStartsWith('bob');
@@ -1584,18 +1476,18 @@ public class fflib_MatcherDefinitionsTest
 		System.Assert.isTrue(matcher.matches('bobby'));
 	}
 
-	@isTest
+	@IsTest
 	private static void whenStringStartsWithToStringReturnsExpectedStrings()
 	{
 		System.Assert.areEqual('[starts with "hello"]', '' + new fflib_MatcherDefinitions.StringStartsWith('hello'));
 	}
 
-	@isTest
+	@IsTest
 	private static void constructStringStartsWith_WithNullArg_ThrowsException()
 	{
 		try
 		{
-			new fflib_MatcherDefinitions.StringStartsWith(null);	
+			new fflib_MatcherDefinitions.StringStartsWith(null);
 			System.Assert.fail('Expected exception');
 		}
 		catch (fflib_ApexMocks.ApexMocksException e)
@@ -1604,7 +1496,7 @@ public class fflib_MatcherDefinitionsTest
 		}
 	}
 
-	@isTest
+	@IsTest
 	private static void whenJSONExceptionOccursStringifyShouldReturnsObjectToString()
 	{
 		// SObjectField object definitely can't be serialized by JSON.serialize() method

--- a/sfdx-source/apex-mocks/test/classes/fflib_MethodArgValuesTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MethodArgValuesTest.cls
@@ -1,32 +1,32 @@
 /**
- * Copyright (c) 2014-2016, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-@isTest
+* Copyright (c) 2014-2016, FinancialForce.com, inc
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+@IsTest
 public with sharing class fflib_MethodArgValuesTest
 {
-	@isTest
+	@IsTest
 	private static void equalsReturnsExpectedResults()
 	{
 		//Given
@@ -66,7 +66,7 @@ public with sharing class fflib_MethodArgValuesTest
 		System.Assert.areEqual(qm6, qm6);
 	}
 
-	@isTest
+	@IsTest
 	private static void hashCodeReturnsExpectedResults()
 	{
 		//Given

--- a/sfdx-source/apex-mocks/test/classes/fflib_MethodArgValuesTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MethodArgValuesTest.cls
@@ -1,28 +1,28 @@
 /**
-* Copyright (c) 2014-2016, FinancialForce.com, inc
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* - Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* - Redistributions in binary form must reproduce the above copyright notice,
-* this list of conditions and the following disclaimer in the documentation
-* and/or other materials provided with the distribution.
-* - Neither the name of the FinancialForce.com, inc nor the names of its contributors
-* may be used to endorse or promote products derived from this software without
-* specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-* THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2014-2016, FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 @IsTest
 public with sharing class fflib_MethodArgValuesTest
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_MethodCountRecorderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MethodCountRecorderTest.cls
@@ -1,21 +1,21 @@
 /*
- Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- * @nodoc
- *
- * Regression coverage for the backward-compatible (deprecated) entry points retained
- * when fflib_MethodCountRecorder moved to instance based recording:
- *   - the static getOrderedMethodCalls() / getMethodArgumentsByTypeName() getters, and
- *   - the no-arg fflib_AnyOrder() constructor that falls back to the static recorder.
- * These paths are not exercised by the rest of the suite (everything internal now uses
- * the instance API), so this class guards against them silently regressing.
- */
-@isTest
+* @nodoc
+*
+* Regression coverage for the backward-compatible (deprecated) entry points retained
+* when fflib_MethodCountRecorder moved to instance based recording:
+* - the static getOrderedMethodCalls() / getMethodArgumentsByTypeName() getters, and
+* - the no-arg fflib_AnyOrder() constructor that falls back to the static recorder.
+* These paths are not exercised by the rest of the suite (everything internal now uses
+* the instance API), so this class guards against them silently regressing.
+*/
+@IsTest
 private class fflib_MethodCountRecorderTest
 {
-	@isTest
+	@IsTest
 	private static void recordMethodPopulatesInstanceState()
 	{
 		// Given
@@ -27,22 +27,15 @@ private class fflib_MethodCountRecorderTest
 		recorder.recordMethod(invocation);
 
 		// Then
-		System.Assert.areEqual(
-			1,
-			recorder.getInstanceOrderedMethodCalls().size(),
-			'The invocation should be recorded against the instance ordered calls');
-		System.Assert.isTrue(
-			recorder.getInstanceMethodArgumentsByTypeName().containsKey(qm),
-			'The instance arguments map should contain the recorded method');
+		System.Assert.areEqual(1, recorder.getInstanceOrderedMethodCalls().size(), 'The invocation should be recorded against the instance ordered calls');
+		System.Assert.isTrue(recorder.getInstanceMethodArgumentsByTypeName().containsKey(qm), 'The instance arguments map should contain the recorded method');
 	}
 
-	@isTest
+	@IsTest
 	private static void recordMethodMirrorsIntoDeprecatedStaticGetters()
 	{
 		// Given the static getters start empty for this transaction
-		System.Assert.isTrue(
-			fflib_MethodCountRecorder.getOrderedMethodCalls().isEmpty(),
-			'The static ordered calls should start empty');
+		System.Assert.isTrue(fflib_MethodCountRecorder.getOrderedMethodCalls().isEmpty(), 'The static ordered calls should start empty');
 
 		fflib_QualifiedMethod qm = new fflib_QualifiedMethod('MyType', 'myMethod', new List<Type>{ String.class });
 		fflib_InvocationOnMock invocation = buildInvocation(qm, 'bob');
@@ -51,16 +44,11 @@ private class fflib_MethodCountRecorderTest
 		new fflib_MethodCountRecorder().recordMethod(invocation);
 
 		// Then the deprecated static getters mirror that recording rather than returning empty
-		System.Assert.areEqual(
-			1,
-			fflib_MethodCountRecorder.getOrderedMethodCalls().size(),
-			'The deprecated static ordered calls getter should mirror the recorded invocation');
-		System.Assert.isTrue(
-			fflib_MethodCountRecorder.getMethodArgumentsByTypeName().containsKey(qm),
-			'The deprecated static arguments getter should mirror the recorded method');
+		System.Assert.areEqual(1, fflib_MethodCountRecorder.getOrderedMethodCalls().size(), 'The deprecated static ordered calls getter should mirror the recorded invocation');
+		System.Assert.isTrue(fflib_MethodCountRecorder.getMethodArgumentsByTypeName().containsKey(qm), 'The deprecated static arguments getter should mirror the recorded method');
 	}
 
-	@isTest
+	@IsTest
 	private static void deprecatedAnyOrderConstructorVerifiesViaStaticRecorder()
 	{
 		// Given an invocation mirrored into the static recorder
@@ -74,13 +62,10 @@ private class fflib_MethodCountRecorderTest
 
 		// Then the verification passes (recorded exactly once) - reaching the assert means no exception was thrown
 		verifier.verifyMethodCall(invocation, once);
-		System.Assert.areEqual(
-			1,
-			fflib_MethodCountRecorder.getOrderedMethodCalls().size(),
-			'The static recorder backing the deprecated verifier should hold the single recorded call');
+		System.Assert.areEqual(1, fflib_MethodCountRecorder.getOrderedMethodCalls().size(), 'The static recorder backing the deprecated verifier should hold the single recorded call');
 	}
 
-	@isTest
+	@IsTest
 	private static void deprecatedAnyOrderConstructorReportsUnexpectedCountViaStaticRecorder()
 	{
 		// Given a single recorded invocation
@@ -100,9 +85,7 @@ private class fflib_MethodCountRecorderTest
 		}
 		catch (fflib_ApexMocks.ApexMocksException ex)
 		{
-			System.Assert.isTrue(
-				ex.getMessage().startsWith('EXPECTED COUNT: 2'),
-				'Unexpected verify fail message: ' + ex.getMessage());
+			System.Assert.isTrue(ex.getMessage().startsWith('EXPECTED COUNT: 2'), 'Unexpected verify fail message: ' + ex.getMessage());
 		}
 	}
 

--- a/sfdx-source/apex-mocks/test/classes/fflib_MethodCountRecorderTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MethodCountRecorderTest.cls
@@ -3,15 +3,15 @@ Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* @nodoc
-*
-* Regression coverage for the backward-compatible (deprecated) entry points retained
-* when fflib_MethodCountRecorder moved to instance based recording:
-* - the static getOrderedMethodCalls() / getMethodArgumentsByTypeName() getters, and
-* - the no-arg fflib_AnyOrder() constructor that falls back to the static recorder.
-* These paths are not exercised by the rest of the suite (everything internal now uses
-* the instance API), so this class guards against them silently regressing.
-*/
+ * @nodoc
+ *
+ * Regression coverage for the backward-compatible (deprecated) entry points retained
+ * when fflib_MethodCountRecorder moved to instance based recording:
+ * - the static getOrderedMethodCalls() / getMethodArgumentsByTypeName() getters, and
+ * - the no-arg fflib_AnyOrder() constructor that falls back to the static recorder.
+ * These paths are not exercised by the rest of the suite (everything internal now uses
+ * the instance API), so this class guards against them silently regressing.
+ */
 @IsTest
 private class fflib_MethodCountRecorderTest
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_MyList.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MyList.cls
@@ -1,11 +1,11 @@
 /*
- Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
- */
+Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
+*/
 
 /**
- * @nodoc
- */
-@isTest
+* @nodoc
+*/
+@IsTest
 public with sharing class fflib_MyList implements IList
 {
 	public interface IList

--- a/sfdx-source/apex-mocks/test/classes/fflib_MyList.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_MyList.cls
@@ -3,8 +3,8 @@ Copyright (c) 2014-2017 FinancialForce.com, inc.  All rights reserved.
 */
 
 /**
-* @nodoc
-*/
+ * @nodoc
+ */
 @IsTest
 public with sharing class fflib_MyList implements IList
 {

--- a/sfdx-source/apex-mocks/test/classes/fflib_QualifiedMethodAndArgValuesTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_QualifiedMethodAndArgValuesTest.cls
@@ -1,24 +1,23 @@
-@isTest
+@IsTest
 public class fflib_QualifiedMethodAndArgValuesTest
 {
-    @isTest
-    private static void equalsReturnsExpectedResults()
-    {
-        fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class } );
-        fflib_MethodArgValues mav1 = new fflib_MethodArgValues(new List<Object>{ 'hello' });
-        Object obj1 = 'hello';
+	@IsTest
+	private static void equalsReturnsExpectedResults()
+	{
+		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class });
+		fflib_MethodArgValues mav1 = new fflib_MethodArgValues(new List<Object>{ 'hello' });
+		Object obj1 = 'hello';
 
-        fflib_QualifiedMethodAndArgValues qmaav = new fflib_QualifiedMethodAndArgValues(qm1, mav1, obj1);
+		fflib_QualifiedMethodAndArgValues qmaav = new fflib_QualifiedMethodAndArgValues(qm1, mav1, obj1);
 
-        fflib_QualifiedMethod qm2 = qmaav.getQualifiedMethod();
-        fflib_MethodArgValues mav2 = qmaav.getMethodArgValues();
-        Object obj2 = qmaav.getMockInstance();
-        String string1 = qmaav.toString();
+		fflib_QualifiedMethod qm2 = qmaav.getQualifiedMethod();
+		fflib_MethodArgValues mav2 = qmaav.getMethodArgValues();
+		Object obj2 = qmaav.getMockInstance();
+		String string1 = qmaav.toString();
 
-        System.Assert.areEqual(qm1, qm2);
-        System.Assert.areEqual(mav1, mav2);
-        System.Assert.areEqual(obj1, obj2);
-        System.Assert.areEqual('Type1.Method1(Integer) with args: [hello]', string1);
-
-    }
+		System.Assert.areEqual(qm1, qm2);
+		System.Assert.areEqual(mav1, mav2);
+		System.Assert.areEqual(obj1, obj2);
+		System.Assert.areEqual('Type1.Method1(Integer) with args: [hello]', string1);
+	}
 }

--- a/sfdx-source/apex-mocks/test/classes/fflib_QualifiedMethodTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_QualifiedMethodTest.cls
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
- */
-@isTest
+* Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
+*/
+@IsTest
 public with sharing class fflib_QualifiedMethodTest
 {
-	@isTest
+	@IsTest
 	private static void equalsReturnsExpectedResults()
 	{
 		//Given
-		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class } );
-		fflib_QualifiedMethod qm2 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class } );
-		fflib_QualifiedMethod qm3 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ String.class } );
-		fflib_QualifiedMethod qm4 = new fflib_QualifiedMethod('Type2', 'Method2', new List<Type>{ Integer.class, String.class, fflib_QualifiedMethodTest.class } );
-		fflib_QualifiedMethod qm5 = new fflib_QualifiedMethod('', '', new List<Type>{} );
-		fflib_QualifiedMethod qm6 = new fflib_QualifiedMethod(null, null, null );
+		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class });
+		fflib_QualifiedMethod qm2 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class });
+		fflib_QualifiedMethod qm3 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ String.class });
+		fflib_QualifiedMethod qm4 = new fflib_QualifiedMethod('Type2', 'Method2', new List<Type>{ Integer.class, String.class, fflib_QualifiedMethodTest.class });
+		fflib_QualifiedMethod qm5 = new fflib_QualifiedMethod('', '', new List<Type>{});
+		fflib_QualifiedMethod qm6 = new fflib_QualifiedMethod(null, null, null);
 
 		//When/thens
 		System.Assert.areEqual(qm1, qm1);
@@ -44,16 +44,16 @@ public with sharing class fflib_QualifiedMethodTest
 		System.Assert.areEqual(qm6, qm6);
 	}
 
-	@isTest
+	@IsTest
 	private static void hashCodeReturnsExpectedResults()
 	{
 		//Given
-		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class } );
-		fflib_QualifiedMethod qm2 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class } );
-		fflib_QualifiedMethod qm3 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ String.class } );
-		fflib_QualifiedMethod qm4 = new fflib_QualifiedMethod('Type2', 'Method2', new List<Type>{ Integer.class, String.class, fflib_QualifiedMethodTest.class } );
-		fflib_QualifiedMethod qm5 = new fflib_QualifiedMethod('', '', new List<Type>{} );
-		fflib_QualifiedMethod qm6 = new fflib_QualifiedMethod(null, null, null );
+		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class });
+		fflib_QualifiedMethod qm2 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class });
+		fflib_QualifiedMethod qm3 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ String.class });
+		fflib_QualifiedMethod qm4 = new fflib_QualifiedMethod('Type2', 'Method2', new List<Type>{ Integer.class, String.class, fflib_QualifiedMethodTest.class });
+		fflib_QualifiedMethod qm5 = new fflib_QualifiedMethod('', '', new List<Type>{});
+		fflib_QualifiedMethod qm6 = new fflib_QualifiedMethod(null, null, null);
 
 		//When/thens
 		System.Assert.areEqual(qm1.hashCode(), qm1.hashCode());
@@ -84,26 +84,26 @@ public with sharing class fflib_QualifiedMethodTest
 		System.Assert.areEqual(qm6.hashCode(), qm6.hashCode());
 	}
 
-	@isTest
+	@IsTest
 	public static void toStringReturnsExpectedResult()
 	{
 		System.Assert.areEqual('MyClass.MyMethod(Integer)', new fflib_QualifiedMethod('MyClass', 'MyMethod', new List<Type>{ Integer.class }).toString());
 	}
 
-	@isTest
+	@IsTest
 	private static void equalsReturnsExpectedResultsForHasDependentMocks()
 	{
 		//Given
 		String instance = 'My object instance';
 		String instance2 = 'My other object instance';
-		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class } );
+		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class });
 		fflib_QualifiedMethod qm2 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance);
 		fflib_QualifiedMethod qm3 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance);
 		fflib_QualifiedMethod qm4 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance2);
 
 		//When/thens
 		fflib_ApexMocksConfig.HasIndependentMocks = false;
-		
+
 		System.Assert.areEqual(qm1, qm2);
 		System.Assert.areEqual(qm1, qm3);
 		System.Assert.areEqual(qm1, qm4);
@@ -120,20 +120,20 @@ public with sharing class fflib_QualifiedMethodTest
 		System.Assert.areNotEqual(qm3, qm4);
 	}
 
-	@isTest
+	@IsTest
 	private static void hashCodeReturnsExpectedResultsForHasDependentMocks()
 	{
 		//Given
 		String instance = 'My object instance';
 		String instance2 = 'My other object instance';
-		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class } );
+		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class });
 		fflib_QualifiedMethod qm2 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance);
 		fflib_QualifiedMethod qm3 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance);
 		fflib_QualifiedMethod qm4 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance2);
 
 		//When/thens
 		fflib_ApexMocksConfig.HasIndependentMocks = false;
-		
+
 		System.Assert.areEqual(qm1.hashCode(), qm2.hashCode());
 		System.Assert.areEqual(qm1.hashCode(), qm3.hashCode());
 		System.Assert.areEqual(qm1.hashCode(), qm4.hashCode());

--- a/sfdx-source/apex-mocks/test/classes/fflib_SystemTest.cls
+++ b/sfdx-source/apex-mocks/test/classes/fflib_SystemTest.cls
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
- */
+* Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+*/
 @IsTest
 private class fflib_SystemTest
 {
@@ -62,11 +62,7 @@ private class fflib_SystemTest
 	@IsTest
 	private static void assertEquals_WithCombinedMatcher_ShouldPass()
 	{
-		fflib_System.assertEquals(fflib_Match.allOf(
-				fflib_Match.stringStartsWith('Test S'),
-				fflib_Match.stringEndsWith('t String'),
-				fflib_Match.stringIsNotBlank())
-			, 'Test String');
+		fflib_System.assertEquals(fflib_Match.allOf(fflib_Match.stringStartsWith('Test S'), fflib_Match.stringEndsWith('t String'), fflib_Match.stringIsNotBlank()), 'Test String');
 	}
 
 	@IsTest
@@ -127,10 +123,6 @@ private class fflib_SystemTest
 	@IsTest
 	private static void assertEquals_WithCustomMessage_WithCombinedMatcher_ShouldPass()
 	{
-		fflib_System.assertEquals(fflib_Match.allOf(
-				fflib_Match.stringStartsWith('Test S'),
-				fflib_Match.stringEndsWith('t String'),
-				fflib_Match.stringIsNotBlank())
-			, 'Test String', 'My Custom Message');
+		fflib_System.assertEquals(fflib_Match.allOf(fflib_Match.stringStartsWith('Test S'), fflib_Match.stringEndsWith('t String'), fflib_Match.stringIsNotBlank()), 'Test String', 'My Custom Message');
 	}
 }


### PR DESCRIPTION
This draft PR applies a personal fork of `afmt` to the Apex source using an explicit fflib-style configuration. It is intentionally limited to formatter/configuration changes; no behavioral or analyzer suppressions were added.

Configuration: `.afmt.toml` with Allman braces, tab indentation, four-column logical indentation, single-statement brace expansion, offset Javadoc stars, canonical Salesforce annotation casing, and `max_width = 250` to preserve the repository's existing long-line convention.

# Code Analyzer comparison

Rule selector: `pmd:all`
Analyzer: Salesforce Code Analyzer `0.48.0`, PMD `0.41.0`
Before: `origin/master` (`b2ae780`)
After: `experiment/afmt-code-analyzer` (`566a18f`)

| Severity | Severity Level | Rule | Before | After | Delta |
|---:|---|---|---:|---:|---:|
| 2 | High | EagerlyLoadedDescribeSObjectResult | 1 | 1 | 0 |
| 3 | Moderate | ApexAssertionsShouldIncludeMessage | 1 | 1 | 0 |
| 3 | Moderate | ApexUnitTestClassShouldHaveAsserts | 109 | 109 | 0 |
| 3 | Moderate | AvoidBooleanMethodParameters | 38 | 38 | 0 |
| 3 | Moderate | AvoidDeeplyNestedIfStmts | 4 | 4 | 0 |
| 3 | Moderate | AvoidHardcodingId | 14 | 14 | 0 |
| 3 | Moderate | ClassNamingConventions | 43 | 43 | 0 |
| 3 | Moderate | CognitiveComplexity | 7 | 7 | 0 |
| 3 | Moderate | CyclomaticComplexity | 11 | 11 | 0 |
| 3 | Moderate | EmptyStatementBlock | 6 | 6 | 0 |
| 3 | Moderate | ExcessiveClassLength | 2 | 2 | 0 |
| 3 | Moderate | ExcessiveParameterList | 21 | 21 | 0 |
| 3 | Moderate | ExcessivePublicCount | 2 | 2 | 0 |
| 3 | Moderate | FieldNamingConventions | 10 | 10 | 0 |
| 3 | Moderate | IfElseStmtsMustUseBraces | 6 | 0 | -6 |
| 3 | Moderate | IfStmtsMustUseBraces | 5 | 0 | -5 |
| 3 | Moderate | MethodNamingConventions | 57 | 57 | 0 |
| 3 | Moderate | NcssCount | 4 | 4 | 0 |
| 3 | Moderate | OneDeclarationPerLine | 2 | 2 | 0 |
| 3 | Moderate | PropertyNamingConventions | 10 | 10 | 0 |
| 3 | Moderate | StdCyclomaticComplexity | 4 | 4 | 0 |
| 3 | Moderate | UnusedLocalVariable | 99 | 99 | 0 |
| 4 | Low | AnnotationsNamingConventions | 490 | 0 | -490 |
| 4 | Low | ApexDoc | 180 | 180 | 0 |
| 4 | Low | ApexUnitTestClassShouldHaveRunAs | 484 | 484 | 0 |
| 4 | Low | AvoidDebugStatements | 1 | 1 | 0 |
| 4 | Low | DebugsShouldUseLoggingLevel | 1 | 1 | 0 |
| 4 | Low | NcssMethodCount | 1 | 1 | 0 |
| 4 | Low | NcssTypeCount | 2 | 2 | 0 |
| | | **Total** | **1615** | **1114** | **-501** |

The reduction is entirely mechanical: annotation casing removes 490 findings, and brace expansion removes 11 findings. All other PMD rule counts are unchanged.

Commands used:

```bash
afmt --config .afmt.toml --time --write sfdx-source
sf code-analyzer run --rule-selector pmd:all --workspace . --target sfdx-source --output-file results.csv --output-file results.json
afmt --config .afmt.toml --check sfdx-source
```

The formatter selected and wrote 39 Apex files in 106 ms; the subsequent check was idempotent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-mocks/176)
<!-- Reviewable:end -->
